### PR TITLE
refactor: receive_imf: Check for better_msg emptiness before per-part loop

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1954,6 +1954,12 @@ async fn add_parts(
         .await?;
     }
 
+    // Empty `better_msg` is returned from `apply_group_changes()` when a group member
+    // addition/removal message has no effect.
+    if better_msg == Some(String::new()) && is_partial_download.is_none() {
+        chat_id = DC_CHAT_ID_TRASH;
+    }
+
     if let Some(node_addr) = mime_parser.get_header(HeaderDef::IrohNodeAddr) {
         match mime_parser.get_header(HeaderDef::InReplyTo) {
             Some(in_reply_to) => match rfc724_mid_exists(context, in_reply_to).await? {


### PR DESCRIPTION
Empty `better_msg` is returned from `apply_group_changes()` when a group member addition/removal message has no effect. It's not clear why `better_msg` was checked and `chat_id` set to `DC_CHAT_ID_TRASH` in the per-part loop.