### PR TITLE
scale avatars based on media_quality, fix avatar rotation

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -380,7 +380,16 @@ impl<'a> BlobObject<'a> {
     pub async fn recode_to_avatar_size(&self, context: &Context) -> Result<(), BlobError> {
         let blob_abs = self.to_abs_path();
 
-        self.recode_to_size(context, blob_abs, AVATAR_SIZE).await
+        let img_wh = if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
+            .unwrap_or_default()
+            == MediaQuality::Balanced
+        {
+            BALANCED_AVATAR_SIZE
+        } else {
+            WORSE_AVATAR_SIZE
+        };
+
+        self.recode_to_size(context, blob_abs, img_wh).await
     }
 
     pub async fn recode_to_image_size(&self, context: &Context) -> Result<(), BlobError> {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -380,14 +380,13 @@ impl<'a> BlobObject<'a> {
     pub async fn recode_to_avatar_size(&self, context: &Context) -> Result<(), BlobError> {
         let blob_abs = self.to_abs_path();
 
-        let img_wh = if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
-            .unwrap_or_default()
-            == MediaQuality::Balanced
-        {
-            BALANCED_AVATAR_SIZE
-        } else {
-            WORSE_AVATAR_SIZE
-        };
+        let img_wh =
+            match MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
+                .unwrap_or_default()
+            {
+                MediaQuality::Balanced => BALANCED_AVATAR_SIZE,
+                MediaQuality::Worse => WORSE_AVATAR_SIZE,
+            };
 
         self.recode_to_size(context, blob_abs, img_wh).await
     }
@@ -400,14 +399,13 @@ impl<'a> BlobObject<'a> {
             return Ok(());
         }
 
-        let img_wh = if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
-            .unwrap_or_default()
-            == MediaQuality::Balanced
-        {
-            BALANCED_IMAGE_SIZE
-        } else {
-            WORSE_IMAGE_SIZE
-        };
+        let img_wh =
+            match MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
+                .unwrap_or_default()
+            {
+                MediaQuality::Balanced => BALANCED_IMAGE_SIZE,
+                MediaQuality::Worse => WORSE_IMAGE_SIZE,
+            };
 
         self.recode_to_size(context, blob_abs, img_wh).await
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -408,12 +408,6 @@ impl<'a> BlobObject<'a> {
             return Ok(());
         }
 
-        let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {
-            blobdir: context.get_blobdir().to_path_buf(),
-            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
-            cause: err,
-        })?;
-
         let img_wh = if MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await)
             .unwrap_or_default()
             == MediaQuality::Balanced
@@ -422,6 +416,21 @@ impl<'a> BlobObject<'a> {
         } else {
             WORSE_IMAGE_SIZE
         };
+
+        self.recode_to_size(context, blob_abs, img_wh).await
+    }
+
+    async fn recode_to_size(
+        &self,
+        context: &Context,
+        blob_abs: PathBuf,
+        img_wh: u32,
+    ) -> Result<(), BlobError> {
+        let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {
+            blobdir: context.get_blobdir().to_path_buf(),
+            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
+            cause: err,
+        })?;
 
         if img.width() <= img_wh && img.height() <= img_wh {
             return Ok(());

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -377,27 +377,10 @@ impl<'a> BlobObject<'a> {
         true
     }
 
-    pub fn recode_to_avatar_size(&self, context: &Context) -> Result<(), BlobError> {
+    pub async fn recode_to_avatar_size(&self, context: &Context) -> Result<(), BlobError> {
         let blob_abs = self.to_abs_path();
-        let img = image::open(&blob_abs).map_err(|err| BlobError::RecodeFailure {
-            blobdir: context.get_blobdir().to_path_buf(),
-            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
-            cause: err,
-        })?;
 
-        if img.width() <= AVATAR_SIZE && img.height() <= AVATAR_SIZE {
-            return Ok(());
-        }
-
-        let img = img.thumbnail(AVATAR_SIZE, AVATAR_SIZE);
-
-        img.save(&blob_abs).map_err(|err| BlobError::WriteFailure {
-            blobdir: context.get_blobdir().to_path_buf(),
-            blobname: blob_abs.to_str().unwrap_or_default().to_string(),
-            cause: err.into(),
-        })?;
-
-        Ok(())
+        self.recode_to_size(context, blob_abs, AVATAR_SIZE).await
     }
 
     pub async fn recode_to_image_size(&self, context: &Context) -> Result<(), BlobError> {
@@ -459,7 +442,7 @@ impl<'a> BlobObject<'a> {
                 cause: err.into(),
             })?;
         }
-        
+
         Ok(())
     }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2609,7 +2609,7 @@ pub async fn set_chat_profile_image(
                 _ => Err(err),
             },
         }?;
