### PR TITLE
fix: Prefer hidden Message-ID header if any

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -288,9 +288,7 @@ impl MimeMessage {
             if let Some(part) = part.subparts.first() {
                 for field in &part.headers {
                     let key = field.get_key().to_lowercase();
-
-                    // For now only avatar headers can be hidden.
-                    if !headers.contains_key(&key) && is_hidden(&key) {
+                    if !headers.contains_key(&key) && is_hidden(&key) || key == "message-id" {
                         headers.insert(key.to_string(), field.get_value());
                     }
                 }

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -1919,6 +1919,29 @@ This is the epilogue.  It is also to be ignored.";
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_hidden_message_id() {
+    let t = &TestContext::new().await;
+    let raw = br#"Message-ID: bar@example.org
+Date: Sun, 08 Dec 2019 23:12:55 +0000
+To: <alice@example.org>
+From: <tunis4@example.org>
+Content-Type: multipart/mixed; boundary="luTiGu6GBoVLCvTkzVtmZmwsmhkNMw"
+
+
+--luTiGu6GBoVLCvTkzVtmZmwsmhkNMw
+Message-ID: foo@example.org
+Content-Type: text/plain; charset=utf-8
+
+Message with a correct Message-ID hidden header
+
+--luTiGu6GBoVLCvTkzVtmZmwsmhkNMw--
+"#;
+
+    let message = MimeMessage::from_bytes(t, &raw[..], None).await.unwrap();
+    assert_eq!(message.get_rfc724_mid().unwrap(), "foo@example.org");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chat_edit_imf_header() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;


### PR DESCRIPTION
Delta Chat already adds hidden Message-ID header because some servers mess up with it, so it should be preferred.