### PR TITLE
refactor: Move proxy_config out of ConfiguredLoginParam

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -271,12 +271,14 @@ impl Imap {
         let param = ConfiguredLoginParam::load(context)
             .await?
             .context("Not configured")?;
+        let proxy_config = ProxyConfig::load(context).await?;
+        let strict_tls = param.strict_tls(proxy_config.is_some());
         let imap = Self::new(
             param.imap.clone(),
             param.imap_password.clone(),
-            param.proxy_config.clone(),
+            proxy_config,
             &param.addr,
-            param.strict_tls(),
+            strict_tls,
             param.oauth2,
             idle_interrupt_receiver,
         );

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -90,13 +90,14 @@ impl Smtp {
         let lp = ConfiguredLoginParam::load(context)
             .await?
             .context("Not configured")?;
+        let proxy_config = ProxyConfig::load(context).await?;
         self.connect(
             context,
             &lp.smtp,
             &lp.smtp_password,
-            &lp.proxy_config,
+            &proxy_config,
             &lp.addr,
-            lp.strict_tls(),
+            lp.strict_tls(proxy_config.is_some()),
             lp.oauth2,
         )
         .await


### PR DESCRIPTION
We want to store ConfiguredLoginParam in the database as Json per-login, but proxy_config should be global for all logins.

This is a preparation for multi-transport.