### PR TITLE
fix: Fix setting up a profile and immediately transferring to a second device

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Union
 from warnings import warn
 
@@ -44,16 +42,8 @@ class Account:
         self._rpc.remove_account(self.id)
 
     def clone(self) -> "Account":
-        """Clone given account."""
-        with TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            self.export_backup(tmp_path)
-            files = list(tmp_path.glob("*.tar"))
-            new_account = self.manager.add_account()
-            new_account.import_backup(files[0])
-            return new_account
-
-    def clone_via_add_second_device(self) -> "Account":
+        """Clone given account.
+        This uses backup-transfer via iroh, i.e. the 'Add second device' feature."""
         future = self._rpc.provide_backup.future(self.id)
         qr = self._rpc.get_backup_qr(self.id)
         new_account = self.manager.add_account()

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -28,10 +28,10 @@ class Account:
     def _rpc(self) -> "Rpc":
         return self.manager.rpc
 
-    def wait_for_event(self, event_type=None, timeout=None) -> AttrDict:
+    def wait_for_event(self, event_type=None) -> AttrDict:
         """Wait until the next event and return it."""
         while True:
-            next_event = AttrDict(self._rpc.wait_for_event(self.id, timeout))
+            next_event = AttrDict(self._rpc.wait_for_event(self.id))
             if event_type is None or next_event.kind == event_type:
                 return next_event
 

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -135,13 +135,6 @@ class Account:
             obj = obj.get_snapshot().address
         return Contact(self, self._rpc.create_contact(self.id, obj, name))
 
-    def get_self_chat(self) -> Chat:
-        """Get the 'Saved Messages' chat"""
-        return Chat(
-            self,
-            self._rpc.create_chat_by_contact_id(self.id, SpecialContactId.SELF),
-        )
-
     def make_vcard(self, contacts: list[Contact]) -> str:
         """Create vCard with the given contacts."""
         assert all(contact.account == self for contact in contacts)

--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -134,7 +134,6 @@ def data():
     class Data:
         def __init__(self) -> None:
             for path in reversed(py.path.local(__file__).parts()):
-                print(path)
                 datadir = path.join("test-data")
                 if datadir.isdir():
                     self.path = datadir

--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -124,3 +124,59 @@ def rpc(tmp_path) -> AsyncGenerator:
 @pytest.fixture
 def acfactory(rpc) -> AsyncGenerator:
     return ACFactory(DeltaChat(rpc))
+
+
+@pytest.fixture
+def data(request):
+    """Test data."""
+
+    class Data:
+        def __init__(self) -> None:
+            # trying to find test data heuristically
+            # because we are run from a dev-setup with pytest direct,
+            # through tox, and then maybe also from deltachat-binding
+            # users like "deltabot".
+            self.paths = [
+                os.path.normpath(x)
+                for x in [
+                    os.path.join(os.path.dirname(request.fspath.strpath), "data"),
+                    os.path.join(os.path.dirname(request.fspath.strpath), "..", "..", "test-data"),
+                    os.path.join(os.path.dirname(__file__), "..", "..", "..", "test-data"),
+                ]
+            ]
+
+        def get_path(self, bn):
+            """return path of file or None if it doesn't exist."""
+            for path in self.paths:
+                fn = os.path.join(path, *bn.split("/"))
+                if os.path.exists(fn):
+                    return fn
+            print(f"WARNING: path does not exist: {fn!r}")
+            return None
+
+        def read_path(self, bn, mode="r"):
+            fn = self.get_path(bn)
+            if fn is not None:
+                with open(fn, mode) as f:
+                    return f.read()
+            return None
+
+    return Data()
+
+
+@pytest.fixture
+def log():
+    """Log printer fixture."""
+
+    class Printer:
+        def section(self, msg: str) -> None:
+            print()
+            print("=" * 10, msg, "=" * 10)
+
+        def step(self, msg: str) -> None:
+            print("-" * 5, "step " + msg, "-" * 5)
+
+        def indent(self, msg: str) -> None:
+            print("  " + msg)
+
+    return Printer()

--- a/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
@@ -177,10 +177,10 @@ class Rpc:
             # Log an exception if the event loop dies.
             logging.exception("Exception in the event loop")
 
-    def wait_for_event(self, account_id: int) -> Optional[dict]:
+    def wait_for_event(self, account_id: int, timeout=None) -> Optional[dict]:
         """Waits for the next event from the given account and returns it."""
         queue = self.get_queue(account_id)
-        return queue.get()
+        return queue.get(timeout=timeout)
 
     def clear_all_events(self, account_id: int):
         """Removes all queued-up events for a given account. Useful for tests."""

--- a/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
@@ -177,10 +177,10 @@ class Rpc:
             # Log an exception if the event loop dies.
             logging.exception("Exception in the event loop")
 
-    def wait_for_event(self, account_id: int, timeout=None) -> Optional[dict]:
+    def wait_for_event(self, account_id: int) -> Optional[dict]:
         """Waits for the next event from the given account and returns it."""
         queue = self.get_queue(account_id)
