### PR TITLE
allow doubled avatar resolution

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -252,24 +252,27 @@ impl<'a> BlobObject<'a> {
     }
 
     pub async fn recode_to_avatar_size(&mut self, context: &Context) -> Result<()> {
-        let img_wh =
+        let (img_wh, max_bytes) =
             match MediaQuality::from_i32(context.get_config_int(Config::MediaQuality).await?)
                 .unwrap_or_default()
             {
-                MediaQuality::Balanced => constants::BALANCED_AVATAR_SIZE,
-                MediaQuality::Worse => constants::WORSE_AVATAR_SIZE,
+                MediaQuality::Balanced => (
+                    constants::BALANCED_AVATAR_SIZE,
+                    constants::BALANCED_AVATAR_BYTES,
+                ),
+                MediaQuality::Worse => {
+                    (constants::WORSE_AVATAR_SIZE, constants::WORSE_AVATAR_BYTES)
+                }
             };
 
         let maybe_sticker = &mut false;
         let strict_limits = true;
-        // max_bytes is 20_000 bytes: Outlook servers don't allow headers larger than 32k.
-        // 32 / 4 * 3 = 24k if you account for base64 encoding. To be safe, we reduced this to 20k.
         self.recode_to_size(
             context,
             None, // The name of an avatar doesn't matter
             maybe_sticker,
             img_wh,
-            20_000,
+            max_bytes,
             strict_limits,
         )?;
 

--- a/src/blob/blob_tests.rs
+++ b/src/blob/blob_tests.rs
@@ -174,7 +174,7 @@ async fn test_selfavatar_outside_blobdir() {
     let avatar_blob = t.get_config(Config::Selfavatar).await.unwrap().unwrap();
     let avatar_path = Path::new(&avatar_blob);
     assert!(
-        avatar_blob.ends_with("d98cd30ed8f2129bf3968420208849d.jpg"),
+        avatar_blob.ends_with("009161310a6afc319163e4bcabd23b9.jpg"),
         "The avatar filename should be its hash, put instead it's {avatar_blob}"
     );
     let scaled_avatar_size = file_size(avatar_path).await;
@@ -226,7 +226,7 @@ async fn test_selfavatar_in_blobdir() {
         .unwrap();
     let avatar_cfg = t.get_config(Config::Selfavatar).await.unwrap().unwrap();
     assert!(
-        avatar_cfg.ends_with("fa7418e646301203538041f60d03190.png"),
+        avatar_cfg.ends_with("ec054c444a5755adf2b0aaea40209f2.png"),
         "Avatar file name {avatar_cfg} should end with its hash"
     );
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -204,9 +204,11 @@ pub(crate) const DC_FETCH_EXISTING_MSGS_COUNT: i64 = 100;
 pub const BALANCED_IMAGE_BYTES: usize = 500_000;
 pub const WORSE_IMAGE_BYTES: usize = 130_000;
 
-// max. width/height of an avatar
-pub(crate) const BALANCED_AVATAR_SIZE: u32 = 256;
+// max. width/height and bytes of an avatar
+pub(crate) const BALANCED_AVATAR_SIZE: u32 = 512;
+pub(crate) const BALANCED_AVATAR_BYTES: usize = 60_000;
 pub(crate) const WORSE_AVATAR_SIZE: u32 = 128;
+pub(crate) const WORSE_AVATAR_BYTES: usize = 20_000; // this also fits to Outlook servers don't allowing headers larger than 32k.
 
 // max. width/height of images scaled down because of being too huge
 pub const BALANCED_IMAGE_SIZE: u32 = 1280;


### PR DESCRIPTION
up to now, avatars were restricted to 20k, 256x256 pixel. resulting in often poor avatar quality.
(the limitation comes from times
where unencrypted outlook inner headers were a thing; this has changed meanwhile)

to increase quality while keeping a reasonable small size, for "balanced quality",
we increase the allowed width to 512x512 and the allowed size to 60k.

for "worse quality", things stay unchanged at 128x128 pixel and 20k.