### PR TITLE
[WIP] fix: Create DeltaChat folder if `mvbox_move` is enabled before configure

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -588,8 +588,8 @@ def test_reactions_for_a_reordering_move(acfactory, direct_imap):
     """
     (ac1,) = acfactory.get_online_accounts(1)
     ac2 = acfactory.new_preconfigured_account()
-    ac2.configure()
     ac2.set_config("mvbox_move", "1")
+    ac2.configure()
     ac2.bring_online()
     chat1 = acfactory.get_accepted_chat(ac1, ac2)
     ac2.stop_io()

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -520,7 +520,7 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Configure
         ctx.set_config(Config::ShowEmails, None).await?;
     }
 
-    let create_mvbox = !is_chatmail;
+    let create_mvbox = !is_chatmail || ctx.get_config_bool(Config::MvboxMove).await?;
     imap.configure_folders(ctx, &mut imap_session, create_mvbox)
         .await?;
 


### PR DESCRIPTION
Fix https://github.com/chatmail/core/issues/6688