### PR TITLE
[WIP] test: Add a test for selfavatar-sync

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -301,10 +301,12 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
     assert "Account transferred" in snapshot.text
 
-    image = data.get_path("d.png")
+    image = data.get_path("image/avatar1000x1000.jpg")
     alice.set_config("selfavatar", image)
+    print(alice.get_config("selfavatar"))
 
     alice2.wait_for_event(EventType.SELFAVATAR_CHANGED)
+    print(alice2.get_config("selfavatar"))
 
     log.section("Sending text from the second device")
     alice2.get_self_chat().send_text("Hello!")


### PR DESCRIPTION
The test now reproduces https://github.com/chatmail/core/issues/6656, and takes 2 minutes to complete (it could easily be made into a failing test by adding a timeout). (the test I added in https://github.com/chatmail/core/pull/6657 tries to use an image `d.png` which doesn't actually exist).

I have no idea how to fix it. I did find out that the bug doesn't appear with gmx.de, but it does appear with nine.testrun.org and testrun.org.

cc @link2xt 