### PR TITLE
feat: get contact-id for info messages

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4483,12 +4483,21 @@ int             dc_msg_is_info                (const dc_msg_t* msg);
  * UIs can display e.g. an icon based upon the type.
  *
  * Currently, the following types are defined:
+ * - DC_INFO_GROUP_NAME_CHANGED (2) - "Group name changd from OLD to BY by CONTACT"
+ * - DC_INFO_GROUP_IMAGE_CHANGED (3) - "Group image changd by CONTACT"
+ * - DC_INFO_MEMBER_ADDED_TO_GROUP (4) - "Member CONTACT added by OTHER_CONTACT"
+ * - DC_INFO_MEMBER_REMOVED_FROM_GROUP (5) - "Member CONTACT removed by OTHER_CONTACT"
+ * - DC_INFO_EPHEMERAL_TIMER_CHANGED (10) - "Disappearing messages CHANGED_TO by CONTACT"
  * - DC_INFO_PROTECTION_ENABLED (11) - Info-message for "Chat is now protected"
  * - DC_INFO_PROTECTION_DISABLED (12) - Info-message for "Chat is no longer protected"
  * - DC_INFO_INVALID_UNENCRYPTED_MAIL (13) - Info-message for "Provider requires end-to-end encryption which is not setup yet",
  *   the UI should change the corresponding string using #DC_STR_INVALID_UNENCRYPTED_MAIL
  *   and also offer a way to fix the encryption, eg. by a button offering a QR scan
  * - DC_INFO_WEBXDC_INFO_MESSAGE (32) - Info-message created by webxdc app sending `update.info`
+ *
+ * For the messages that refer to a CONTACT,
+ * dc_msg_get_info_contact_id() returns the contact ID.
+ * The UI should open the contact's profile when tapping the info message.
  *
  * Even when you display an icon,
  * you should still display the text of the informational message using dc_msg_get_text()
@@ -4500,6 +4509,19 @@ int             dc_msg_is_info                (const dc_msg_t* msg);
  *     or that the message is not an info-message.
  */
 int             dc_msg_get_info_type          (const dc_msg_t* msg);
+
+
+/**
+ * Return the contact ID of the profile to open when tapping the info message.
+ *
+ * No need to check additionally for dc_msg_get_info_type(),
+ * unless you e.g. want to show the info message in another style.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return The contact ID that the info message refers to, if any. Otherwise 0.
+ */
+uint_32_t       dc_msg_get_info_contact_id    (const dc_msg_t* msg);
 
 
 // DC_INFO* uses the same values as SystemMessage in rust-land

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3731,6 +3731,20 @@ pub unsafe extern "C" fn dc_msg_get_info_type(msg: *mut dc_msg_t) -> libc::c_int
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_info_contact_id(msg: *mut dc_msg_t) -> libc::c_int {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_info_contact_id()");
+        return 0;
+    }
+    let ffi_msg = &*msg;
+    ffi_msg
+        .message
+        .get_info_contact_id()
+        .map(|id| id.to_u32())
+        .unwrap_or_default()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_msg_get_webxdc_href(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_webxdc_href()");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -582,7 +582,7 @@ impl ChatId {
             ProtectionStatus::Unprotected => SystemMessage::ChatProtectionDisabled,
             ProtectionStatus::ProtectionBroken => SystemMessage::ChatProtectionDisabled,
         };
-        add_info_msg_with_cmd(context, self, &text, cmd, timestamp_sort, None, None, None).await?;
+        add_info_msg_with_cmd(context, self, &text, cmd, timestamp_sort, None, None, None, None).await?;
 
         Ok(())
     }
@@ -1789,6 +1789,7 @@ impl Chat {
             // never sorted below the protection message if the SecureJoin finishes in parallel.
             ts_sort,
             Some(now),
+            None,
             None,
             None,
         )
