### PR TITLE
refactor: Move logins into SQL table

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -717,7 +717,7 @@ def test_configured_imap_certificate_checks(acfactory):
     # Certificate checks should be configured (not None)
     assert "cert_automatic" in alice.get_info().used_account_settings
 
-    # "old_automatic" is the value old Delta Chat core versions used
+    # "cert_old_automatic" is the value old Delta Chat core versions used
     # to mean user entered "imap_certificate_checks=0" (Automatic)
     # and configuration failed to use strict TLS checks
     # so it switched strict TLS checks off.

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -713,12 +713,11 @@ def test_get_http_response(acfactory):
 
 def test_configured_imap_certificate_checks(acfactory):
     alice = acfactory.new_configured_account()
-    configured_certificate_checks = alice.get_config("configured_imap_certificate_checks")
 
     # Certificate checks should be configured (not None)
-    assert configured_certificate_checks
+    assert "cert_automatic" in alice.get_info().used_account_settings
 
-    # 0 is the value old Delta Chat core versions used
+    # "old_automatic" is the value old Delta Chat core versions used
     # to mean user entered "imap_certificate_checks=0" (Automatic)
     # and configuration failed to use strict TLS checks
     # so it switched strict TLS checks off.
@@ -729,7 +728,7 @@ def test_configured_imap_certificate_checks(acfactory):
     #
     # Core 1.142.4, 1.142.5 and 1.142.6 saved this value due to bug.
     # This test is a regression test to prevent this happening again.
-    assert configured_certificate_checks != "0"
+    assert "cert_old_automatic" not in alice.get_info().used_account_settings
 
 
 def test_no_old_msg_is_fresh(acfactory):

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -482,12 +482,8 @@ class ACFactory:
         addr = f"{acname}@offline.org"
         ac.update_config(
             {
-                "addr": addr,
-                "displayname": acname,
-                "mail_pw": "123",
                 "configured_addr": addr,
-                "configured_mail_pw": "123",
-                "configured": "1",
+                "displayname": acname,
             },
         )
         self._preconfigure_key(ac)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1502,11 +1502,10 @@ def test_connectivity(acfactory, lp):
     assert len(msgs) == 2
     assert msgs[1].text == "Hi 2"
 
-    lp.sec("Test that the connectivity is NOT_CONNECTED if the password is wrong")
 
-    ac1.set_config("configured_mail_pw", "abc")
-    ac1.stop_io()
-    ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_NOT_CONNECTED)
+def test_connectivity_not_connected(acfactory, lp)
+    ac1 = acfactory.get_pseudo_configured_account()
+    lp.sec("Test that the connectivity is NOT_CONNECTED if the password is wrong")
     ac1.start_io()
     ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_CONNECTING)
     ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_NOT_CONNECTED)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1503,7 +1503,7 @@ def test_connectivity(acfactory, lp):
     assert msgs[1].text == "Hi 2"
 
 
-def test_connectivity_not_connected(acfactory, lp)
+def test_connectivity_not_connected(acfactory, lp):
     ac1 = acfactory.get_pseudo_configured_account()
     lp.sec("Test that the connectivity is NOT_CONNECTED if the password is wrong")
     ac1.start_io()

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1503,14 +1503,6 @@ def test_connectivity(acfactory, lp):
     assert msgs[1].text == "Hi 2"
 
 
