### PR TITLE
feat: add chat-deleted event

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6315,6 +6315,18 @@ void dc_event_unref(dc_event_t* event);
 
 
 /**
+ * Chat was deleted.
+ * This event is emitted in response to dc_delete_chat()
+ * called on this or another device.
+ * The event is a good place to remove notifications or homescreen shortcuts.
+ *
+ * @param data1 (int) chat_id
+ * @param data2 (int) 0
+ */
+#define DC_EVENT_CHAT_DELETED             2023
+
+
+/**
  * Contact(s) created, renamed, verified, blocked or deleted.
  *
  * @param data1 (int) contact_id of the changed contact or 0 on batch-changes or deletion.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -544,6 +544,7 @@ pub unsafe extern "C" fn dc_event_get_id(event: *mut dc_event_t) -> libc::c_int 
         EventType::MsgDeleted { .. } => 2016,
         EventType::ChatModified(_) => 2020,
         EventType::ChatEphemeralTimerModified { .. } => 2021,
+        EventType::ChatDeleted { .. } => 2023,
         EventType::ContactsChanged(_) => 2030,
         EventType::LocationChanged(_) => 2035,
         EventType::ConfigureProgress { .. } => 2041,
@@ -610,7 +611,8 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
         | EventType::MsgRead { chat_id, .. }
         | EventType::MsgDeleted { chat_id, .. }
         | EventType::ChatModified(chat_id)
-        | EventType::ChatEphemeralTimerModified { chat_id, .. } => chat_id.to_u32() as libc::c_int,
+        | EventType::ChatEphemeralTimerModified { chat_id, .. }
+        | EventType::ChatDeleted { chat_id } => chat_id.to_u32() as libc::c_int,
         EventType::ContactsChanged(id) | EventType::LocationChanged(id) => {
             let id = id.unwrap_or_default();
             id.to_u32() as libc::c_int
@@ -676,6 +678,7 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         | EventType::AccountsItemChanged
         | EventType::ConfigSynced { .. }
         | EventType::ChatModified(_)
+        | EventType::ChatDeleted { .. }
         | EventType::WebxdcRealtimeAdvertisementReceived { .. }
         | EventType::EventChannelOverflow { .. } => 0,
         EventType::MsgsChanged { msg_id, .. }
@@ -767,6 +770,7 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::WebxdcInstanceDeleted { .. }
         | EventType::AccountsBackgroundFetchDone
         | EventType::ChatEphemeralTimerModified { .. }
+        | EventType::ChatDeleted { .. }
         | EventType::IncomingMsgBunch { .. }
         | EventType::ChatlistItemChanged { .. }
         | EventType::ChatlistChanged

--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -243,6 +243,12 @@ pub enum EventType {
         timer: u32,
     },
 
+    /// Chat deleted.
+    ChatDeleted {
+        /// Chat ID.
+        chat_id: u32,
+    },
+
     /// Contact(s) created, renamed, blocked or deleted.
     #[serde(rename_all = "camelCase")]
     ContactsChanged {
@@ -499,6 +505,9 @@ impl From<CoreEventType> for EventType {
                     timer: timer.to_u32(),
                 }
             }
+            CoreEventType::ChatDeleted { chat_id } => ChatDeleted {
+                chat_id: chat_id.to_u32(),
+            },
             CoreEventType::ContactsChanged(contact) => ContactsChanged {
                 contact_id: contact.map(|c| c.to_u32()),
             },

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -803,6 +803,7 @@ impl ChatId {
             })
             .await?;
 
+        context.emit_event(EventType::ChatDeleted { chat_id: self });
         context.emit_msgs_changed_without_ids();
 
         if let Some(id) = sync_id {

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -219,6 +219,12 @@ pub enum EventType {
         timer: EphemeralTimer,
     },
 
+    /// Chat was deleted.
+    ChatDeleted {
+        /// Chat ID.
+        chat_id: ChatId,
+    },
+
     /// Contact(s) created, renamed, blocked, deleted or changed their "recently seen" status.
     ///
     /// @param data1 (int) If set, this is the contact_id of an added contact that should be selected.


### PR DESCRIPTION
this PR adds an event when a chat is deleted.

this is needed for removing existing notifications or homescreen shortcuts 