### PR TITLE
feat: Send avatars as large as usual images when possible

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4068,7 +4068,9 @@ pub async fn set_chat_profile_image(
         msg.text = stock_str::msg_grp_img_deleted(context, ContactId::SELF).await;
     } else {
         let mut image_blob = BlobObject::new_from_path(context, Path::new(new_image)).await?;
-        image_blob.recode_to_avatar_size(context).await?;
+        image_blob
+            .recode_to_avatar_size(context, chat.is_protected())
+            .await?;
         chat.param.set(Param::ProfileImage, image_blob.as_name());
         msg.param.set(Param::Arg, image_blob.as_name());
         msg.text = stock_str::msg_grp_img_changed(context, ContactId::SELF).await;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -204,10 +204,6 @@ pub(crate) const DC_FETCH_EXISTING_MSGS_COUNT: i64 = 100;
 pub const BALANCED_IMAGE_BYTES: usize = 500_000;
 pub const WORSE_IMAGE_BYTES: usize = 130_000;
 
-// max. width/height of an avatar
-pub(crate) const BALANCED_AVATAR_SIZE: u32 = 256;
-pub(crate) const WORSE_AVATAR_SIZE: u32 = 128;
-
 // max. width/height of images scaled down because of being too huge
 pub const BALANCED_IMAGE_SIZE: u32 = 1280;
 pub const WORSE_IMAGE_SIZE: u32 = 640;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -258,7 +258,8 @@ impl Sql {
         if recode_avatar {
             if let Some(avatar) = context.get_config(Config::Selfavatar).await? {
                 let mut blob = BlobObject::new_from_path(context, avatar.as_ref()).await?;
-                match blob.recode_to_avatar_size(context).await {
+                let protected = true;
+                match blob.recode_to_avatar_size(context, protected).await {
                     Ok(()) => {
                         context
                             .set_config_internal(Config::Selfavatar, Some(&avatar))


### PR DESCRIPTION
See commit messages. The issue was raised in https://support.delta.chat/t/the-ability-to-remove-media-compression/3115