-def test_connectivity_not_connected(acfactory, lp):
-    ac1 = acfactory.get_pseudo_configured_account()
-    lp.sec("Test that the connectivity is NOT_CONNECTED if the password is wrong")
-    ac1.start_io()
-    ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_CONNECTING)
-    ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_NOT_CONNECTED)
-
-
 def test_fetch_deleted_msg(acfactory, lp):
     """This is a regression test: Messages with \\Deleted flag were downloaded again and again,
     hundreds of times, because uid_next was not updated.

--- a/src/config.rs
+++ b/src/config.rs
@@ -810,7 +810,7 @@ impl Context {
             }
             Config::ConfiguredAddr => {
                 if self.is_configured().await? {
-                    bail!("Cannot change ConfiguredSelfAddr");
+                    bail!("Cannot change ConfiguredAddr");
                 }
                 if let Some(addr) = value {
                     info!(self, "Creating a pseudo configured account which will not be able to send or receive messages. Only meant for tests!");

--- a/src/config.rs
+++ b/src/config.rs
@@ -891,6 +891,7 @@ impl Context {
     /// primary address (if exists) as a secondary address.
     ///
     /// This should only be used by test code and during configure.
+    #[cfg(test)] // AEAP is disabled, but there are still tests for it
     pub(crate) async fn set_primary_self_addr(&self, primary_new: &str) -> Result<()> {
         self.quota.write().await.take();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -924,7 +924,8 @@ impl Context {
         )
         .await?;
 
-        self.set_config_internal(Config::ConfiguredAddr, Some(primary_new))
+        self.sql
+            .set_raw_config(Config::ConfiguredAddr.as_ref(), Some(primary_new))
             .await?;
         self.emit_event(EventType::ConnectivityChanged);
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -816,7 +816,7 @@ impl Context {
                     bail!("Cannot change ConfiguredSelfAddr");
                 }
                 if let Some(addr) = value {
-                    info!(self, "Creating a pseudo configured account which will not be able to send or receive messages. ONLY MEANT FOR TESTS.");
+                    info!(self, "Creating a pseudo configured account which will not be able to send or receive messages. Only meant for tests!");
                     ConfiguredLoginParam::from_json(&format!(
                         r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#
                     ))?

--- a/src/config.rs
+++ b/src/config.rs
@@ -539,10 +539,7 @@ impl Context {
                     false => Some("0".to_string()),
                 }
             }
-            Config::Addr => {
-                warn!(self, "It looks like you are using `Config::Addr` to get the configured address. You should use `Config::ConfiguredAddr` instead.");
-                self.get_config_opt(Config::ConfiguredAddr).await?
-            }
+            Config::Addr => self.get_config_opt(Config::ConfiguredAddr).await?,
             _ => key.get_str("default").map(|s| s.to_string()),
         };
         Ok(val)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -63,7 +63,7 @@ macro_rules! progress {
 impl Context {
     /// Checks if the context is already configured.
     pub async fn is_configured(&self) -> Result<bool> {
-        self.sql.get_raw_config_bool("configured").await
+        self.sql.exists("SELECT COUNT(*) FROM transports", ()).await
     }
 
     /// Configures this account with the currently provided parameters.

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -35,7 +35,7 @@ use crate::login_param::{
 };
 use crate::message::Message;
 use crate::oauth2::get_oauth2_addr;
-use crate::provider::{Protocol, Socket, UsernamePattern};
+use crate::provider::{Protocol, Provider, Socket, UsernamePattern};
 use crate::qr::set_account_from_qr;
 use crate::smtp::Smtp;
 use crate::sync::Sync::*;
@@ -209,20 +209,20 @@ impl Context {
         info!(self, "Configure ...");
 
         let old_addr = self.get_config(Config::ConfiguredAddr).await?;
-        let configured_param = configure(self, param).await?;
+        let provider = configure(self, param).await?;
         self.set_config_internal(Config::NotifyAboutWrongPw, Some("1"))
             .await?;
-        on_configure_completed(self, configured_param, old_addr).await?;
+        on_configure_completed(self, provider, old_addr).await?;
         Ok(())
     }
 }
 
 async fn on_configure_completed(
     context: &Context,
-    param: ConfiguredLoginParam,
+    provider: Option<&'static Provider>,
     old_addr: Option<String>,
 ) -> Result<()> {
-    if let Some(provider) = param.provider {
+    if let Some(provider) = provider {
         if let Some(config_defaults) = provider.config_defaults {
             for def in config_defaults {
                 if !context.config_exists(def.key).await? {
@@ -458,7 +458,7 @@ async fn get_configured_param(
     Ok(configured_login_param)
 }
 
-async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<ConfiguredLoginParam> {
+async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Option<&'static Provider>> {
     progress!(ctx, 1);
 
     let ctx2 = ctx.clone();
@@ -568,7 +568,11 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Configure
         }
     }
 
-    configured_param.save_as_configured_params(ctx).await?;
+    let provider = configured_param.provider;
+    configured_param
+        .save_to_transports_table(ctx, param)
+        .await?;
+
     ctx.set_config_internal(Config::ConfiguredTimestamp, Some(&time().to_string()))
         .await?;
 
@@ -584,7 +588,7 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Configure
     ctx.sql.set_raw_config_bool("configured", true).await?;
     ctx.emit_event(EventType::AccountsItemChanged);
 
-    Ok(configured_param)
+    Ok(provider)
 }
 
 /// Retrieve available autoconfigurations.

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -829,7 +829,8 @@ impl ConfiguredLoginParam {
             )
             .await?;
         context
-            .set_config(Config::ConfiguredAddr, Some(&addr))
+            .sql
+            .set_raw_config(Config::ConfiguredAddr.as_ref(), Some(&addr))
             .await?;
         Ok(())
     }

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -535,7 +535,7 @@ impl ConfiguredLoginParam {
         }
     }
 
-    /// Load legacy configured param. Only used for tests and the migration.
+    /// Loads legacy configured param. Only used for tests and the migration.
     pub(crate) async fn load_legacy(context: &Context) -> Result<Option<Self>> {
         if !context.get_config_bool(Config::Configured).await? {
             return Ok(None);

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -896,6 +896,7 @@ impl ConfiguredLoginParam {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::log::LogExt as _;
     use crate::provider::get_provider_by_id;
     use crate::test_utils::TestContext;
     use pretty_assertions::assert_eq;
@@ -1186,8 +1187,8 @@ mod tests {
 
     async fn migrate_configured_login_param(t: &TestContext) {
         t.sql.execute("DROP TABLE transports;", ()).await.unwrap();
-        t.sql.set_raw_config_int("dbversion", 129).await.unwrap();
-        t.sql.run_migrations(t).await.unwrap();
+        t.sql.set_raw_config_int("dbversion", 130).await.unwrap();
+        t.sql.run_migrations(t).await.log_err(t).ok();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -861,6 +861,26 @@ impl ConfiguredLoginParam {
         Ok(())
     }
 
+    pub(crate) async fn save_to_transports_table(
+        self,
+        context: &Context,
+        entered_param: &EnteredLoginParam,
+    ) -> Result<()> {
+        context
+            .sql
+            .execute(
+                "INSERT INTO transports (addr, entered_params, configured_params)
+                VALUES (?, ?, ?)",
+                (
+                    self.addr.clone(),
+                    serde_json::to_string(entered_param)?,
+                    self.into_json()?,
+                ),
+            )
+            .await?;
+        Ok(())
+    }
+
     pub(crate) fn from_json(json: &str) -> Result<Self> {
         let json: ConfiguredLoginParamJson = serde_json::from_str(json)?;
         let imap;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -5,6 +5,7 @@ pub(crate) mod data;
 use anyhow::Result;
 use deltachat_contact_tools::EmailAddress;
 use hickory_resolver::{config, Resolver, TokioResolver};
+use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use crate::context::Context;
@@ -37,7 +38,19 @@ pub enum Protocol {
 }
 
 /// Socket security.
-#[derive(Debug, Default, Display, PartialEq, Eq, Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(
+    Debug,
+    Default,
+    Display,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    FromPrimitive,
+    ToPrimitive,
+    Serialize,
+    Deserialize,
+)]
 #[repr(u8)]
 pub enum Socket {
     /// Unspecified socket security, select automatically.

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3113,7 +3113,6 @@ Message with references."#;
 async fn test_rfc1847_encapsulation() -> Result<()> {
     let alice = TestContext::new_alice().await;
     let bob = TestContext::new_bob().await;
-    alice.configure_addr("alice@example.org").await;
 
     // Alice sends an Autocrypt message to Bob so Bob gets Alice's key.
     let chat_alice = alice.create_chat(&bob).await;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1199,14 +1199,15 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
                     "CREATE TABLE transports (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         addr TEXT NOT NULL,
-                        entered_param TEXT NOT NULL
-                        configured_param TEXT NOT NULL
-                        )", // TODO could be UNIQUE(addr)
+                        entered_param TEXT NOT NULL,
+                        configured_param TEXT NOT NULL,
+                        UNIQUE(addr)
+                        )",
                     (),
                 )?;
                 if let Some(configured_param) = configured_param {
                     transaction.execute(
-                        "INSERT INTO transports (addr, entered_params, configured_params)
+                        "INSERT INTO transports (addr, entered_param, configured_param)
                         VALUES (?, ?, ?)",
                         (
                             configured_param.addr.clone(),

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1208,7 +1208,7 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
                 if let Some(configured_param) = configured_param {
                     transaction.execute(
                         "INSERT INTO transports (addr, entered_param, configured_param)
-                        VALUES (?, ?, ?)",
+                         VALUES (?, ?, ?)",
                         (
                             configured_param.addr.clone(),
                             serde_json::to_string(&entered_param)?,

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1191,7 +1191,7 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
     inc_and_check(&mut migration_version, 131)?;
     if dbversion < migration_version {
         let entered_param = EnteredLoginParam::load(context).await?;
-        let configured_param = ConfiguredLoginParam::load(context).await?;
+        let configured_param = ConfiguredLoginParam::load_legacy(context).await?;
 
         sql.execute_migration_closure(
             |transaction| {
@@ -1201,7 +1201,7 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
                         addr TEXT NOT NULL,
                         entered_param TEXT NOT NULL
                         configured_param TEXT NOT NULL
-                        )",
+                        )", // TODO could be UNIQUE(addr)
                     (),
                 )?;
                 if let Some(configured_param) = configured_param {

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -5,9 +5,11 @@ use deltachat_contact_tools::EmailAddress;
 use rusqlite::OptionalExtension;
 
 use crate::config::Config;
+use crate::configure::EnteredLoginParam;
 use crate::constants::ShowEmails;
 use crate::context::Context;
 use crate::imap;
+use crate::login_param::ConfiguredLoginParam;
 use crate::message::MsgId;
 use crate::provider::get_provider_by_domain;
 use crate::sql::Sql;
@@ -1186,6 +1188,41 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 131)?;
+    if dbversion < migration_version {
+        let entered_param = EnteredLoginParam::load(context).await?;
+        let configured_param = ConfiguredLoginParam::load(context).await?;
+
+        sql.execute_migration_closure(
+            |transaction| {
+                transaction.execute(
+                    "CREATE TABLE transports (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        addr TEXT NOT NULL,
+                        entered_param TEXT NOT NULL
+                        configured_param TEXT NOT NULL
+                        )",
+                    (),
+                )?;
+                if let Some(configured_param) = configured_param {
+                    transaction.execute(
+                        "INSERT INTO transports (addr, entered_params, configured_params)
+                        VALUES (?, ?, ?)",
+                        (
+                            configured_param.addr.clone(),
+                            serde_json::to_string(&entered_param)?,
+                            configured_param.into_json()?,
+                        ),
+                    )?;
+                }
+
+                Ok(())
+            },
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?
@@ -1230,6 +1267,21 @@ impl Sql {
     }
 
     async fn execute_migration(&self, query: &str, version: i32) -> Result<()> {
+        self.execute_migration_closure(
+            |transaction| {
+                transaction.execute_batch(query)?;
+                Ok(())
+            },
+            version,
+        )
+        .await
+    }
+
+    async fn execute_migration_closure(
+        &self,
+        migration: impl Send + FnOnce(&mut rusqlite::Transaction) -> Result<()>,
+        version: i32,
+    ) -> Result<()> {
         self.transaction(move |transaction| {
             let curr_version: String = transaction.query_row(
                 "SELECT IFNULL(value, ?) FROM config WHERE keyname=?;",
@@ -1239,7 +1291,7 @@ impl Sql {
             let curr_version: i32 = curr_version.parse()?;
             ensure!(curr_version < version, "Db version must be increased");
             Self::set_db_version_trans(transaction, version)?;
-            transaction.execute_batch(query)?;
+            migration(transaction)?;
 
             Ok(())
         })

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1193,7 +1193,7 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
         let entered_param = EnteredLoginParam::load(context).await?;
         let configured_param = ConfiguredLoginParam::load_legacy(context).await?;
 
-        sql.execute_migration_closure(
+        sql.execute_migration_transaction(
             |transaction| {
                 transaction.execute(
                     "CREATE TABLE transports (
@@ -1268,7 +1268,7 @@ impl Sql {
     }
 
     async fn execute_migration(&self, query: &str, version: i32) -> Result<()> {
-        self.execute_migration_closure(
+        self.execute_migration_transaction(
             |transaction| {
                 transaction.execute_batch(query)?;
                 Ok(())
@@ -1278,7 +1278,7 @@ impl Sql {
         .await
     }
 
-    async fn execute_migration_closure(
+    async fn execute_migration_transaction(
         &self,
         migration: impl Send + FnOnce(&mut rusqlite::Transaction) -> Result<()>,
         version: i32,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -25,6 +25,7 @@ use crate::chat::{
 };
 use crate::chatlist::Chatlist;
 use crate::config::Config;
+use crate::configure::EnteredLoginParam;
 use crate::constants::DC_CHAT_ID_TRASH;
 use crate::constants::DC_GCL_NO_SPECIALS;
 use crate::constants::{Blocked, Chattype};
@@ -33,6 +34,7 @@ use crate::context::Context;
 use crate::e2ee::EncryptHelper;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{self, DcKey, DcSecretKey};
+use crate::login_param::ConfiguredLoginParam;
 use crate::message::{update_msg_state, Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::peerstate::Peerstate;
@@ -478,14 +480,14 @@ impl TestContext {
     /// used the fingerprint will be different every time.
     pub async fn configure_addr(&self, addr: &str) {
         self.ctx.set_config(Config::Addr, Some(addr)).await.unwrap();
-        self.ctx
-            .set_config(Config::ConfiguredAddr, Some(addr))
-            .await
-            .unwrap();
-        self.ctx
-            .set_config(Config::Configured, Some("1"))
-            .await
-            .unwrap();
+        ConfiguredLoginParam::from_json(&format!(
+            r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#
+        ))
+        .unwrap()
+        .save_to_transports_table(&self, &EnteredLoginParam::default())
+        .await
+        .unwrap();
+
         if let Some(name) = addr.split('@').next() {
             self.set_name(name);
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -479,14 +479,10 @@ impl TestContext {
     /// The context will be configured but the key will not be pre-generated so if a key is
     /// used the fingerprint will be different every time.
     pub async fn configure_addr(&self, addr: &str) {
-        self.ctx.set_config(Config::Addr, Some(addr)).await.unwrap();
-        ConfiguredLoginParam::from_json(&format!(
-            r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#
-        ))
-        .unwrap()
-        .save_to_transports_table(self, &EnteredLoginParam::default())
-        .await
-        .unwrap();
+        self.ctx
+            .set_config(Config::ConfiguredAddr, Some(addr))
+            .await
+            .unwrap();
 
         if let Some(name) = addr.split('@').next() {
             self.set_name(name);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -484,7 +484,7 @@ impl TestContext {
             r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#
         ))
         .unwrap()
-        .save_to_transports_table(&self, &EnteredLoginParam::default())
+        .save_to_transports_table(self, &EnteredLoginParam::default())
         .await
         .unwrap();
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -25,7 +25,6 @@ use crate::chat::{
 };
 use crate::chatlist::Chatlist;
 use crate::config::Config;
-use crate::configure::EnteredLoginParam;
 use crate::constants::DC_CHAT_ID_TRASH;
 use crate::constants::DC_GCL_NO_SPECIALS;
 use crate::constants::{Blocked, Chattype};
@@ -34,7 +33,6 @@ use crate::context::Context;
 use crate::e2ee::EncryptHelper;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{self, DcKey, DcSecretKey};
-use crate::login_param::ConfiguredLoginParam;
 use crate::message::{update_msg_state, Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::peerstate::Peerstate;


### PR DESCRIPTION
Move all `configured_*` parameters into a new SQL table `transports`. All `configured_*` parameters are deprecated; the only exception is `configured_addr`, which is used to store the address of the primary transport. Currently, there can only ever be one primary transport (i.e. the `transports` table only ever has one row); this PR is not supposed to change DC's behavior in any meaningful way.

This is a preparation for mt.
