### PR TITLE
fix: Don't SMTP-send self-only messages if DeleteServerAfter is "immediate" (#6661)

### DIFF
--- a/deltachat-rpc-client/tests/test_key_transfer.py
+++ b/deltachat-rpc-client/tests/test_key_transfer.py
@@ -21,6 +21,7 @@ def test_autocrypt_setup_message_key_transfer(acfactory):
     alice2.set_config("addr", alice1.get_config("addr"))
     alice2.set_config("mail_pw", alice1.get_config("mail_pw"))
     alice2.configure()
+    alice2.bring_online()
 
     setup_code = alice1.initiate_autocrypt_key_transfer()
     msg = wait_for_autocrypt_setup_message(alice2)
@@ -34,10 +35,12 @@ def test_autocrypt_setup_message_key_transfer(acfactory):
 
 def test_ac_setup_message_twice(acfactory):
     alice1 = acfactory.get_online_account()
+
     alice2 = acfactory.get_unconfigured_account()
     alice2.set_config("addr", alice1.get_config("addr"))
     alice2.set_config("mail_pw", alice1.get_config("mail_pw"))
     alice2.configure()
+    alice2.bring_online()
 
     # Send the first Autocrypt Setup Message and ignore it.
     _setup_code = alice1.initiate_autocrypt_key_transfer()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3029,10 +3029,10 @@ pub(crate) async fn create_send_msg_jobs(context: &Context, msg: &mut Message) -
     // disabled by default is fine.
     //
     // `from` must be the last addr, see `receive_imf_inner()` why.
-    if context.get_config_bool(Config::BccSelf).await?
-        && !recipients
-            .iter()
-            .any(|x| x.to_lowercase() == lowercase_from)
+    recipients.retain(|x| x.to_lowercase() != lowercase_from);
+    if (context.get_config_bool(Config::BccSelf).await?
+        || msg.param.get_cmd() == SystemMessage::AutocryptSetupMessage)
+        && (context.get_config_delete_server_after().await? != Some(0) || !recipients.is_empty())
     {
         recipients.push(from);
     }

--- a/src/imex/key_transfer.rs
+++ b/src/imex/key_transfer.rs
@@ -46,11 +46,11 @@ pub async fn initiate_key_transfer(context: &Context) -> Result<String> {
     msg.force_plaintext();
     msg.param.set_int(Param::SkipAutocrypt, 1);
 
-    chat::send_msg(context, chat_id, &mut msg).await?;
-
     // Enable BCC-self, because transferring a key
     // means we have a multi-device setup.
     context.set_config_bool(Config::BccSelf, true).await?;
+
+    chat::send_msg(context, chat_id, &mut msg).await?;
     Ok(setup_code)
 }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -184,9 +184,6 @@ impl MimeFactory {
         let mut req_mdn = false;
 
         if chat.is_self_talk() {
-            if msg.param.get_cmd() == SystemMessage::AutocryptSetupMessage {
-                recipients.push(from_addr.to_string());
-            }
             to.push((from_displayname.to_string(), from_addr.to_string()));
         } else if chat.is_mailing_list() {
             let list_post = chat

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -2218,6 +2218,17 @@ async fn test_no_smtp_job_for_self_chat() -> Result<()> {
     let mut msg = Message::new_text("Happy birthday to me".to_string());
     chat::send_msg(bob, chat_id, &mut msg).await?;
     assert!(bob.pop_sent_msg_opt(Duration::ZERO).await.is_none());
+
+    bob.set_config_bool(Config::BccSelf, true).await?;
+    bob.set_config(Config::DeleteServerAfter, Some("1")).await?;
+    let mut msg = Message::new_text("Happy birthday to me".to_string());
+    chat::send_msg(bob, chat_id, &mut msg).await?;
+    assert!(bob.pop_sent_msg_opt(Duration::ZERO).await.is_none());
+
+    bob.set_config(Config::DeleteServerAfter, None).await?;
+    let mut msg = Message::new_text("Happy birthday to me".to_string());
+    chat::send_msg(bob, chat_id, &mut msg).await?;
+    assert!(bob.pop_sent_msg_opt(Duration::ZERO).await.is_some());
     Ok(())
 }
 


### PR DESCRIPTION
Fix #6661 