### PR TITLE
api: Sketch add_transport_from_qr(), add_transport(), list_transports(), delete_transport() APIs

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -423,6 +423,9 @@ impl CommandApi {
 
     /// Configures this account with the currently set parameters.
     /// Setup the credential config before calling this.
+    ///
+    /// Deprecated as of 2025-02; use `add_transport_from_qr()`
+    /// or `add_transport()` instead.
     async fn configure(&self, account_id: u32) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.stop_io().await;

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -38,6 +38,7 @@ use deltachat::{imex, info};
 use sanitize_filename::is_sanitized;
 use tokio::fs;
 use tokio::sync::{watch, Mutex, RwLock};
+use types::login_param::EnteredLoginParam;
 use walkdir::WalkDir;
 use yerpc::rpc;
 
@@ -434,6 +435,32 @@ impl CommandApi {
         }
         ctx.start_io().await;
         Ok(())
+    }
+
+    async fn add_transport(&self, account_id: u32, param: EnteredLoginParam) -> Result<()> {
+        let ctx = self.get_context(account_id).await?;
+        ctx.add_transport_ex(&param.try_into()?).await
+    }
+
+    async fn add_transport_from_qr(&self, account_id: u32, qr: String) -> Result<()> {
+        let ctx = self.get_context(account_id).await?;
+        ctx.add_transport_from_qr(&qr).await
+    }
+
+    async fn list_transports(&self, account_id: u32) -> Result<Vec<EnteredLoginParam>> {
+        let ctx = self.get_context(account_id).await?;
+        let res = ctx
+            .list_transports()
+            .await?
+            .into_iter()
+            .map(|t| t.into())
+            .collect();
+        Ok(res)
+    }
+
+    async fn delete_transport(&self, account_id: u32, transport_id: u32) -> Result<()> {
+        let ctx = self.get_context(account_id).await?;
+        ctx.delete_transport(transport_id).await
     }
 
     /// Signal an ongoing process to stop.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -456,11 +456,11 @@ impl CommandApi {
     /// and may be used to create a progress bar.
     /// This function will return after configuration is finished.
     ///
-    /// If configuration is successful:
-    /// - The parameters entered by the user will be saved
-    ///   so that they can be prefilled when the user opens the server-configuration screen again
-    /// - and the working server parameters will be saved
-    ///   and used for connecting to the server.
+    /// If configuration is successful,
+    /// the working server parameters will be saved
+    /// and used for connecting to the server.
+    /// The parameters entered by the user will be saved separately
+    /// so that they can be prefilled when the user opens the server-configuration screen again.
     ///
     /// See also:
     /// - [Self::is_configured()] to check whether there is

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -439,7 +439,7 @@ impl CommandApi {
 
     async fn add_transport(&self, account_id: u32, param: EnteredLoginParam) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        ctx.add_transport_ex(&param.try_into()?).await
+        ctx.add_transport(&param.try_into()?).await
     }
 
     async fn add_transport_from_qr(&self, account_id: u32, qr: String) -> Result<()> {

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -496,11 +496,11 @@ impl CommandApi {
         Ok(res)
     }
 
-    /// Removes the specified transport.
-    /// `transport_id` is the position in the list returned by [Self::list_transports].
-    async fn delete_transport(&self, account_id: u32, transport_id: u32) -> Result<()> {
+    /// Removes the transport with the specified email address
+    /// (i.e. [EnteredLoginParam::addr]).
+    async fn delete_transport(&self, account_id: u32, addr: String) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        ctx.delete_transport(transport_id).await
+        ctx.delete_transport(&addr).await
     }
 
     /// Signal an ongoing process to stop.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -437,16 +437,51 @@ impl CommandApi {
         Ok(())
     }
 
