### PR TITLE
refactor: Extract handle_edit_delete() function for message edit/delete 

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1766,6 +1766,10 @@ RETURNING id
     })
 }
 
+/// Checks for "Chat-Edit" and "Chat-Delete" headers,
+/// and edits/deletes existing messages accordingly.
+///
+/// Returns `true` if this message is an edit/deletion request.
 async fn handle_edit_delete(
     context: &Context,
     mime_parser: &MimeMessage,


### PR DESCRIPTION
Follow-up to https://github.com/chatmail/core/pull/6576