@@ -3941,6 +3942,8 @@ pub(crate) async fn add_contact_to_chat_ex(
         msg.param.set_cmd(SystemMessage::MemberAddedToGroup);
         msg.param.set(Param::Arg, contact_addr);
         msg.param.set_int(Param::Arg2, from_handshake.into());
+        msg.param
+            .set_int(Param::ContactAddedRemoved, contact.id.to_u32() as i32);
         send_msg(context, chat_id, &mut msg).await?;
 
         sync = Nosync;
@@ -4736,13 +4739,17 @@ pub(crate) async fn add_info_msg_with_cmd(
     timestamp_sent_rcvd: Option<i64>,
     parent: Option<&Message>,
     from_id: Option<ContactId>,
+    added_removed_id: Option<ContactId>,
 ) -> Result<MsgId> {
     let rfc724_mid = create_outgoing_rfc724_mid();
     let ephemeral_timer = chat_id.get_ephemeral_timer(context).await?;
 
     let mut param = Params::new();
     if cmd != SystemMessage::Unknown {
-        param.set_cmd(cmd)
+        param.set_cmd(cmd);
+    }
+    if let Some(contact_id) = added_removed_id {
+        param.set_int(Param::ContactAddedRemoved, contact_id.to_u32() as i32);
     }
 
     let row_id =
@@ -4787,6 +4794,7 @@ pub(crate) async fn add_info_msg(
         text,
         SystemMessage::Unknown,
         timestamp,
+        None,
         None,
         None,
         None,

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -330,26 +330,22 @@ async fn test_member_add_remove() -> Result<()> {
     // Alice adds Bob to the chat.
     add_contact_to_chat(&alice, alice_chat_id, alice_bob_contact_id).await?;
     let sent = alice.pop_sent_msg().await;
-    assert!(sent
-        .payload
-        .contains("I added member Bob (bob@example.net)."));
+    assert!(sent.payload.contains("I added member Bob."));
     // Locally set name "robert" should not leak.
     assert!(!sent.payload.contains("robert"));
     assert_eq!(
         sent.load_from_db().await.get_text(),
-        "You added member robert (bob@example.net)."
+        "You added member robert."
     );
 
     // Alice removes Bob from the chat.
     remove_contact_from_chat(&alice, alice_chat_id, alice_bob_contact_id).await?;
     let sent = alice.pop_sent_msg().await;
-    assert!(sent
-        .payload
-        .contains("I removed member Bob (bob@example.net)."));
+    assert!(sent.payload.contains("I removed member Bob."));
     assert!(!sent.payload.contains("robert"));
     assert_eq!(
         sent.load_from_db().await.get_text(),
-        "You removed member robert (bob@example.net)."
+        "You removed member robert."
     );
 
     // Alice leaves the chat.
@@ -416,7 +412,7 @@ async fn test_parallel_member_remove() -> Result<()> {
     // Test that remove message is rewritten.
     assert_eq!(
         bob_received_remove_msg.get_text(),
-        "Member Me (bob@example.net) removed by alice@example.org."
+        "Member Me removed by alice@example.org."
     );
 
     Ok(())

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::chatlist::get_archived_cnt;
 use crate::constants::{DC_GCL_ARCHIVED_ONLY, DC_GCL_NO_SPECIALS};
+use crate::ephemeral::Timer;
 use crate::headerdef::HeaderDef;
 use crate::imex::{has_backup, imex, ImexMode};
 use crate::message::{delete_msgs, MessengerMessage};
@@ -520,6 +521,8 @@ async fn test_modify_chat_multi_device() -> Result<()> {
     assert!(a2_msg.is_system_message());
     assert_eq!(a1_msg.get_info_type(), SystemMessage::GroupNameChanged);
     assert_eq!(a2_msg.get_info_type(), SystemMessage::GroupNameChanged);
+    assert_eq!(a1_msg.get_info_contact_id()?, Some(ContactId::SELF));
+    assert_eq!(a2_msg.get_info_contact_id()?, Some(ContactId::SELF));
     assert_eq!(Chat::load_from_db(&a1, a1_chat_id).await?.name, "bar");
     assert_eq!(Chat::load_from_db(&a2, a2_chat_id).await?.name, "bar");
 
@@ -1530,6 +1533,7 @@ async fn test_add_info_msg_with_cmd() -> Result<()> {
         "foo bar info",
         SystemMessage::EphemeralTimerChanged,
         10000,
+        None,
         None,
         None,
         None,
@@ -3290,6 +3294,114 @@ async fn test_do_not_overwrite_draft() -> Result<()> {
     self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
     let draft2 = self_chat.get_draft(&alice).await?.unwrap();
     assert_eq!(draft1.timestamp_sort, draft2.timestamp_sort);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_info_contact_id() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let alice2 = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    async fn pop_recv_and_check(
+        alice: &TestContext,
+        alice2: &TestContext,
+        bob: &TestContext,
+        expected_type: SystemMessage,
+        expected_alice_id: ContactId,
+        expected_bob_id: ContactId,
+    ) -> Result<()> {
+        let sent_msg = alice.pop_sent_msg().await;
+        let msg = Message::load_from_db(alice, sent_msg.sender_msg_id).await?;
+        assert_eq!(msg.get_info_type(), expected_type);
+        assert_eq!(msg.get_info_contact_id()?, Some(expected_alice_id));
+
+        let msg = alice2.recv_msg(&sent_msg).await;
+        assert_eq!(msg.get_info_type(), expected_type);
+        //assert_eq!(msg.get_info_contact_id()?, Some(expected_alice_id));
+
+        let msg = bob.recv_msg(&sent_msg).await;
+        assert_eq!(msg.get_info_type(), expected_type);
+        //assert_eq!(msg.get_info_contact_id()?, Some(expected_bob_id));
+
+        Ok(())
+    }
+
+    // Alice creates group, Bob receives group
+    let alice_chat_id = create_group_chat(alice, ProtectionStatus::Unprotected, "play").await?;
+    let alice_bob_id = Contact::create(alice, "Bob", "bob@example.net").await?;
+    add_contact_to_chat(alice, alice_chat_id, alice_bob_id).await?;
+    let sent_msg1 = alice.send_text(alice_chat_id, "moin").await;
+
+    let msg = bob.recv_msg(&sent_msg1).await;
+    let bob_alice_id = msg.from_id;
+    assert!(!bob_alice_id.is_special());
+
+    // Alice does group changes, Bob receives them
+    set_chat_name(&alice, alice_chat_id, "games").await?;
+    pop_recv_and_check(
+        alice,
+        alice2,
+        bob,
+        SystemMessage::GroupNameChanged,
+        ContactId::SELF,
+        bob_alice_id,
+    )
+    .await?;
+
+    let file = alice.dir.path().join("avatar.png");
+    let bytes = include_bytes!("../../test-data/image/avatar64x64.png");
+    tokio::fs::write(&file, bytes).await?;
+    set_chat_profile_image(&alice, alice_chat_id, file.to_str().unwrap()).await?;
+    pop_recv_and_check(
+        alice,
+        alice2,
+        bob,
+        SystemMessage::GroupImageChanged,
+        ContactId::SELF,
+        bob_alice_id,
+    )
+    .await?;
+
+    alice_chat_id
+        .set_ephemeral_timer(alice, Timer::Enabled { duration: 60 })
+        .await?;
+    pop_recv_and_check(
+        alice,
+        alice2,
+        bob,
+        SystemMessage::EphemeralTimerChanged,
+        ContactId::SELF,
+        bob_alice_id,
+    )
+    .await?;
+
+    let fiona_id = Contact::create(alice, "Fiona", "fiona@example.net").await?; // atm, as contexts are in sync, fiona_id is same everywhere
+    add_contact_to_chat(alice, alice_chat_id, fiona_id).await?;
+    pop_recv_and_check(
+        alice,
+        alice2,
+        bob,
+        SystemMessage::MemberAddedToGroup,
+        fiona_id,
+        fiona_id,
+    )
+    .await?;
+
+    /* XXX
+    remove_contact_from_chat(alice, alice_chat_id, fiona_id).await?;
+    pop_recv_and_check(
+        alice,
+        alice2,
+        bob,
+        SystemMessage::MemberRemovedFromGroup,
+        fiona_id,
+        fiona_id,
+    )
+    .await?;
+    */
 
     Ok(())
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1392,16 +1392,16 @@ impl Contact {
         &self.addr
     }
 
-    /// Get a summary of authorized name and address.
+    /// Get authorized name or address.
     ///
     /// The returned string is either "Name (email@domain.com)" or just
     /// "email@domain.com" if the name is unset.
     ///
     /// This string is suitable for sending over email
     /// as it does not leak the locally set name.
-    pub fn get_authname_n_addr(&self) -> String {
+    pub(crate) fn get_authname_or_addr(&self) -> String {
         if !self.authname.is_empty() {
-            format!("{} ({})", self.authname, self.addr)
+            (&self.authname).into()
         } else {
             (&self.addr).into()
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -951,6 +951,44 @@ impl Message {
         self.param.get_cmd()
     }
 
+    /// Return the contact ID of the profile to open when tapping the info message.
+    pub fn get_info_contact_id(&self) -> Result<Option<ContactId>> {
+        match self.param.get_cmd() {
+            SystemMessage::GroupNameChanged
+            | SystemMessage::GroupImageChanged
+            | SystemMessage::EphemeralTimerChanged => {
+                if self.from_id != ContactId::INFO {
+                    Ok(Some(self.from_id))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            SystemMessage::MemberAddedToGroup | SystemMessage::MemberRemovedFromGroup => {
+                if let Some(contact_i32) = self.param.get_int(Param::ContactAddedRemoved) {
+                    Ok(Some(ContactId::new(contact_i32.try_into()?)))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            SystemMessage::AutocryptSetupMessage
+            | SystemMessage::SecurejoinMessage
+            | SystemMessage::LocationStreamingEnabled
+            | SystemMessage::LocationOnly
+            | SystemMessage::ChatProtectionEnabled
+            | SystemMessage::ChatProtectionDisabled
+            | SystemMessage::InvalidUnencryptedMail
+            | SystemMessage::SecurejoinWait
+            | SystemMessage::SecurejoinWaitTimeout
+            | SystemMessage::MultiDeviceSync
+            | SystemMessage::WebxdcStatusUpdate
+            | SystemMessage::WebxdcInfoMessage
+            | SystemMessage::IrohNodeAddr
+            | SystemMessage::Unknown => Ok(None),
+        }
+    }
+
     /// Returns true if the message is a system message.
     pub fn is_system_message(&self) -> bool {
         let cmd = self.param.get_cmd();

--- a/src/param.rs
+++ b/src/param.rs
@@ -215,6 +215,9 @@ pub enum Param {
 
     /// For messages: Message text was edited.
     IsEdited = b'L',
+
+    /// For info messages: Contact ID in added or removed to a group.
+    ContactAddedRemoved = b'5',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -748,6 +748,7 @@ impl Peerstate {
                 Some(timestamp),
                 None,
                 None,
+                None,
             )
             .await?;
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1451,13 +1451,13 @@ async fn add_parts(
             None => better_msg = Some(m),
             Some(_) => {
                 if !m.is_empty() {
-                    group_changes.extra_msgs.push((m, is_system_message))
+                    group_changes.extra_msgs.push((m, is_system_message, None))
                 }
             }
         }
     }
 
-    for (group_changes_msg, cmd) in group_changes.extra_msgs {
+    for (group_changes_msg, cmd, added_removed_id) in group_changes.extra_msgs {
         chat::add_info_msg_with_cmd(
             context,
             chat_id,
@@ -1467,6 +1467,7 @@ async fn add_parts(
             None,
             None,
             None,
+            added_removed_id,
         )
         .await?;
     }
@@ -2345,7 +2346,7 @@ struct GroupChangesInfo {
     /// If true, the user should not be notified about the group change.
     silent: bool,
     /// A list of additional group changes messages that should be shown in the chat.
-    extra_msgs: Vec<(String, SystemMessage)>,
+    extra_msgs: Vec<(String, SystemMessage, Option<ContactId>)>,
 }
 
 /// Apply group member list, name, avatar and protection status changes from the MIME message.
@@ -2673,7 +2674,7 @@ async fn group_changes_msgs(
     added_ids: &HashSet<ContactId>,
     removed_ids: &HashSet<ContactId>,
     chat_id: ChatId,
-) -> Result<Vec<(String, SystemMessage)>> {
+) -> Result<Vec<(String, SystemMessage, Option<ContactId>)>> {
     let mut group_changes_msgs = Vec::new();
     if !added_ids.is_empty() {
         warn!(
@@ -2694,6 +2695,7 @@ async fn group_changes_msgs(
             stock_str::msg_add_member_local(context, contact.get_addr(), ContactId::UNDEFINED)
                 .await,
             SystemMessage::MemberAddedToGroup,
+            Some(contact.id),
         ));
     }
     for contact_id in removed_ids {
@@ -2702,6 +2704,7 @@ async fn group_changes_msgs(
             stock_str::msg_del_member_local(context, contact.get_addr(), ContactId::UNDEFINED)
                 .await,
             SystemMessage::MemberRemovedFromGroup,
+            Some(contact.id),
         ));
     }
 

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -126,6 +126,7 @@ pub(super) async fn start_protocol(context: &Context, invite: QrInvite) -> Resul
                     Some(ts_start),
                     None,
                     None,
+                    None,
                 )
                 .await?;
                 chat_id.spawn_securejoin_wait(context, constants::SECUREJOIN_WAIT_TIMEOUT);

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -438,6 +438,7 @@ pub(crate) async fn send_msg_to_smtp(
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await?;
                 };

--- a/src/stock_str/stock_str_tests.rs
+++ b/src/stock_str/stock_str_tests.rs
@@ -54,10 +54,7 @@ async fn test_stock_string_repl_str() {
         .unwrap();
     let contact = Contact::get_by_id(&t.ctx, contact_id).await.unwrap();
     // uses %1$s substitution
-    assert_eq!(
-        contact_verified(&t, &contact).await,
-        "Someone (someone@example.org) verified."
-    );
+    assert_eq!(contact_verified(&t, &contact).await, "Someone verified.");
     // We have no string using %1$d to test...
 }
 
@@ -95,7 +92,7 @@ async fn test_stock_system_msg_add_member_by_me_with_displayname() {
     );
     assert_eq!(
         msg_add_member_local(&t, "alice@example.org", ContactId::SELF).await,
-        "You added member Alice (alice@example.org)."
+        "You added member Alice."
     );
 }
 
@@ -112,7 +109,7 @@ async fn test_stock_system_msg_add_member_by_other_with_displayname() {
     };
     assert_eq!(
         msg_add_member_local(&t, "alice@example.org", contact_id,).await,
-        "Member Alice (alice@example.org) added by Bob (bob@example.com)."
+        "Member Alice added by Bob."
     );
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -743,10 +743,7 @@ mod tests {
         let fiona = &tcm.fiona().await;
         tcm.exec_securejoin_qr(fiona, alice2, &qr).await;
         let msg = fiona.get_last_msg().await;
-        assert_eq!(
-            msg.text,
-            "Member Me (fiona@example.net) added by alice@example.org."
-        );
+        assert_eq!(msg.text, "Member Me added by alice@example.org.");
         Ok(())
     }
 }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -388,6 +388,7 @@ impl Context {
                         None,
                         Some(&instance),
                         Some(from_id),
+                        None,
                     )
                     .await?;
                 }

--- a/test-data/golden/receive_imf_delayed_removal_is_ignored
+++ b/test-data/golden/receive_imf_delayed_removal_is_ignored
@@ -2,8 +2,8 @@ Group#Chat#10: Group [5 member(s)]
 --------------------------------------------------------------------------------
 Msg#10: Me (Contact#Contact#Self): populate  √
 Msg#11: info (Contact#Contact#Info): Member blue@example.net added. [NOTICED][INFO]
-Msg#12: info (Contact#Contact#Info): Member fiona (fiona@example.net) removed. [NOTICED][INFO]
-Msg#13: bob (Contact#Contact#11): Member orange@example.net added by bob (bob@example.net). [FRESH][INFO]
-Msg#14: Me (Contact#Contact#Self): You added member fiona (fiona@example.net). [INFO] o
-Msg#15: bob (Contact#Contact#11): Member fiona (fiona@example.net) removed by bob (bob@example.net). [FRESH][INFO]
+Msg#12: info (Contact#Contact#Info): Member fiona removed. [NOTICED][INFO]
+Msg#13: bob (Contact#Contact#11): Member orange@example.net added by bob. [FRESH][INFO]
+Msg#14: Me (Contact#Contact#Self): You added member fiona. [INFO] o
+Msg#15: bob (Contact#Contact#11): Member fiona removed by bob. [FRESH][INFO]
 --------------------------------------------------------------------------------

--- a/test-data/golden/two_group_securejoins
+++ b/test-data/golden/two_group_securejoins
@@ -5,5 +5,5 @@ Msg#11: info (Contact#Contact#Info): alice@example.org invited you to join this 
 Waiting for the device of alice@example.org to reply… [NOTICED][INFO]
 Msg#13: info (Contact#Contact#Info): alice@example.org replied, waiting for being added to the group… [NOTICED][INFO]
 Msg#17: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
-Msg#18🔒:  (Contact#Contact#10): Member Me (fiona@example.net) added by alice@example.org. [FRESH][INFO]
+Msg#18🔒:  (Contact#Contact#10): Member Me added by alice@example.org. [FRESH][INFO]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
instead of showing addresses in info message, provide an API to make them tappable

closes #6702