+    /// Configures a new email account using the provided parameters
+    /// and adds it as a transport.
+    ///
+    /// If the email address is the same as an existing transport,
+    /// then this existing account will be reconfigured instead of a new one being added.
+    ///
+    /// This function stops and starts IO as needed.
+    ///
+    /// Usually it will be enough to only set `addr` and `imap.password`,
+    /// and all the other settings will be autoconfigured.
+    ///
+    /// During configuration, ConfigureProgress events are emitted;
+    /// they indicate a successful configuration as well as errors
+    /// and may be used to create a progress bar.
+    /// This function will return after configuration is finished.
+    ///
+    /// If configuration is successful:
+    /// - The parameters entered by the user will be saved
+    ///   so that they can be prefilled when the user opens the server-configuration screen again
+    /// - and the working server parameters will be saved
+    ///   and used for connecting to the server.
+    ///
+    /// See also:
+    /// - [Self::is_configured()] to check whether there is
+    ///   at least one working transport.
+    /// - [Self::add_transport_from_qr()] to add a transport
+    ///   from a server encoded in a QR code.
+    /// - [Self::list_transports()] to get a list of all configured transports.
+    /// - [Self::delete_transport()] to remove a transport.
     async fn add_transport(&self, account_id: u32, param: EnteredLoginParam) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.add_transport(&param.try_into()?).await
     }
 
+    /// Adds a new email account as a transport
+    /// using the server encoded in the QR code.
+    /// See [Self::add_transport].
     async fn add_transport_from_qr(&self, account_id: u32, qr: String) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.add_transport_from_qr(&qr).await
     }
 
