### PR TITLE
recode images

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -8,9 +8,11 @@ use async_std::prelude::*;
 use async_std::{fs, io};
 
 use image::GenericImageView;
+use num_traits::FromPrimitive;
 use thiserror::Error;
 
-use crate::constants::AVATAR_SIZE;
+use crate::config::Config;
+use crate::constants::*;
 use crate::context::Context;
 use crate::events::Event;
 
@@ -368,6 +370,39 @@ impl<'a> BlobObject<'a> {
         }
 
         let img = img.thumbnail(AVATAR_SIZE, AVATAR_SIZE);
+
+        img.save(&blob_abs).map_err(|err| BlobError::WriteFailure {
+            blobdir: context.get_blobdir().to_path_buf(),
+            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
+            cause: err,
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn recode_to_image_size(&self, context: &Context) -> Result<(), BlobError> {
+        let blob_abs = self.to_abs_path();
+        let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {
+            blobdir: context.get_blobdir().to_path_buf(),
+            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
+            cause: err,
+        })?;
+
+        let (img_wh, _quality) =
+            if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
+                .unwrap_or_default()
+                == MediaQuality::Balanced
+            {
+                (BALANCED_IMAGE_SIZE, BALANCED_IMAGE_QUALITY)
+            } else {
+                (WORSE_IMAGE_SIZE, WORSE_IMAGE_QUALITY)
+            };
+
+        if img.width() <= img_wh && img.height() <= img_wh {
+            return Ok(());
+        }
+
+        let img = img.thumbnail(img_wh, img_wh);
 
         img.save(&blob_abs).map_err(|err| BlobError::WriteFailure {
             blobdir: context.get_blobdir().to_path_buf(),

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -398,15 +398,14 @@ impl<'a> BlobObject<'a> {
             cause: err,
         })?;
 
-        let (img_wh, _quality) =
-            if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
-                .unwrap_or_default()
-                == MediaQuality::Balanced
-            {
-                (BALANCED_IMAGE_SIZE, BALANCED_IMAGE_QUALITY)
-            } else {
-                (WORSE_IMAGE_SIZE, WORSE_IMAGE_QUALITY)
-            };
+        let img_wh = if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
+            .unwrap_or_default()
+            == MediaQuality::Balanced
+        {
+            BALANCED_IMAGE_SIZE
+        } else {
+            WORSE_IMAGE_SIZE
+        };
 
         if img.width() <= img_wh && img.height() <= img_wh {
             return Ok(());

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -15,6 +15,7 @@ use crate::config::Config;
 use crate::constants::*;
 use crate::context::Context;
 use crate::events::Event;
+use crate::message;
 
 /// Represents a file in the blob directory.
 ///
@@ -382,6 +383,15 @@ impl<'a> BlobObject<'a> {
 
     pub async fn recode_to_image_size(&self, context: &Context) -> Result<(), BlobError> {
         let blob_abs = self.to_abs_path();
+        match message::guess_msgtype_from_suffix(Path::new(&blob_abs)) {
+            None => return Ok(()),
+            Some(imgtype) => {
+                if imgtype.1 != "image/jpeg" {
+                    return Ok(());
+                }
+            }
+        }
+
         let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {
             blobdir: context.get_blobdir().to_path_buf(),
             blobname: blob_abs.to_str().unwrap_or_default().to_string(),

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -383,13 +383,10 @@ impl<'a> BlobObject<'a> {
 
     pub async fn recode_to_image_size(&self, context: &Context) -> Result<(), BlobError> {
         let blob_abs = self.to_abs_path();
-        match message::guess_msgtype_from_suffix(Path::new(&blob_abs)) {
-            None => return Ok(()),
-            Some(imgtype) => {
-                if imgtype.1 != "image/jpeg" {
-                    return Ok(());
-                }
-            }
+        if message::guess_msgtype_from_suffix(Path::new(&blob_abs))
+            != Some((Viewtype::Image, "image/jpeg"))
+        {
+            return Ok(());
         }
 
         let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1332,6 +1332,12 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<(), Er
             .ok_or_else(|| {
                 format_err!("Attachment missing for message of type #{}", msg.viewtype)
             })?;
+
+        if msg.viewtype == Viewtype::Image {
+            if blob.recode_to_image_size(context).await.is_err() {
+                warn!(context, "Cannot recode image, using original data");
+            }
+        }
         msg.param.set(Param::File, blob.as_name());
 
         if msg.viewtype == Viewtype::File || msg.viewtype == Viewtype::Image {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1333,10 +1333,8 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<(), Er
                 format_err!("Attachment missing for message of type #{}", msg.viewtype)
             })?;
 
-        if msg.viewtype == Viewtype::Image {
-            if blob.recode_to_image_size(context).await.is_err() {
-                warn!(context, "Cannot recode image, using original data");
-            }
+        if msg.viewtype == Viewtype::Image && blob.recode_to_image_size(context).await.is_err() {
+            warn!(context, "Cannot recode image, using original data");
         }
         msg.param.set(Param::File, blob.as_name());
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1333,8 +1333,10 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<(), Er
                 format_err!("Attachment missing for message of type #{}", msg.viewtype)
             })?;
 
-        if msg.viewtype == Viewtype::Image && blob.recode_to_image_size(context).await.is_err() {
-            warn!(context, "Cannot recode image, using original data");
+        if msg.viewtype == Viewtype::Image {
+            if let Err(e) = blob.recode_to_image_size(context).await {
+                warn!(context, "Cannot recode image, using original data: {:?}", e);
+            }
         }
         msg.param.set(Param::File, blob.as_name());
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -229,9 +229,7 @@ pub const AVATAR_SIZE: u32 = 192;
 
 // max. width/height of images
 pub const BALANCED_IMAGE_SIZE: u32 = 1280;
-pub const BALANCED_IMAGE_QUALITY: u32 = 85;
 pub const WORSE_IMAGE_SIZE: u32 = 640;
-pub const WORSE_IMAGE_QUALITY: u32 = 75;
 
 // this value can be increased if the folder configuration is changed and must be redone on next program start
 pub const DC_FOLDERS_CONFIGURED_VERSION: i32 = 3;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -227,6 +227,12 @@ pub const DC_BOB_SUCCESS: i32 = 1;
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;
 
+// max. width/height of images
+pub const BALANCED_IMAGE_SIZE: u32 = 1280;
+pub const BALANCED_IMAGE_QUALITY: u32 = 85;
+pub const WORSE_IMAGE_SIZE: u32 = 640;
+pub const WORSE_IMAGE_QUALITY: u32 = 75;
+
 // this value can be increased if the folder configuration is changed and must be redone on next program start
 pub const DC_FOLDERS_CONFIGURED_VERSION: i32 = 3;
 


### PR DESCRIPTION
this pr adds simple image recoding.

as a first step, for simplicity, i just recode the image already copied to the blob-directory "in place".

in a subsequent pr, it would be nice if BlobObject could avoid unneeded copies part (if some image outside the blob-directory is given to dc_send_msg(), we could just recode that to the blob-directory - instead of copying several mb before and recoding the copy). 
@flub iirc, you are pretty deep into this blob handling - maybe you can have a look at this at some point?

targets https://github.com/deltachat/deltachat-ios/issues/733 and https://github.com/deltachat/deltachat-desktop/issues/1681 