-        return queue.get(timeout=timeout)
+        return queue.get()
 
     def clear_all_events(self, account_id: int):
         """Removes all queued-up events for a given account. Useful for tests."""

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -301,10 +301,12 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
     assert "Account transferred" in snapshot.text
 
-    image = data.get_path("d.png")
+    image = data.get_path("image/avatar1000x1000.jpg")
     alice.set_config("selfavatar", image)
+    print(alice.get_config("selfavatar"))
 
     alice2.wait_for_event(EventType.SELFAVATAR_CHANGED)
+    print(alice2.get_config("selfavatar"))
 
     log.section("Sending text from the second device")
     alice2.get_self_chat().send_text("Hello!")

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -291,7 +291,7 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     alice = acfactory.get_online_account()
 
     log.section("Alice adds a second device")
-    alice2 = alice.clone_via_add_second_device()
+    alice2 = alice.clone()
 
     log.section("Second device goes online")
     alice2.start_io()

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -296,10 +296,6 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     log.section("Second device goes online")
     alice2.start_io()
 
-    event = alice.wait_for_msgs_changed_event()
-    snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
-    assert "Account transferred" in snapshot.text
-
     log.section("First device changes avatar")
     image = data.get_path("image/avatar1000x1000.jpg")
     alice.set_config("selfavatar", image)

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -296,24 +296,24 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     log.section("Second device goes online")
     alice2.start_io()
 
-    log.section("First device waits for the text")
-    event = alice.wait_for_event(EventType.MSGS_CHANGED)
+    event = alice.wait_for_msgs_changed_event()
     snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
     assert "Account transferred" in snapshot.text
 
+    log.section("First device changes avatar")
     image = data.get_path("image/avatar1000x1000.jpg")
     alice.set_config("selfavatar", image)
-    print(alice.get_config("selfavatar"))
+    avatar_config = alice.get_config("selfavatar")
+    avatar_hash = os.path.basename(avatar_config)
+    print("Info: avatar hash is ", avatar_hash)
 
+    log.section("First device receives avatar change")
     alice2.wait_for_event(EventType.SELFAVATAR_CHANGED)
-    print(alice2.get_config("selfavatar"))
-
-    log.section("Sending text from the second device")
-    alice2.get_self_chat().send_text("Hello!")
-
-    event = alice.wait_for_event(EventType.MSGS_CHANGED)
-    snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
-    assert snapshot.text == "Hello!"
+    avatar_config2 = alice2.get_config("selfavatar")
+    avatar_hash2 = os.path.basename(avatar_config2)
+    print("Info: avatar hash on second device is ", avatar_hash2)
+    assert avatar_hash == avatar_hash2
+    assert avatar_config != avatar_config2
 
 
 def test_reaction_seen_on_another_dev(acfactory) -> None:

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -297,7 +297,7 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     alice2.start_io()
 
     log.section("First device waits for the text")
-    event = alice.wait_for_event(EventType.MSGS_CHANGED, timeout=2)
+    event = alice.wait_for_event(EventType.MSGS_CHANGED)
     snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
     assert "Account transferred" in snapshot.text
 
@@ -309,7 +309,7 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     log.section("Sending text from the second device")
     alice2.get_self_chat().send_text("Hello!")
 
-    event = alice.wait_for_event(EventType.MSGS_CHANGED, timeout=2)
+    event = alice.wait_for_event(EventType.MSGS_CHANGED)
     snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
     assert snapshot.text == "Hello!"
 

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -45,7 +45,7 @@ use crate::message::Message;
 use crate::qr::Qr;
 use crate::stock_str::backup_transfer_msg_body;
 use crate::tools::{create_id, time, TempPathGuard};
-use crate::EventType;
+use crate::{e2ee, EventType};
 
 use super::{export_backup_stream, export_database, import_backup_stream, DBFILE_BACKUP_NAME};
 
@@ -108,6 +108,11 @@ impl BackupProvider {
             .get_blobdir()
             .parent()
             .context("Context dir not found")?;
+
+        // before we export, make sure the private key exists
+        e2ee::ensure_secret_key_exists(context)
+            .await
+            .context("Cannot create private key or private key not available")?;
 
         let dbfile = context_dir.join(DBFILE_BACKUP_NAME);
         if fs::metadata(&dbfile).await.is_ok() {


### PR DESCRIPTION
Found and fixed a bug while investigating https://github.com/chatmail/core/issues/6656. It's not the same bug, though.

Steps to reproduce this bug:
- Create a new profile
- Transfer it to a second device
- Send a message from the first device
- -> It will never arrive on the second device, instead a warning will be printed that you are using DC on multiple devices.

The bug was that the key wasn't created before the backup transfer, so that the second device then created its own key instead of using the same key as the first device.

In order to regression-test, this PR now changes `clone()` to use "Add second device" instead of exporting and importing a backup. Exporting and importing a backup has enough tests already.

This PR also adds an unrelated test `test_selfavatar_sync()`.

The bug was introduced by https://github.com/chatmail/core/pull/6574 in v1.156.0