+    /// Returns the list of all email accounts that are used as a transport in the current profile.
+    /// Use [Self::add_transport()] to add or change a transport
+    /// and [Self::delete_transport()] to delete a transport.
     async fn list_transports(&self, account_id: u32) -> Result<Vec<EnteredLoginParam>> {
         let ctx = self.get_context(account_id).await?;
         let res = ctx
@@ -458,6 +493,8 @@ impl CommandApi {
         Ok(res)
     }
 
+    /// Removes the specified transport.
+    /// `transport_id` is the position in the list returned by [Self::list_transports].
     async fn delete_transport(&self, account_id: u32, transport_id: u32) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.delete_transport(transport_id).await

--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -1,0 +1,196 @@
+use anyhow::Result;
+use deltachat::login_param as dc;
+use deltachat::login_param::ProxyConfig;
+use serde::Deserialize;
+use serde::Serialize;
+use yerpc::TypeDef;
+
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EnteredServerLoginParam {
+    /// Server hostname or IP address.
+    pub server: String,
+
+    /// Server port.
+    ///
+    /// 0 if not specified.
+    pub port: u16,
+
+    /// Socket security.
+    pub security: Socket,
+
+    /// Username.
+    ///
+    /// Empty string if not specified.
+    pub user: String,
+
+    /// Password.
+    pub password: String,
+}
+
+impl From<dc::EnteredServerLoginParam> for EnteredServerLoginParam {
+    fn from(param: dc::EnteredServerLoginParam) -> Self {
+        Self {
+            server: param.server,
+            port: param.port,
+            security: param.security.into(),
+            user: param.user,
+            password: param.password,
+        }
+    }
+}
+
+impl From<EnteredServerLoginParam> for dc::EnteredServerLoginParam {
+    fn from(param: EnteredServerLoginParam) -> Self {
+        Self {
+            server: param.server,
+            port: param.port,
+            security: param.security.into(),
+            user: param.user,
+            password: param.password,
+        }
+    }
+}
+
+/// Login parameters entered by the user.
+
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EnteredLoginParam {
+    /// Email address.
+    pub addr: String,
+
+    /// IMAP settings.
+    pub imap: EnteredServerLoginParam,
+
+    /// SMTP settings.
+    pub smtp: EnteredServerLoginParam,
+
+    /// TLS options: whether to allow invalid certificates and/or
+    /// invalid hostnames
+    pub certificate_checks: EnteredCertificateChecks,
+
+    /// Proxy configuration.
+    pub proxy_config: Option<String>,
+
+    pub oauth2: bool,
+}
+
+impl From<dc::EnteredLoginParam> for EnteredLoginParam {
+    fn from(param: dc::EnteredLoginParam) -> Self {
+        Self {
+            addr: param.addr,
+            imap: param.imap.into(),
+            smtp: param.smtp.into(),
+            certificate_checks: param.certificate_checks.into(),
+            proxy_config: param.proxy_config.map(|p| p.to_url()),
+            oauth2: param.oauth2,
+        }
+    }
+}
+
+impl TryFrom<EnteredLoginParam> for dc::EnteredLoginParam {
+    type Error = anyhow::Error;
+
+    fn try_from(param: EnteredLoginParam) -> Result<Self> {
+        Ok(Self {
+            addr: param.addr,
+            imap: param.imap.into(),
+            smtp: param.smtp.into(),
+            certificate_checks: param.certificate_checks.into(),
+            proxy_config: {
+                match param.proxy_config {
+                    Some(url) => Some(ProxyConfig::from_url(&url)?),
+                    None => None,
+                }
+            },
+            oauth2: param.oauth2,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Socket {
+    /// Unspecified socket security, select automatically.
+    Automatic = 0,
+
+    /// TLS connection.
+    Ssl = 1,
+
+    /// STARTTLS connection.
+    Starttls = 2,
+
+    /// No TLS, plaintext connection.
+    Plain = 3,
+}
+
+impl From<dc::Socket> for Socket {
+    fn from(value: dc::Socket) -> Self {
+        match value {
+            dc::Socket::Automatic => Self::Automatic,
+            dc::Socket::Ssl => Self::Ssl,
+            dc::Socket::Starttls => Self::Starttls,
+            dc::Socket::Plain => Self::Plain,
+        }
+    }
+}
+
+impl From<Socket> for dc::Socket {
+    fn from(value: Socket) -> Self {
+        match value {
+            Socket::Automatic => Self::Automatic,
+            Socket::Ssl => Self::Ssl,
+            Socket::Starttls => Self::Starttls,
+            Socket::Plain => Self::Plain,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum EnteredCertificateChecks {
+    /// `Automatic` means that provider database setting should be taken.
+    /// If there is no provider database setting for certificate checks,
+    /// check certificates strictly.
+    Automatic = 0,
+
+    /// Ensure that TLS certificate is valid for the server hostname.
+    Strict = 1,
+
+    /// Accept certificates that are expired, self-signed
+    /// or otherwise not valid for the server hostname.
+    AcceptInvalidCertificates = 2,
+
+    /// Alias for `AcceptInvalidCertificates`
+    /// for API compatibility.
+    AcceptInvalidCertificates2 = 3,
+}
+
+impl From<dc::EnteredCertificateChecks> for EnteredCertificateChecks {
+    fn from(value: dc::EnteredCertificateChecks) -> Self {
+        match value {
+            dc::EnteredCertificateChecks::Automatic => Self::Automatic,
+            dc::EnteredCertificateChecks::Strict => Self::Strict,
+            dc::EnteredCertificateChecks::AcceptInvalidCertificates => {
+                Self::AcceptInvalidCertificates
+            }
+            dc::EnteredCertificateChecks::AcceptInvalidCertificates2 => {
+                Self::AcceptInvalidCertificates2
+            }
+        }
+    }
+}
+
+impl From<EnteredCertificateChecks> for dc::EnteredCertificateChecks {
+    fn from(value: EnteredCertificateChecks) -> Self {
+        match value {
+            EnteredCertificateChecks::Automatic => Self::Automatic,
+            EnteredCertificateChecks::Strict => Self::Strict,
+            EnteredCertificateChecks::AcceptInvalidCertificates => Self::AcceptInvalidCertificates,
+            EnteredCertificateChecks::AcceptInvalidCertificates2 => {
+                Self::AcceptInvalidCertificates2
+            }
+        }
+    }
+}

--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -73,6 +73,7 @@ pub struct EnteredLoginParam {
     /// Proxy configuration.
     pub proxy_config: Option<String>,
 
+    /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
 }
 
@@ -161,10 +162,6 @@ pub enum EnteredCertificateChecks {
     /// Accept certificates that are expired, self-signed
     /// or otherwise not valid for the server hostname.
     AcceptInvalidCertificates = 2,
-
-    /// Alias for `AcceptInvalidCertificates`
-    /// for API compatibility.
-    AcceptInvalidCertificates2 = 3,
 }
 
 impl From<dc::EnteredCertificateChecks> for EnteredCertificateChecks {
@@ -176,7 +173,7 @@ impl From<dc::EnteredCertificateChecks> for EnteredCertificateChecks {
                 Self::AcceptInvalidCertificates
             }
             dc::EnteredCertificateChecks::AcceptInvalidCertificates2 => {
-                Self::AcceptInvalidCertificates2
+                Self::AcceptInvalidCertificates
             }
         }
     }
@@ -188,9 +185,6 @@ impl From<EnteredCertificateChecks> for dc::EnteredCertificateChecks {
             EnteredCertificateChecks::Automatic => Self::Automatic,
             EnteredCertificateChecks::Strict => Self::Strict,
             EnteredCertificateChecks::AcceptInvalidCertificates => Self::AcceptInvalidCertificates,
-            EnteredCertificateChecks::AcceptInvalidCertificates2 => {
-                Self::AcceptInvalidCertificates2
-            }
         }
     }
 }

--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use deltachat::login_param as dc;
-use deltachat::login_param::ProxyConfig;
 use serde::Deserialize;
 use serde::Serialize;
 use yerpc::TypeDef;
@@ -70,9 +69,6 @@ pub struct EnteredLoginParam {
     /// invalid hostnames
     pub certificate_checks: EnteredCertificateChecks,
 
-    /// Proxy configuration.
-    pub proxy_config: Option<String>,
-
     /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
 }
@@ -84,7 +80,6 @@ impl From<dc::EnteredLoginParam> for EnteredLoginParam {
             imap: param.imap.into(),
             smtp: param.smtp.into(),
             certificate_checks: param.certificate_checks.into(),
-            proxy_config: param.proxy_config.map(|p| p.to_url()),
             oauth2: param.oauth2,
         }
     }
@@ -99,12 +94,6 @@ impl TryFrom<EnteredLoginParam> for dc::EnteredLoginParam {
             imap: param.imap.into(),
             smtp: param.smtp.into(),
             certificate_checks: param.certificate_checks.into(),
-            proxy_config: {
-                match param.proxy_config {
-                    Some(url) => Some(ProxyConfig::from_url(&url)?),
-                    None => None,
-                }
-            },
             oauth2: param.oauth2,
         })
     }

--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -114,16 +114,16 @@ impl TryFrom<EnteredLoginParam> for dc::EnteredLoginParam {
 #[serde(rename_all = "camelCase")]
 pub enum Socket {
     /// Unspecified socket security, select automatically.
-    Automatic = 0,
+    Automatic,
 
     /// TLS connection.
-    Ssl = 1,
+    Ssl,
 
     /// STARTTLS connection.
-    Starttls = 2,
+    Starttls,
 
     /// No TLS, plaintext connection.
-    Plain = 3,
+    Plain,
 }
 
 impl From<dc::Socket> for Socket {
@@ -154,14 +154,14 @@ pub enum EnteredCertificateChecks {
     /// `Automatic` means that provider database setting should be taken.
     /// If there is no provider database setting for certificate checks,
     /// check certificates strictly.
-    Automatic = 0,
+    Automatic,
 
     /// Ensure that TLS certificate is valid for the server hostname.
-    Strict = 1,
+    Strict,
 
     /// Accept certificates that are expired, self-signed
     /// or otherwise not valid for the server hostname.
-    AcceptInvalidCertificates = 2,
+    AcceptInvalidCertificates,
 }
 
 impl From<dc::EnteredCertificateChecks> for EnteredCertificateChecks {

--- a/deltachat-jsonrpc/src/api/types/mod.rs
+++ b/deltachat-jsonrpc/src/api/types/mod.rs
@@ -5,6 +5,7 @@ pub mod contact;
 pub mod events;
 pub mod http;
 pub mod location;
+pub mod login_param;
 pub mod message;
 pub mod provider_info;
 pub mod qr;

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -461,7 +461,7 @@ def test_qr_new_group_unblocked(acfactory):
     assert ac2_msg.chat.get_basic_snapshot().is_contact_request
 
 
-@pytest.mark.ignored
+@pytest.mark.skip(reason="AEAP is disabled for now")
 def test_aeap_flow_verified(acfactory):
     """Test that a new address is added to a contact when it changes its address."""
     ac1, ac2 = acfactory.get_online_accounts(2)

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -461,6 +461,7 @@ def test_qr_new_group_unblocked(acfactory):
     assert ac2_msg.chat.get_basic_snapshot().is_contact_request
 
 
+@pytest.mark.ignored
 def test_aeap_flow_verified(acfactory):
     """Test that a new address is added to a contact when it changes its address."""
     ac1, ac2 = acfactory.get_online_accounts(2)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -31,7 +31,7 @@ use crate::log::LogExt;
 pub use crate::login_param::EnteredLoginParam;
 use crate::login_param::{
     ConfiguredCertificateChecks, ConfiguredLoginParam, ConfiguredServerLoginParam,
-    ConnectionCandidate, EnteredCertificateChecks,
+    ConnectionCandidate, EnteredCertificateChecks, ProxyConfig,
 };
 use crate::message::Message;
 use crate::oauth2::get_oauth2_addr;
@@ -259,8 +259,7 @@ async fn get_configured_param(
         param.smtp.password.clone()
     };
 
-    let proxy_config = param.proxy_config.clone();
-    let proxy_enabled = proxy_config.is_some();
+    let proxy_enabled = ctx.get_config_bool(Config::ProxyEnabled).await?;
 
     let mut addr = param.addr.clone();
     if param.oauth2 {
@@ -419,7 +418,7 @@ async fn get_configured_param(
             .collect(),
         smtp_user: param.smtp.user.clone(),
         smtp_password,
-        proxy_config: param.proxy_config.clone(),
+        proxy_config: ProxyConfig::load(ctx).await?,
         provider,
         certificate_checks: match param.certificate_checks {
             EnteredCertificateChecks::Automatic => ConfiguredCertificateChecks::Automatic,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -67,6 +67,9 @@ impl Context {
     }
 
     /// Configures this account with the currently provided parameters.
+    ///
+    /// Deprecated since 2025-02; use `add_transport_from_qr()`
+    /// or `add_transport()` instead.
     pub async fn configure(&self) -> Result<()> {
         let param = EnteredLoginParam::load(self).await?;
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -73,7 +73,7 @@ impl Context {
     pub async fn configure(&self) -> Result<()> {
         let param = EnteredLoginParam::load(self).await?;
 
-        self.add_transport_ex(&param).await
+        self.add_transport_inner(&param).await
     }
 
     /// Configures a new email account using the provided parameters
@@ -107,7 +107,7 @@ impl Context {
     /// - [Self::delete_transport()] to remove a transport.
     pub async fn add_transport(&self, param: &EnteredLoginParam) -> Result<()> {
         self.stop_io().await;
-        let result = self.add_transport_ex(param).await;
+        let result = self.add_transport_inner(param).await;
         if result.is_err() {
             if let Ok(true) = self.is_configured().await {
                 self.start_io().await;
@@ -118,7 +118,7 @@ impl Context {
         Ok(())
     }
 
-    async fn add_transport_ex(&self, param: &EnteredLoginParam) -> Result<()> {
+    async fn add_transport_inner(&self, param: &EnteredLoginParam) -> Result<()> {
         ensure!(
             !self.scheduler.is_running().await,
             "cannot configure, already running"

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -92,11 +92,11 @@ impl Context {
     /// and may be used to create a progress bar.
     /// This function will return after configuration is finished.
     ///
-    /// If configuration is successful:
-    /// - The parameters entered by the user will be saved
-    ///   so that they can be prefilled when the user opens the server-configuration screen again
-    /// - and the working server parameters will be saved
-    ///   and used for connecting to the server.
+    /// If configuration is successful,
+    /// the working server parameters will be saved
+    /// and used for connecting to the server.
+    /// The parameters entered by the user will be saved separately
+    /// so that they can be prefilled when the user opens the server-configuration screen again.
     ///
     /// See also:
     /// - [Self::is_configured()] to check whether there is

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -28,9 +28,10 @@ use crate::constants::NON_ALPHANUMERIC_WITHOUT_DOT;
 use crate::context::Context;
 use crate::imap::Imap;
 use crate::log::LogExt;
+pub use crate::login_param::EnteredLoginParam;
 use crate::login_param::{
     ConfiguredCertificateChecks, ConfiguredLoginParam, ConfiguredServerLoginParam,
-    ConnectionCandidate, EnteredCertificateChecks, EnteredLoginParam,
+    ConnectionCandidate, EnteredCertificateChecks,
 };
 use crate::message::Message;
 use crate::oauth2::get_oauth2_addr;
@@ -128,6 +129,7 @@ impl Context {
 
     /// Removes the specified transport.
     /// `index` is the position in the list returned by `list_transports()`.
+    #[expect(clippy::unused_async)]
     pub async fn delete_transport(_index: usize) -> Result<()> {
         bail!("Adding and removing additional transports is not supported yet. Check back in a few months!")
     }
@@ -136,7 +138,7 @@ impl Context {
         info!(self, "Configure ...");
 
         let old_addr = self.get_config(Config::ConfiguredAddr).await?;
-        let configured_param = configure(self, &param).await?;
+        let configured_param = configure(self, param).await?;
         self.set_config_internal(Config::NotifyAboutWrongPw, Some("1"))
             .await?;
         on_configure_completed(self, configured_param, old_addr).await?;

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -84,19 +84,10 @@ impl Context {
         self.free_ongoing().await;
 
         if let Err(err) = res.as_ref() {
-            progress!(
-                self,
-                0,
-                Some(
-                    stock_str::configuration_failed(
-                        self,
-                        // We are using Anyhow's .context() and to show the
-                        // inner error, too, we need the {:#}:
-                        &format!("{err:#}"),
-                    )
-                    .await
-                )
-            );
+            // We are using Anyhow's .context() and to show the
+            // inner error, too, we need the {:#}:
+            let error_msg = stock_str::configuration_failed(self, &format!("{err:#}")).await;
+            progress!(self, 0, Some(error_msg));
         } else {
             progress!(self, 1000);
         }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -141,7 +141,7 @@ impl Context {
     }
 
     /// Removes the specified transport.
-    /// `transport_id` is the position in the list returned by [list_transports].
+    /// `transport_id` is the position in the list returned by [Self::list_transports].
     #[expect(clippy::unused_async)]
     pub async fn delete_transport(&self, _transport_id: u32) -> Result<()> {
         bail!("Adding and removing additional transports is not supported yet. Check back in a few months!")

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -172,10 +172,10 @@ impl Context {
         Ok(vec![param])
     }
 
-    /// Removes the specified transport.
-    /// `transport_id` is the position in the list returned by [Self::list_transports].
+    /// Removes the transport with the specified email address
+    /// (i.e. [EnteredLoginParam::addr]).
     #[expect(clippy::unused_async)]
-    pub async fn delete_transport(&self, _transport_id: u32) -> Result<()> {
+    pub async fn delete_transport(&self, _addr: &str) -> Result<()> {
         bail!("Adding and removing additional transports is not supported yet. Check back in a few months!")
     }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -73,6 +73,10 @@ impl Context {
         self.add_transport_ex(&param).await
     }
 
+    /// Adds a new email account as a transport using the provided parameters.
+    ///
+    /// If the email address is the same as an existing transport,
+    /// then this existing account will be reconfigured instead of a new one being added.
     pub async fn add_transport(&self, param: &EnteredLoginParam) -> Result<()> {
         self.stop_io().await;
         let result = self.add_transport_ex(param).await;
@@ -86,11 +90,7 @@ impl Context {
         Ok(())
     }
 
-    /// Adds a new email account as a transport using the provided parameters.
-    ///
-    /// If the email address is the same as an existing transport,
-    /// then this existing account will be reconfigured instead of a new one being added.
-    pub async fn add_transport_ex(&self, param: &EnteredLoginParam) -> Result<()> {
+    async fn add_transport_ex(&self, param: &EnteredLoginParam) -> Result<()> {
         ensure!(
             !self.scheduler.is_running().await,
             "cannot configure, already running"

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -76,7 +76,6 @@ impl Context {
     ///
     /// If the email address is the same as an existing transport,
     /// then this existing account will be reconfigured instead of a new one being added.
-    /// TODO this fn doesn't save the entered parameters
     pub async fn add_transport_by_params(&self, param: &EnteredLoginParam) -> Result<()> {
         ensure!(
             !self.scheduler.is_running().await,
@@ -105,6 +104,7 @@ impl Context {
             let error_msg = stock_str::configuration_failed(self, &format!("{err:#}")).await;
             progress!(self, 0, Some(error_msg));
         } else {
+            param.save(self).await?;
             progress!(self, 1000);
         }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -76,6 +76,7 @@ impl Context {
     ///
     /// If the email address is the same as an existing transport,
     /// then this existing account will be reconfigured instead of a new one being added.
+    /// TODO this fn doesn't save the entered parameters
     pub async fn add_transport_by_params(&self, param: &EnteredLoginParam) -> Result<()> {
         ensure!(
             !self.scheduler.is_running().await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod imap;
 pub mod imex;
 pub mod key;
 pub mod location;
-mod login_param;
+pub mod login_param;
 pub mod message;
 mod mimefactory;
 pub mod mimeparser;

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -464,6 +464,7 @@ pub(crate) struct ConfiguredLoginParam {
     /// invalid hostnames
     pub certificate_checks: ConfiguredCertificateChecks,
 
+    /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
 }
 

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -119,9 +119,6 @@ pub struct EnteredLoginParam {
     /// invalid hostnames
     pub certificate_checks: EnteredCertificateChecks,
 
-    /// Proxy configuration.
-    pub proxy_config: Option<ProxyConfig>,
-
     /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
 }
@@ -200,8 +197,6 @@ impl EnteredLoginParam {
             .unwrap_or_default();
         let oauth2 = matches!(server_flags & DC_LP_AUTH_FLAGS, DC_LP_AUTH_OAUTH2);
 
-        let proxy_config = ProxyConfig::load(context).await?;
-
         Ok(EnteredLoginParam {
             addr,
             imap: EnteredServerLoginParam {
@@ -219,7 +214,6 @@ impl EnteredLoginParam {
                 password: send_pw,
             },
             certificate_checks,
-            proxy_config,
             oauth2,
         })
     }
@@ -281,14 +275,6 @@ impl EnteredLoginParam {
         };
         context
             .set_config(Config::ServerFlags, server_flags.as_deref())
-            .await?;
-
-        context
-            .set_config_bool(Config::ProxyEnabled, self.proxy_config.is_some())
-            .await?;
-        let proxy = self.proxy_config.as_ref().map(|proxy| proxy.to_url());
-        context
-            .set_config(Config::ProxyUrl, proxy.as_deref())
             .await?;
 
         Ok(())
@@ -934,7 +920,6 @@ mod tests {
                 password: "".to_string(),
             },
             certificate_checks: Default::default(),
-            proxy_config: Default::default(),
             oauth2: false,
         };
         param.save(&t).await?;

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -122,6 +122,7 @@ pub struct EnteredLoginParam {
     /// Proxy configuration.
     pub proxy_config: Option<ProxyConfig>,
 
+    /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
 }
 

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -276,16 +276,14 @@ impl EnteredLoginParam {
         } else {
             None
         };
-        context.set_config(Config::ServerFlags, server_flags.as_deref()).await?;
+        context
+            .set_config(Config::ServerFlags, server_flags.as_deref())
+            .await?;
 
         context
             .set_config_bool(Config::ProxyEnabled, self.proxy_config.is_some())
             .await?;
-        let proxy = if let Some(proxy) = &self.proxy_config {
-            Some(proxy.to_url())
-        } else {
-            None
-        };
+        let proxy = self.proxy_config.as_ref().map(|proxy| proxy.to_url());
         context
             .set_config(Config::ProxyUrl, proxy.as_deref())
             .await?;

--- a/src/net/proxy.rs
+++ b/src/net/proxy.rs
@@ -154,18 +154,21 @@ impl Socks5Config {
     }
 }
 
+/// Configuration for the proxy through which all traffic
+/// (except for iroh p2p connections)
+/// will be sent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProxyConfig {
-    // HTTP proxy.
+    /// HTTP proxy.
     Http(HttpConfig),
 
-    // HTTPS proxy.
+    /// HTTPS proxy.
     Https(HttpConfig),
 
-    // SOCKS5 proxy.
+    /// SOCKS5 proxy.
     Socks5(Socks5Config),
 
-    // Shadowsocks proxy.
+    /// Shadowsocks proxy.
     Shadowsocks(ShadowsocksConfig),
 }
 

--- a/src/net/proxy.rs
+++ b/src/net/proxy.rs
@@ -246,7 +246,7 @@ where
 
 impl ProxyConfig {
     /// Creates a new proxy configuration by parsing given proxy URL.
-    pub(crate) fn from_url(url: &str) -> Result<Self> {
+    pub fn from_url(url: &str) -> Result<Self> {
         let url = Url::parse(url).context("Cannot parse proxy URL")?;
         match url.scheme() {
             "http" => {
@@ -305,7 +305,7 @@ impl ProxyConfig {
     ///
     /// This function can be used to normalize proxy URL
     /// by parsing it and serializing back.
-    pub(crate) fn to_url(&self) -> String {
+    pub fn to_url(&self) -> String {
         match self {
             Self::Http(http_config) => http_config.to_url("http"),
             Self::Https(http_config) => http_config.to_url("https"),

--- a/src/net/proxy.rs
+++ b/src/net/proxy.rs
@@ -391,7 +391,7 @@ impl ProxyConfig {
 
     /// If `load_dns_cache` is true, loads cached DNS resolution results.
     /// Use this only if the connection is going to be protected with TLS checks.
-    pub async fn connect(
+    pub(crate) async fn connect(
         &self,
         context: &Context,
         target_host: &str,

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -678,7 +678,7 @@ struct CreateAccountErrorResponse {
 /// take a qr of the type DC_QR_ACCOUNT, parse it's parameters,
 /// download additional information from the contained url and set the parameters.
 /// on success, a configure::configure() should be able to log in to the account
-async fn set_account_from_qr(context: &Context, qr: &str) -> Result<()> {
+pub(crate) async fn set_account_from_qr(context: &Context, qr: &str) -> Result<()> {
     let url_str = qr
         .get(DCACCOUNT_SCHEME.len()..)
         .context("Invalid DCACCOUNT scheme")?;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -603,6 +603,36 @@ where
     }
 }
 
+pub(crate) trait ToOption<T> {
+    fn to_option(self) -> Option<T>;
+}
+impl<'a> ToOption<&'a str> for &'a String {
+    fn to_option(self) -> Option<&'a str> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
+impl ToOption<String> for u16 {
+    fn to_option(self) -> Option<String> {
+        if self == 0 {
+            None
+        } else {
+            Some(self.to_string())
+        }
+    }
+}
+impl ToOption<String> for Option<i32> {
+    fn to_option(self) -> Option<String> {
+        match self {
+            None | Some(0) => None,
+            Some(v) => Some(v.to_string()),
+        }
+    }
+}
+
 pub fn remove_subject_prefix(last_subject: &str) -> String {
     let subject_start = if last_subject.starts_with("Chat:") {
         0


### PR DESCRIPTION
Four new APIs `add_transport_from_qr()`, `add_transport()`, `list_transports()`, `delete_transport()`, as described in the draft at "API".

The `add_tranport*()` APIs automatically stops and starts I/O; for `configure()` the stopping and starting is done in the JsonRPC bindings, which is not where things like this should be done I think, the bindings should just translate the APIs.

This also completely disables AEAP for now.

I won't be available for a week, but if you want to merge this already, feel free to just commit all review suggestions and squash-merge.

For the new `deltachat-jsonrpc/src/api/types/login_param.rs` file and for the function `to_option()`, it seems to me like there should be a more straightforward way to do things, but probably they are fine as-is.

