### PR TITLE
fix: Ignore hidden headers in IMF section

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -23,7 +23,7 @@ use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::location;
 use crate::message::{self, Message, MsgId, Viewtype};
-use crate::mimeparser::SystemMessage;
+use crate::mimeparser::{is_hidden, SystemMessage};
 use crate::param::Param;
 use crate::peer_channels::create_iroh_header;
 use crate::peerstate::Peerstate;
@@ -869,11 +869,7 @@ impl MimeFactory {
             if header_name == "message-id" {
                 unprotected_headers.push(header.clone());
                 hidden_headers.push(header.clone());
-            } else if header_name == "chat-user-avatar"
-                || header_name == "chat-group-avatar"
-                || header_name == "chat-delete"
-                || header_name == "chat-edit"
-            {
+            } else if is_hidden(&header_name) {
                 hidden_headers.push(header.clone());
             } else if header_name == "autocrypt"
                 && !context.get_config_bool(Config::ProtectAutocrypt).await?

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -253,6 +253,7 @@ impl MimeMessage {
             &mut chat_disposition_notification_to,
             &mail.headers,
         );
+        headers.retain(|k, _| !is_hidden(k));
 
         // Parse hidden headers.
         let mimetype = mail.ctype.mimetype.parse::<Mime>()?;
@@ -289,12 +290,7 @@ impl MimeMessage {
                     let key = field.get_key().to_lowercase();
 
                     // For now only avatar headers can be hidden.
-                    if !headers.contains_key(&key)
-                        && (key == "chat-user-avatar"
-                            || key == "chat-group-avatar"
-                            || key == "chat-delete"
-                            || key == "chat-edit")
-                    {
+                    if !headers.contains_key(&key) && is_hidden(&key) {
                         headers.insert(key.to_string(), field.get_value());
                     }
                 }
@@ -1985,6 +1981,14 @@ fn is_known(key: &str) -> bool {
             | "references"
             | "subject"
             | "secure-join"
+    )
+}
+
+/// Returns if the header is hidden and must be ignored in the IMF section.
+pub(crate) fn is_hidden(key: &str) -> bool {
+    matches!(
+        key,
+        "chat-user-avatar" | "chat-group-avatar" | "chat-delete" | "chat-edit"
     )
 }
 

--- a/test-data/message/mail_with_user_and_group_avatars.eml
+++ b/test-data/message/mail_with_user_and_group_avatars.eml
@@ -1,7 +1,5 @@
 Chat-Group-ID: WVnDtF5azch
 Chat-Group-Name: =?utf-8?q?testgr1?=
-Chat-Group-Avatar: group-image.png
-Chat-User-Avatar: avatar.png
 Subject: =?utf-8?q?Chat=3A_testgr1=3A_hi!_?=
 Date: Thu, 12 Dec 2019 17:24:03 +0000
 X-Mailer: Delta Chat Core 1.0.0-beta.15/CLI
@@ -14,6 +12,8 @@ Content-Type: multipart/mixed; boundary="LV8nfXkpyyn39fsVyoB1b29PKDMeb5"
 
 --LV8nfXkpyyn39fsVyoB1b29PKDMeb5
 Content-Type: text/plain; charset=utf-8
+Chat-Group-Avatar: group-image.png
+Chat-User-Avatar: avatar.png
 
 hi! 
 

--- a/test-data/message/mail_with_user_avatar.eml
+++ b/test-data/message/mail_with_user_avatar.eml
@@ -1,4 +1,3 @@
-Chat-User-Avatar: avatar.png
 Subject: =?utf-8?q?Chat=3A_this_is_a_message_with_a_=2E=2E=2E?=
 Message-ID: Mr.wOBwZNbBTVt.NZpmQDwWoNk@example.org
 In-Reply-To: Mr.ETXqza5-WpB.zDEYOLECxAw@example.org
@@ -12,6 +11,7 @@ Content-Type: multipart/mixed; boundary="luTiGu6GBoVLCvTkzVtmZmwsmhkNMw"
 
 --luTiGu6GBoVLCvTkzVtmZmwsmhkNMw
 Content-Type: text/plain; charset=utf-8
+Chat-User-Avatar: avatar.png
 
 this is a message with a profile-image attached
 

--- a/test-data/message/mail_with_user_avatar_deleted.eml
+++ b/test-data/message/mail_with_user_avatar_deleted.eml
@@ -1,5 +1,3 @@
-Content-Type: text/plain; charset=utf-8
-Chat-User-Avatar: 0
 Subject: =?utf-8?q?Chat=3A_profile_image_deleted?=
 Message-ID: Mr.tsgoJgn-cBf.0TkFWKJzeSp@example.org
 Date: Sun, 08 Dec 2019 23:28:30 +0000
@@ -7,8 +5,16 @@ X-Mailer: Delta Chat Core 1.0.0-beta.12/CLI
 Chat-Version: 1.0
 To: <tunis3@example>
 From: "=?utf-8?q??=" <tunis4@example.org>
+Content-Type: multipart/mixed; boundary="luTiGu6GBoVLCvTkzVtmZmwsmhkNMw"
+
+
+--luTiGu6GBoVLCvTkzVtmZmwsmhkNMw
+Content-Type: text/plain; charset=utf-8
+Chat-User-Avatar: 0
 
 profile image deleted
 
 -- 
 Sent with my Delta Chat Messenger: https://delta.chat
+
+--luTiGu6GBoVLCvTkzVtmZmwsmhkNMw--


### PR DESCRIPTION
Hidden headers are nonstandard, so they aren't DKIM-signed by e.g. OpenDKIM if they appear in IMF section.