-        image_blob.recode_to_avatar_size(context)?;
+        image_blob.recode_to_avatar_size(context).await?;
         chat.param.set(Param::ProfileImage, image_blob.as_name());
         msg.param.set(Param::Arg, image_blob.as_name());
         msg.text = Some(

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,7 +217,7 @@ impl Context {
                 match value {
                     Some(value) => {
                         let blob = BlobObject::new_from_path(&self, value).await?;
-                        blob.recode_to_avatar_size(self)?;
+                        blob.recode_to_avatar_size(self).await?;
                         self.sql
                             .set_raw_config(self, key, Some(blob.as_name()))
                             .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -287,7 +287,7 @@ mod tests {
     use std::string::ToString;
 
     use crate::constants;
-    use crate::constants::AVATAR_SIZE;
+    use crate::constants::BALANCED_AVATAR_SIZE;
     use crate::test_utils::*;
     use image::GenericImageView;
     use num_traits::FromPrimitive;
@@ -336,8 +336,8 @@ mod tests {
         assert_eq!(img.height(), 1000);
 
         let img = image::open(avatar_blob).unwrap();
-        assert_eq!(img.width(), AVATAR_SIZE);
-        assert_eq!(img.height(), AVATAR_SIZE);
+        assert_eq!(img.width(), BALANCED_AVATAR_SIZE);
+        assert_eq!(img.height(), BALANCED_AVATAR_SIZE);
     }
 
     #[async_std::test]
@@ -362,8 +362,8 @@ mod tests {
         assert_eq!(avatar_cfg, avatar_src.to_str().map(|s| s.to_string()));
 
         let img = image::open(avatar_src).unwrap();
-        assert_eq!(img.width(), AVATAR_SIZE);
-        assert_eq!(img.height(), AVATAR_SIZE);
+        assert_eq!(img.width(), BALANCED_AVATAR_SIZE);
+        assert_eq!(img.height(), BALANCED_AVATAR_SIZE);
     }
 
     #[async_std::test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -196,7 +196,8 @@ pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 pub const DC_FETCH_EXISTING_MSGS_COUNT: i64 = 100;
 
 // max. width/height of an avatar
-pub const AVATAR_SIZE: u32 = 192;
+pub const BALANCED_AVATAR_SIZE: u32 = 256;
+pub const WORSE_AVATAR_SIZE: u32 = 128;
 
 // max. width/height of images
 pub const BALANCED_IMAGE_SIZE: u32 = 1280;


### PR DESCRIPTION
this pr changes the avatar-pixel-size from unconditional 192x192 to 128x128 for low-media-quality and 256x256 for high-media-quality.

- both sizes are fine to display the avatar in the chatlist or in the chat

- since avatars were introduced one year ago, enlarging avatars was added on all platforms. however, the 192x192 was a bit poor for viewing details, this should be much better with 256x256 now as the number of pixels are rougly doubled

- otoh, for regions with poor traffic, avatar bytes-size should be rougly halved if low media-quality is chosen

moreover, this pr fixes bugs wrt rotation:

- exif-rotation-information for avatars were ignored before, that led to accidentally rotated avatars sometimes. this is fixed, normal-image-recoding and avatar-recoding share the same code now.

- exif-rotation-information for normal images were accidentally ignored before when scaling was not needed. this is also fixed.

closes #2062