### PR TITLE
feat: understandable error message when accounts.lock can't be locked

### DIFF
--- a/deltachat-rpc-server/src/main.rs
+++ b/deltachat-rpc-server/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     // thread, and it is impossible to cancel that read. This can make shutdown of the runtime hang
     // until the user presses enter."
     if let Err(error) = &r {
-        log::error!("Fatal error: {error:#}.")
+        log::error!("Error: {error:#}.")
     }
     std::process::exit(if r.is_ok() { 0 } else { 1 });
 }


### PR DESCRIPTION
Targets https://github.com/chatmail/core/issues/6636

Right now the error message is:

> Error: Delta Chat is already running. To use Delta Chat, you must first close the existing Delta Chat process, or restart your device.
> 
> (accounts.lock lock file is already locked)

other suggestions welcome!