### PR TITLE
Add python and tox to flake.nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -584,6 +584,8 @@
               cargo-nextest
               perl # needed to build vendored OpenSSL
               git-cliff
+              python311
+              python311Packages.tox
             ];
           };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -584,8 +584,9 @@
               cargo-nextest
               perl # needed to build vendored OpenSSL
               git-cliff
-              python311
-              python311Packages.tox
+              (python3.withPackages (pypkgs: with pypkgs; [
+                tox
+              ]))
             ];
           };
       }


### PR DESCRIPTION
Without tox any python `scripts/make-python-env.sh` does not run. Maybe at some point we can even generate the environment for testing with `venvHook` like functionality. We could also add `python3` instead of fixing it to 3.11, but I don't know which version core expects