### PR TITLE
feat(jsonrpc): add `copy_to_blobdir` api

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::Arc;
 use std::time::Duration;
@@ -7,6 +7,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 pub use deltachat::accounts::Accounts;
+use deltachat::blob::BlobObject;
 use deltachat::chat::{
     self, add_contact_to_chat, forward_msgs, get_chat_media, get_chat_msgs, get_chat_msgs_ex,
     marknoticed_chat, remove_contact_from_chat, Chat, ChatId, ChatItem, MessageListOptions,
@@ -344,6 +345,18 @@ impl CommandApi {
     async fn get_blob_dir(&self, account_id: u32) -> Result<Option<String>> {
         let ctx = self.get_context(account_id).await?;
         Ok(ctx.get_blobdir().to_str().map(|s| s.to_owned()))
+    }
+
+    async fn copy_to_blobdir(&self, account_id: u32, path: String) -> Result<PathBuf> {
+        let ctx = self.get_context(account_id).await?;
+        let file = Path::new(&path);
+        let name = BlobObject::create_and_deduplicate(&ctx, file, file)?
+            .as_name()
+            .to_string();
+        ctx.get_blobdir()
+            .join(name)
+            .canonicalize()
+            .map_err(anyhow::Error::from)
     }
 
     async fn draft_self_report(&self, account_id: u32) -> Result<u32> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub(crate) mod events;
 pub use events::*;
 
 mod aheader;
-mod blob;
+pub mod blob;
 pub mod chat;
 pub mod chatlist;
 pub mod config;


### PR DESCRIPTION
Add a new API to jsonrpc to copy a file over to blobdir. This enables desktop tauri to not give global file permission.