### PR TITLE
feat: get contact-id for info messages

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4483,12 +4483,21 @@ int             dc_msg_is_info                (const dc_msg_t* msg);
  * UIs can display e.g. an icon based upon the type.
  *
  * Currently, the following types are defined:
+ * - DC_INFO_GROUP_NAME_CHANGED (2) - "Group name changd from OLD to BY by CONTACT"
+ * - DC_INFO_GROUP_IMAGE_CHANGED (3) - "Group image changd by CONTACT"
+ * - DC_INFO_MEMBER_ADDED_TO_GROUP (4) - "Member CONTACT added by OTHER_CONTACT"
+ * - DC_INFO_MEMBER_REMOVED_FROM_GROUP (5) - "Member CONTACT removed by OTHER_CONTACT"
+ * - DC_INFO_EPHEMERAL_TIMER_CHANGED (10) - "Disappearing messages CHANGED_TO by CONTACT"
  * - DC_INFO_PROTECTION_ENABLED (11) - Info-message for "Chat is now protected"
  * - DC_INFO_PROTECTION_DISABLED (12) - Info-message for "Chat is no longer protected"
  * - DC_INFO_INVALID_UNENCRYPTED_MAIL (13) - Info-message for "Provider requires end-to-end encryption which is not setup yet",
  *   the UI should change the corresponding string using #DC_STR_INVALID_UNENCRYPTED_MAIL
  *   and also offer a way to fix the encryption, eg. by a button offering a QR scan
  * - DC_INFO_WEBXDC_INFO_MESSAGE (32) - Info-message created by webxdc app sending `update.info`
+ *
+ * For the messages that refer to a CONTACT,
+ * dc_msg_get_info_contact_id() returns the contact ID.
+ * The UI should open the contact's profile when tapping the info message.
  *
  * Even when you display an icon,
  * you should still display the text of the informational message using dc_msg_get_text()
@@ -4500,6 +4509,29 @@ int             dc_msg_is_info                (const dc_msg_t* msg);
  *     or that the message is not an info-message.
  */
 int             dc_msg_get_info_type          (const dc_msg_t* msg);
