### PR TITLE
feat: delete messages on IMAP when deleting chat

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -784,6 +784,7 @@ impl ChatId {
         );
 
         let chat = Chat::load_from_db(context, self).await?;
+        let delete_msgs_target = context.get_delete_msgs_target().await?;
         let sync_id = match sync {
             Nosync => None,
             Sync => chat.get_sync_id(context).await?,
@@ -792,6 +793,16 @@ impl ChatId {
         context
             .sql
             .transaction(|transaction| {
+                if sync_id.is_some() {
+                    transaction.execute(
+                        "UPDATE imap SET target=? WHERE rfc724_mid IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
+                        (delete_msgs_target, self,),
+                    )?;
+                    transaction.execute(
+                        "DELETE FROM smtp WHERE msg_id IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
+                        (self,),
+                    )?;
+                }
                 transaction.execute(
                     "DELETE FROM msgs_mdns WHERE msg_id IN (SELECT id FROM msgs WHERE chat_id=?)",
                     (self,),

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -793,16 +793,14 @@ impl ChatId {
         context
             .sql
             .transaction(|transaction| {
-                if sync_id.is_some() {
-                    transaction.execute(
-                        "UPDATE imap SET target=? WHERE rfc724_mid IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
-                        (delete_msgs_target, self,),
-                    )?;
-                    transaction.execute(
-                        "DELETE FROM smtp WHERE msg_id IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
-                        (self,),
-                    )?;
-                }
+                transaction.execute(
+                    "UPDATE imap SET target=? WHERE rfc724_mid IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
+                    (delete_msgs_target, self,),
+                )?;
+                transaction.execute(
+                    "DELETE FROM smtp WHERE msg_id IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
+                    (self,),
+                )?;
                 transaction.execute(
                     "DELETE FROM msgs_mdns WHERE msg_id IN (SELECT id FROM msgs WHERE chat_id=?)",
                     (self,),

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -798,7 +798,7 @@ impl ChatId {
                     (delete_msgs_target, self,),
                 )?;
                 transaction.execute(
-                    "DELETE FROM smtp WHERE msg_id IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
+                    "DELETE FROM smtp WHERE msg_id IN (SELECT id FROM msgs WHERE chat_id=?)",
                     (self,),
                 )?;
                 transaction.execute(


### PR DESCRIPTION
this PR deletes all known messages belonging to a chat when the chat is deleted. 

this may not be an exhaustive list as a client might not know all message-ids (eg. when using different times for "delete from device"). in this case, other devices may know more IDs. otherwise, the chatmail server will eventually clean up at some point. for non-chatmail, this is up to the user then.

the deletion sql commands were inspired by [`delete_msgs_ex`](https://github.com/chatmail/core/blob/main/src/message.rs#L1743) (in fact, [a first try](https://github.com/chatmail/core/compare/r10s/clear-chat-on-delete) was adapting that part, however, that seems less performant as lots of sql commands are needed)

successor of #5007