### PR TITLE
Generate `rfc724_mid` when creating `Message`

### DIFF
--- a/src/message/message_tests.rs
+++ b/src/message/message_tests.rs
@@ -147,8 +147,6 @@ async fn test_quote() {
 
     let mut msg = Message::new_text("Quoted message".to_string());
 
-    // Send message, so it gets a Message-Id.
-    assert!(msg.rfc724_mid.is_empty());
     let msg_id = chat::send_msg(ctx, chat.id, &mut msg).await.unwrap();
     let msg = Message::load_from_db(ctx, msg_id).await.unwrap();
     assert!(!msg.rfc724_mid.is_empty());
@@ -358,6 +356,7 @@ async fn test_markseen_msgs() -> Result<()> {
     let sent1 = alice.send_msg(alice_chat.id, &mut msg).await;
     let msg1 = bob.recv_msg(&sent1).await;
     let bob_chat_id = msg1.chat_id;
+    let mut msg = Message::new_text("this is the text!".to_string());
     let sent2 = alice.send_msg(alice_chat.id, &mut msg).await;
     let msg2 = bob.recv_msg(&sent2).await;
     assert_eq!(msg1.chat_id, msg2.chat_id);
@@ -380,9 +379,11 @@ async fn test_markseen_msgs() -> Result<()> {
 
     // bob sends to alice,
     // alice knows bob and messages appear in normal chat
+    let mut msg = Message::new_text("this is the text!".to_string());
     let msg1 = alice
         .recv_msg(&bob.send_msg(bob_chat_id, &mut msg).await)
         .await;
+    let mut msg = Message::new_text("this is the text!".to_string());
     let msg2 = alice
         .recv_msg(&bob.send_msg(bob_chat_id, &mut msg).await)
         .await;

--- a/src/mimefactory/mimefactory_tests.rs
+++ b/src/mimefactory/mimefactory_tests.rs
@@ -727,6 +727,7 @@ async fn test_selfavatar_unencrypted_signed() {
         .is_some());
 
     // if another message is sent, that one must not contain the avatar
+    let mut msg = Message::new_text("this is the text!".to_string());
     let sent_msg = t.send_msg(chat.id, &mut msg).await;
     let mut payload = sent_msg.payload().splitn(4, "\r\n\r\n");
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3216,6 +3216,7 @@ async fn get_parent_message(
     if let Some(field) = references {
         mids.append(&mut parse_message_ids(field));
     }
+    info!(context, "mids: {mids:?}");
     message::get_by_rfc724_mids(context, &mids).await
 }
 

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -5139,7 +5139,7 @@ async fn test_references() -> Result<()> {
     alice.set_config_bool(Config::BccSelf, true).await?;
 
     let alice_chat_id = create_group_chat(alice, ProtectionStatus::Unprotected, "Group").await?;
-    let _sent = alice
+    alice
         .send_text(alice_chat_id, "Hi! I created a group.")
         .await;
 


### PR DESCRIPTION
Set rfc724_mid in `Message::new()` and `Message::new_text` instead of while sending the message. This way the rfc724 mid can be read in the draft stage. Tests had to be adjusted to create multiple messages to get unique mid, otherwise core would not send the messages out.

close #6621