### PR TITLE
feat: no unencrypted chat when securejoin times out

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7569,8 +7569,13 @@ void dc_event_unref(dc_event_t* event);
 
 /// "Could not yet establish guaranteed end-to-end encryption, but you may already send a message."
 ///
-/// Used as info message.
+/// @deprecated 2025-03
 #define DC_STR_SECUREJOIN_WAIT_TIMEOUT 191
+
+/// "This takes longer than expected, maybe devices are offline…\n\nHowever, the process continues in background, you can do something else"
+///
+/// Used as info message.
+#define DC_STR_SECUREJOIN_TAKES_LONGER 192
 
 /// "Contact". Deprecated, currently unused.
 #define DC_STR_CONTACT 200

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -149,7 +149,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
     );
     if case == SetupContactCase::SecurejoinWaitTimeout {
         SystemTime::shift(Duration::from_secs(constants::SECUREJOIN_WAIT_TIMEOUT));
-        assert_eq!(bob_chat.can_send(&bob).await.unwrap(), true);
+        assert_eq!(bob_chat.can_send(&bob).await.unwrap(), false);
     }
 
     // Step 4: Bob receives vc-auth-required, sends vc-request-with-auth
@@ -318,7 +318,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
                 .check_securejoin_wait(&bob, constants::SECUREJOIN_WAIT_TIMEOUT)
                 .await
                 .unwrap(),
-            0
+            (true, 0)
         );
     }
 
@@ -336,7 +336,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
         assert!(msg.is_info());
         assert_eq!(
             msg.get_text(),
-            stock_str::securejoin_wait_timeout(&bob).await
+            stock_str::securejoin_takes_longer(&bob).await
         );
     }
     let msg = get_chat_msg(&bob, bob_chat.get_id(), i.next().unwrap(), msg_cnt).await;

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -438,9 +438,9 @@ pub enum StockMessage {
     SecurejoinWait = 190,
 
     #[strum(props(
-        fallback = "Could not yet establish guaranteed end-to-end encryption, but you may already send a message."
+        fallback = "This takes longer than expected, maybe devices are offline…\n\nHowever, the process continues in background, you can do something else 🕺"
     ))]
-    SecurejoinWaitTimeout = 191,
+    SecurejoinTakesLonger = 192,
 }
 
 impl StockMessage {
@@ -833,8 +833,8 @@ pub(crate) async fn securejoin_wait(context: &Context) -> String {
 }
 
 /// Stock string: `Could not yet establish guaranteed end-to-end encryption, but you may already send a message.`.
-pub(crate) async fn securejoin_wait_timeout(context: &Context) -> String {
-    translated(context, StockMessage::SecurejoinWaitTimeout).await
+pub(crate) async fn securejoin_takes_longer(context: &Context) -> String {
+    translated(context, StockMessage::SecurejoinTakesLonger).await
 }
 
 /// Stock string: `Scan to chat with %1$s`.


### PR DESCRIPTION
this PR leaves one-to-one chats that were created by a QR code scan unwritable until e2ee is established.

the logic of the timeout is reused to show a message with additional information:

<img width=250 src=https://github.com/user-attachments/assets/b9928e7b-8128-4d7a-934d-37d51c8275ce>
<img width=250 src=https://github.com/user-attachments/assets/4a3a28e9-4491-47f9-8962-86aa2302dd21>
<img width=250 src=https://github.com/user-attachments/assets/5130a87c-ba1c-496f-81e1-899dc8aabe4e>

if the secure-join finishes faster than the 15 seconds, the middle message is not shown.

closes #6706 