+
+
+/**
+ * Return the contact ID of the profile to open when tapping the info message.
+ *
+ * - For DC_INFO_MEMBER_ADDED_TO_GROUP and DC_INFO_MEMBER_REMOVED_FROM_GROUP,
+ *   this is the contact being added/removed.
+ *   The contact that did the adding/removal is usually only a tap away
+ *   (as introducer and/or atop of the memberlist),
+ *   and usually more known anyways.
+ * - For DC_INFO_GROUP_NAME_CHANGED, DC_INFO_GROUP_IMAGE_CHANGED and DC_INFO_EPHEMERAL_TIMER_CHANGED
+ *   this is the contact who did the change.
+ *
+ * No need to check additionally for dc_msg_get_info_type(),
+ * unless you e.g. want to show the info message in another style.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return If the info message refers to a contact,
+ *     this contact ID or DC_CONTACT_ID_SELF is returned.
+ *     Otherwise 0.
+ */
+uint32_t        dc_msg_get_info_contact_id    (const dc_msg_t* msg);
 
 
 // DC_INFO* uses the same values as SystemMessage in rust-land

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3731,6 +3731,20 @@ pub unsafe extern "C" fn dc_msg_get_info_type(msg: *mut dc_msg_t) -> libc::c_int
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_info_contact_id(msg: *mut dc_msg_t) -> u32 {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_info_contact_id()");
+        return 0;
+    }
+    let ffi_msg = &*msg;
+    let context = &*ffi_msg.context;
+    block_on(ffi_msg.message.get_info_contact_id(context))
+        .unwrap_or_default()
+        .map(|id| id.to_u32())
+        .unwrap_or_default()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_msg_get_webxdc_href(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_webxdc_href()");

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -89,7 +89,7 @@ def test_qr_securejoin(acfactory, protect):
     assert alice_contact_bob_snapshot.is_verified
 
     snapshot = bob.get_message_by_id(bob.wait_for_incoming_msg_event().msg_id).get_snapshot()
-    assert snapshot.text == "Member Me ({}) added by {}.".format(bob.get_config("addr"), alice.get_config("addr"))
+    assert snapshot.text == "Member Me added by {}.".format(alice.get_config("addr"))
     assert snapshot.chat.get_basic_snapshot().is_protected == protect
 
     # Test that Bob verified Alice's profile.
@@ -563,7 +563,7 @@ def test_securejoin_after_contact_resetup(acfactory) -> None:
 
     # ac1 waits for member added message and creates a QR code.
     snapshot = ac1.get_message_by_id(ac1.wait_for_incoming_msg_event().msg_id).get_snapshot()
-    assert snapshot.text == "Member Me ({}) added by {}.".format(ac1.get_config("addr"), ac3.get_config("addr"))
+    assert snapshot.text == "Member Me added by {}.".format(ac3.get_config("addr"))
     ac1_qr_code = snapshot.chat.get_qr_code()
 
     # ac2 verifies ac1
@@ -646,7 +646,7 @@ def test_withdraw_securejoin_qr(acfactory):
     alice.clear_all_events()
 
     snapshot = bob.get_message_by_id(bob.wait_for_incoming_msg_event().msg_id).get_snapshot()
-    assert snapshot.text == "Member Me ({}) added by {}.".format(bob.get_config("addr"), alice.get_config("addr"))
+    assert snapshot.text == "Member Me added by {}.".format(alice.get_config("addr"))
     assert snapshot.chat.get_basic_snapshot().is_protected
     bob_chat.leave()
 

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1346,7 +1346,7 @@ def test_qr_email_capitalization(acfactory, lp):
     lp.sec("ac1 joins a verified group via a QR code")
     ac1_chat = ac1.qr_join_chat(qr)
     msg = ac1._evtracker.wait_next_incoming_message()
-    assert msg.text == "Member Me ({}) added by {}.".format(ac1.get_config("addr"), ac3.get_config("addr"))
+    assert msg.text == "Member Me added by {}.".format(ac3.get_config("addr"))
     assert len(ac1_chat.get_contacts()) == 2
 
     lp.sec("ac2 joins a verified group via a QR code")

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -582,7 +582,18 @@ impl ChatId {
             ProtectionStatus::Unprotected => SystemMessage::ChatProtectionDisabled,
             ProtectionStatus::ProtectionBroken => SystemMessage::ChatProtectionDisabled,
         };
-        add_info_msg_with_cmd(context, self, &text, cmd, timestamp_sort, None, None, None).await?;
+        add_info_msg_with_cmd(
+            context,
+            self,
+            &text,
+            cmd,
+            timestamp_sort,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?;
 
         Ok(())
     }
@@ -1789,6 +1800,7 @@ impl Chat {
             // never sorted below the protection message if the SecureJoin finishes in parallel.
             ts_sort,
             Some(now),
+            None,
             None,
             None,
         )
@@ -3942,6 +3954,8 @@ pub(crate) async fn add_contact_to_chat_ex(
         msg.param.set_cmd(SystemMessage::MemberAddedToGroup);
         msg.param.set(Param::Arg, contact_addr);
         msg.param.set_int(Param::Arg2, from_handshake.into());
+        msg.param
+            .set_int(Param::ContactAddedRemoved, contact.id.to_u32() as i32);
         send_msg(context, chat_id, &mut msg).await?;
 
         sync = Nosync;
@@ -4139,6 +4153,8 @@ pub async fn remove_contact_from_chat(
                     }
                     msg.param.set_cmd(SystemMessage::MemberRemovedFromGroup);
                     msg.param.set(Param::Arg, contact.get_addr().to_lowercase());
+                    msg.param
+                        .set(Param::ContactAddedRemoved, contact.id.to_u32() as i32);
                     let res = send_msg(context, chat_id, &mut msg).await;
                     if contact_id == ContactId::SELF {
                         res?;
@@ -4737,13 +4753,17 @@ pub(crate) async fn add_info_msg_with_cmd(
     timestamp_sent_rcvd: Option<i64>,
     parent: Option<&Message>,
     from_id: Option<ContactId>,
+    added_removed_id: Option<ContactId>,
 ) -> Result<MsgId> {
     let rfc724_mid = create_outgoing_rfc724_mid();
     let ephemeral_timer = chat_id.get_ephemeral_timer(context).await?;
 
     let mut param = Params::new();
     if cmd != SystemMessage::Unknown {
-        param.set_cmd(cmd)
+        param.set_cmd(cmd);
+    }
+    if let Some(contact_id) = added_removed_id {
+        param.set_int(Param::ContactAddedRemoved, contact_id.to_u32() as i32);
     }
 
     let row_id =
@@ -4788,6 +4808,7 @@ pub(crate) async fn add_info_msg(
         text,
         SystemMessage::Unknown,
         timestamp,
+        None,
         None,
         None,
         None,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4763,7 +4763,7 @@ pub(crate) async fn add_info_msg_with_cmd(
         param.set_cmd(cmd);
     }
     if let Some(contact_id) = added_removed_id {
-        param.set_int(Param::ContactAddedRemoved, contact_id.to_u32() as i32);
+        param.set(Param::ContactAddedRemoved, contact_id.to_u32().to_string());
     }
 
     let row_id =

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3391,7 +3391,7 @@ async fn test_info_contact_id() -> Result<()> {
     assert!(!bob_alice_id.is_special());
 
     // Alice does group changes, Bob receives them
-    set_chat_name(&alice, alice_chat_id, "games").await?;
+    set_chat_name(alice, alice_chat_id, "games").await?;
     pop_recv_and_check(
         alice,
         alice2,
@@ -3405,7 +3405,7 @@ async fn test_info_contact_id() -> Result<()> {
     let file = alice.dir.path().join("avatar.png");
     let bytes = include_bytes!("../../test-data/image/avatar64x64.png");
     tokio::fs::write(&file, bytes).await?;
-    set_chat_profile_image(&alice, alice_chat_id, file.to_str().unwrap()).await?;
+    set_chat_profile_image(alice, alice_chat_id, file.to_str().unwrap()).await?;
     pop_recv_and_check(
         alice,
         alice2,

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3402,7 +3402,7 @@ async fn test_info_contact_id() -> Result<()> {
     )
     .await?;
 
-    let file = alice.dir.path().join("avatar.png");
+    let file = alice.get_blobdir().join("avatar.png");
     let bytes = include_bytes!("../../test-data/image/avatar64x64.png");
     tokio::fs::write(&file, bytes).await?;
     set_chat_profile_image(alice, alice_chat_id, file.to_str().unwrap()).await?;

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3429,7 +3429,7 @@ async fn test_info_contact_id() -> Result<()> {
     )
     .await?;
 
-    let fiona_id = Contact::create(alice, "Fiona", "fiona@example.net").await?; // contexts are in sync, fiona_id is same everywhere
+    let fiona_id = alice.add_or_lookup_contact_id(&tcm.fiona().await).await; // contexts are in sync, fiona_id is same everywhere
     add_contact_to_chat(alice, alice_chat_id, fiona_id).await?;
     pop_recv_and_check(
         alice,

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -331,11 +331,12 @@ async fn test_member_add_remove() -> Result<()> {
     // Alice adds Bob to the chat.
     add_contact_to_chat(&alice, alice_chat_id, alice_bob_contact_id).await?;
     let sent = alice.pop_sent_msg().await;
+
     // Locally set name "robert" should not leak.
     assert!(!sent.payload.contains("robert"));
     assert_eq!(
         sent.load_from_db().await.get_text(),
-        "You added member robert (bob@example.net)."
+        "You added member robert."
     );
 
     // Alice removes Bob from the chat.
@@ -344,7 +345,7 @@ async fn test_member_add_remove() -> Result<()> {
     assert!(!sent.payload.contains("robert"));
     assert_eq!(
         sent.load_from_db().await.get_text(),
-        "You removed member robert (bob@example.net)."
+        "You removed member robert."
     );
 
     // Alice leaves the chat.
@@ -412,7 +413,7 @@ async fn test_parallel_member_remove() -> Result<()> {
     // Test that remove message is rewritten.
     assert_eq!(
         bob_received_remove_msg.get_text(),
-        "Member Me (bob@example.net) removed by alice@example.org."
+        "Member Me removed by alice@example.org."
     );
 
     Ok(())

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3381,9 +3381,9 @@ async fn test_info_contact_id() -> Result<()> {
     }
 
     // Alice creates group, Bob receives group
-    let alice_chat_id = create_group_chat(alice, ProtectionStatus::Unprotected, "play").await?;
-    let alice_bob_id = Contact::create(alice, "Bob", "bob@example.net").await?;
-    add_contact_to_chat(alice, alice_chat_id, alice_bob_id).await?;
+    let alice_chat_id = alice
+        .create_group_with_members(ProtectionStatus::Unprotected, "play", &[bob])
+        .await;
     let sent_msg1 = alice.send_text(alice_chat_id, "moin").await;
 
     let msg = bob.recv_msg(&sent_msg1).await;

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3453,7 +3453,7 @@ async fn test_info_contact_id() -> Result<()> {
     .await?;
 
     // When fiona_id is deleted, get_info_contact_id() returns None.
-    // We raw deletion in db as Contact::delete() leaves a tombstone (which is great as the tap works longer then)
+    // We raw delete in db as Contact::delete() leaves a tombstone (which is great as the tap works longer then)
     alice
         .sql
         .execute("DELETE FROM contacts WHERE id=?", (fiona_id,))

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1406,16 +1406,16 @@ impl Contact {
         &self.addr
     }
 
-    /// Get a summary of authorized name and address.
+    /// Get authorized name or address.
     ///
     /// The returned string is either "Name (email@domain.com)" or just
     /// "email@domain.com" if the name is unset.
     ///
     /// This string is suitable for sending over email
     /// as it does not leak the locally set name.
-    pub fn get_authname_n_addr(&self) -> String {
+    pub(crate) fn get_authname_or_addr(&self) -> String {
         if !self.authname.is_empty() {
-            format!("{} ({})", self.authname, self.addr)
+            (&self.authname).into()
         } else {
             (&self.addr).into()
         }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1408,9 +1408,6 @@ impl Contact {
 
     /// Get authorized name or address.
     ///
-    /// The returned string is either "Name (email@domain.com)" or just
-    /// "email@domain.com" if the name is unset.
-    ///
     /// This string is suitable for sending over email
     /// as it does not leak the locally set name.
     pub(crate) fn get_authname_or_addr(&self) -> String {

--- a/src/param.rs
+++ b/src/param.rs
@@ -215,6 +215,9 @@ pub enum Param {
 
     /// For messages: Message text was edited.
     IsEdited = b'L',
+
+    /// For info messages: Contact ID in added or removed to a group.
+    ContactAddedRemoved = b'5',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -748,6 +748,7 @@ impl Peerstate {
                 Some(timestamp),
                 None,
                 None,
+                None,
             )
             .await?;
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1451,13 +1451,13 @@ async fn add_parts(
             None => better_msg = Some(m),
             Some(_) => {
                 if !m.is_empty() {
-                    group_changes.extra_msgs.push((m, is_system_message))
+                    group_changes.extra_msgs.push((m, is_system_message, None))
                 }
             }
         }
     }
 
-    for (group_changes_msg, cmd) in group_changes.extra_msgs {
+    for (group_changes_msg, cmd, added_removed_id) in group_changes.extra_msgs {
         chat::add_info_msg_with_cmd(
             context,
             chat_id,
@@ -1467,6 +1467,7 @@ async fn add_parts(
             None,
             None,
             None,
+            added_removed_id,
         )
         .await?;
     }
@@ -1549,6 +1550,10 @@ async fn add_parts(
         };
         let part_is_empty =
             typ == Viewtype::Text && msg.is_empty() && part.param.get(Param::Quote).is_none();
+
+        if let Some(contact_id) = group_changes.added_removed_id {
+            param.set_int(Param::ContactAddedRemoved, contact_id.to_u32() as i32);
+        }
 
         save_mime_modified |= mime_parser.is_mime_modified && !part_is_empty && !hidden;
         let save_mime_modified = save_mime_modified && parts.peek().is_none();
@@ -2334,10 +2339,12 @@ struct GroupChangesInfo {
     /// Optional: A better message that should replace the original system message.
     /// If this is an empty string, the original system message should be trashed.
     better_msg: Option<String>,
+    /// Added/removed contact `better_msg` refers to,
+    added_removed_id: Option<ContactId>,
     /// If true, the user should not be notified about the group change.
     silent: bool,
     /// A list of additional group changes messages that should be shown in the chat.
-    extra_msgs: Vec<(String, SystemMessage)>,
+    extra_msgs: Vec<(String, SystemMessage, Option<ContactId>)>,
 }
 
 /// Apply group member list, name, avatar and protection status changes from the MIME message.
@@ -2654,6 +2661,11 @@ async fn apply_group_changes(
     }
     Ok(GroupChangesInfo {
         better_msg,
+        added_removed_id: if added_id.is_some() {
+            added_id
+        } else {
+            removed_id
+        },
         silent,
         extra_msgs: group_changes_msgs,
     })
@@ -2665,7 +2677,7 @@ async fn group_changes_msgs(
     added_ids: &HashSet<ContactId>,
     removed_ids: &HashSet<ContactId>,
     chat_id: ChatId,
-) -> Result<Vec<(String, SystemMessage)>> {
+) -> Result<Vec<(String, SystemMessage, Option<ContactId>)>> {
     let mut group_changes_msgs = Vec::new();
     if !added_ids.is_empty() {
         warn!(
@@ -2686,6 +2698,7 @@ async fn group_changes_msgs(
             stock_str::msg_add_member_local(context, contact.get_addr(), ContactId::UNDEFINED)
                 .await,
             SystemMessage::MemberAddedToGroup,
+            Some(contact.id),
         ));
     }
     for contact_id in removed_ids {
@@ -2694,6 +2707,7 @@ async fn group_changes_msgs(
             stock_str::msg_del_member_local(context, contact.get_addr(), ContactId::UNDEFINED)
                 .await,
             SystemMessage::MemberRemovedFromGroup,
+            Some(contact.id),
         ));
     }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2339,7 +2339,7 @@ struct GroupChangesInfo {
     /// Optional: A better message that should replace the original system message.
     /// If this is an empty string, the original system message should be trashed.
     better_msg: Option<String>,
-    /// Added/removed contact `better_msg` refers to,
+    /// Added/removed contact `better_msg` refers to.
     added_removed_id: Option<ContactId>,
     /// If true, the user should not be notified about the group change.
     silent: bool,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1552,7 +1552,7 @@ async fn add_parts(
             typ == Viewtype::Text && msg.is_empty() && part.param.get(Param::Quote).is_none();
 
         if let Some(contact_id) = group_changes.added_removed_id {
-            param.set_int(Param::ContactAddedRemoved, contact_id.to_u32() as i32);
+            param.set(Param::ContactAddedRemoved, contact_id.to_u32().to_string());
         }
 
         save_mime_modified |= mime_parser.is_mime_modified && !part_is_empty && !hidden;

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -126,6 +126,7 @@ pub(super) async fn start_protocol(context: &Context, invite: QrInvite) -> Resul
                     Some(ts_start),
                     None,
                     None,
+                    None,
                 )
                 .await?;
                 chat_id.spawn_securejoin_wait(context, constants::SECUREJOIN_WAIT_TIMEOUT);

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -439,6 +439,7 @@ pub(crate) async fn send_msg_to_smtp(
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await?;
                 };

--- a/src/stock_str/stock_str_tests.rs
+++ b/src/stock_str/stock_str_tests.rs
@@ -54,10 +54,7 @@ async fn test_stock_string_repl_str() {
         .unwrap();
     let contact = Contact::get_by_id(&t.ctx, contact_id).await.unwrap();
     // uses %1$s substitution
-    assert_eq!(
-        contact_verified(&t, &contact).await,
-        "Someone (someone@example.org) verified."
-    );
+    assert_eq!(contact_verified(&t, &contact).await, "Someone verified.");
     // We have no string using %1$d to test...
 }
 
@@ -95,7 +92,7 @@ async fn test_stock_system_msg_add_member_by_me_with_displayname() {
     );
     assert_eq!(
         msg_add_member_local(&t, "alice@example.org", ContactId::SELF).await,
-        "You added member Alice (alice@example.org)."
+        "You added member Alice."
     );
 }
 
@@ -112,7 +109,7 @@ async fn test_stock_system_msg_add_member_by_other_with_displayname() {
     };
     assert_eq!(
         msg_add_member_local(&t, "alice@example.org", contact_id,).await,
-        "Member Alice (alice@example.org) added by Bob (bob@example.com)."
+        "Member Alice added by Bob."
     );
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -743,10 +743,7 @@ mod tests {
         let fiona = &tcm.fiona().await;
         tcm.exec_securejoin_qr(fiona, alice2, &qr).await;
         let msg = fiona.get_last_msg().await;
-        assert_eq!(
-            msg.text,
-            "Member Me (fiona@example.net) added by alice@example.org."
-        );
+        assert_eq!(msg.text, "Member Me added by alice@example.org.");
         Ok(())
     }
 }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -388,6 +388,7 @@ impl Context {
                         None,
                         Some(&instance),
                         Some(from_id),
+                        None,
                     )
                     .await?;
                 }

--- a/test-data/golden/two_group_securejoins
+++ b/test-data/golden/two_group_securejoins
@@ -5,5 +5,5 @@ Msg#11: info (Contact#Contact#Info): alice@example.org invited you to join this 
 Waiting for the device of alice@example.org to reply… [NOTICED][INFO]
 Msg#13: info (Contact#Contact#Info): alice@example.org replied, waiting for being added to the group… [NOTICED][INFO]
 Msg#17: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
-Msg#18🔒:  (Contact#Contact#10): Member Me (fiona@example.net) added by alice@example.org. [FRESH][INFO]
+Msg#18🔒:  (Contact#Contact#10): Member Me added by alice@example.org. [FRESH][INFO]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
instead of showing addresses in info message, provide an API to get the contact-id. 

UI can then make the info message  tappable and open the contact profile in scope

the corresponding iOS PR - incl. **screencast** - is at https://github.com/deltachat/deltachat-ios/pull/2652 ; jsonrpc can come in a subsequent PR when things are settled on android/ios

the number of parameters in `add_info_msg_with_cmd` gets bigger and bigger, however,  i did not want to refactor this in this PR. it is also not really adding complexity



closes #6702