### PR TITLE
fix: Remove unsigned Chat-* headers from Autocrypt-encrypted messages

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -422,23 +422,7 @@ impl MimeMessage {
                 // Remove unsigned opportunistically protected headers from messages considered
                 // Autocrypt-encrypted / displayed with padlock.
                 // For "Subject" see <https://github.com/deltachat/deltachat-core-rust/issues/1790>.
-                for h in [
-                    HeaderDef::Subject,
-                    HeaderDef::ChatGroupId,
-                    HeaderDef::ChatGroupName,
-                    HeaderDef::ChatGroupNameChanged,
-                    HeaderDef::ChatGroupNameTimestamp,
-                    HeaderDef::ChatGroupAvatar,
-                    HeaderDef::ChatGroupMemberRemoved,
-                    HeaderDef::ChatGroupMemberAdded,
-                    HeaderDef::ChatGroupMemberTimestamps,
-                    HeaderDef::ChatGroupPastMembers,
-                    HeaderDef::ChatDelete,
-                    HeaderDef::ChatEdit,
-                    HeaderDef::ChatUserAvatar,
-                ] {
-                    headers.remove(h.get_headername());
-                }
+                headers.retain(|k, _| !(k.starts_with("chat-") || k == "subject"));
             }
 
             // let known protected headers from the decrypted

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -1419,6 +1419,25 @@ async fn test_x_microsoft_original_message_id_precedence() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_extra_imf_chat_header() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let t = &tcm.alice().await;
+    let chat_id = t.get_self_chat().await.id;
+
+    chat::send_text_msg(t, chat_id, "hi!".to_string()).await?;
+    let sent_msg = t.pop_sent_msg().await;
+    let payload = sent_msg
+        .payload
+        .replace("Message-ID:", "Chat-Forty-Two: 42\r\nMessage-ID:");
+    let msg = MimeMessage::from_bytes(t, payload.as_bytes(), None)
+        .await
+        .unwrap();
+    assert!(msg.headers.contains_key("chat-version"));
+    assert!(!msg.headers.contains_key("chat-forty-two"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_long_in_reply_to() -> Result<()> {
     let t = TestContext::new_alice().await;
 


### PR DESCRIPTION
This fixes e.g. a case when the server injects a "Chat-Version" IMF header tricking Delta Chat into thinking that it's a chat message. The test checks this for some nonexistent "Chat-*" header to protect the code from future breakages.