### PR TITLE
add name resp. "Me" to contact encryption info

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1277,9 +1277,16 @@ impl Contact {
             .map(|k| k.dc_fingerprint().to_string())
             .unwrap_or_default();
         if addr < peerstate.addr {
-            cat_fingerprint(&mut ret, &addr, &fingerprint_self, "");
             cat_fingerprint(
                 &mut ret,
+                &stock_str::self_msg(context).await,
+                &addr,
+                &fingerprint_self,
+                "",
+            );
+            cat_fingerprint(
+                &mut ret,
+                contact.get_display_name(),
                 &peerstate.addr,
                 &fingerprint_other_verified,
                 &fingerprint_other_unverified,
@@ -1287,11 +1294,18 @@ impl Contact {
         } else {
             cat_fingerprint(
                 &mut ret,
+                contact.get_display_name(),
                 &peerstate.addr,
                 &fingerprint_other_verified,
                 &fingerprint_other_unverified,
             );
-            cat_fingerprint(&mut ret, &addr, &fingerprint_self, "");
+            cat_fingerprint(
+                &mut ret,
+                &stock_str::self_msg(context).await,
+                &addr,
+                &fingerprint_self,
+                "",
+            );
         }
 
         Ok(ret)
@@ -1848,12 +1862,14 @@ pub(crate) async fn update_last_seen(
 
 fn cat_fingerprint(
     ret: &mut String,
+    name: &str,
     addr: &str,
     fingerprint_verified: &str,
     fingerprint_unverified: &str,
 ) {
     *ret += &format!(
-        "\n\n{}:\n{}",
+        "\n\n{} ({}):\n{}",
+        name,
         addr,
         if !fingerprint_verified.is_empty() {
             fingerprint_verified
@@ -1865,7 +1881,7 @@ fn cat_fingerprint(
         && !fingerprint_unverified.is_empty()
         && fingerprint_verified != fingerprint_unverified
     {
-        *ret += &format!("\n\n{addr} (alternative):\n{fingerprint_unverified}");
+        *ret += &format!("\n\n{name} (alternative):\n{fingerprint_unverified}");
     }
 }
 

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -763,11 +763,11 @@ async fn test_contact_get_encrinfo() -> Result<()> {
         "End-to-end encryption preferred.
 Fingerprints:
 
-alice@example.org:
+Me (alice@example.org):
 2E6F A2CB 23B5 32D7 2863
 4B58 64B0 8F61 A9ED 9443
 
-bob@example.net:
+Bob (bob@example.net):
 CCCB 5AA9 F6E1 141C 9431
 65F1 DB18 B18C BCF7 0487"
     );


### PR DESCRIPTION
otherwise, by tuning down the email addresses,
one does not really has and idea who is SELF.

maybe the dialog is the only way at the end to get the transport adresses of contacts,
this is unclear atm, this PR fixes the issue at hand