### PR TITLE
fix: Set GroupNameTimestamp on group promotion (#6729)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2063,7 +2063,9 @@ impl Chat {
             && self.param.get_int(Param::Unpromoted).unwrap_or_default() == 1
         {
             msg.param.set_int(Param::AttachGroupImage, 1);
-            self.param.remove(Param::Unpromoted);
+            self.param
+                .remove(Param::Unpromoted)
+                .set_i64(Param::GroupNameTimestamp, timestamp);
             self.update_param(context).await?;
             // TODO: Remove this compat code needed because Core <= v1.143:
             // - doesn't accept synchronization of QR code tokens for unpromoted groups, so we also
@@ -3917,7 +3919,9 @@ pub(crate) async fn add_contact_to_chat_ex(
 
     let sync_qr_code_tokens;
     if from_handshake && chat.param.get_int(Param::Unpromoted).unwrap_or_default() == 1 {
-        chat.param.remove(Param::Unpromoted);
+        chat.param
+            .remove(Param::Unpromoted)
+            .set_i64(Param::GroupNameTimestamp, smeared_time(context));
         chat.update_param(context).await?;
         sync_qr_code_tokens = true;
     } else {

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2450,16 +2450,16 @@ async fn apply_group_changes(
             .filter(|grpname| grpname.len() < 200)
         {
             let grpname = &sanitize_single_line(grpname);
-            let old_name = &sanitize_single_line(old_name);
 
             let chat_group_name_timestamp =
                 chat.param.get_i64(Param::GroupNameTimestamp).unwrap_or(0);
             let group_name_timestamp = group_name_timestamp.unwrap_or(mime_parser.timestamp_sent);
             // To provide group name consistency, compare names if timestamps are equal.
-            if (chat_group_name_timestamp, grpname) < (group_name_timestamp, old_name)
+            if (chat_group_name_timestamp, grpname) < (group_name_timestamp, &chat.name)
                 && chat_id
                     .update_timestamp(context, Param::GroupNameTimestamp, group_name_timestamp)
                     .await?
+                && grpname != &chat.name
             {
                 info!(context, "Updating grpname for chat {chat_id}.");
                 context
@@ -2472,6 +2472,7 @@ async fn apply_group_changes(
                 .get_header(HeaderDef::ChatGroupNameChanged)
                 .is_some()
             {
+                let old_name = &sanitize_single_line(old_name);
                 better_msg.get_or_insert(
                     stock_str::msg_grp_name(context, old_name, grpname, from_id).await,
                 );

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -179,7 +179,7 @@ pub(crate) fn gm2local_offset() -> i64 {
 
 /// Returns the current smeared timestamp,
 ///
-/// The returned timestamp MUST NOT be sent out.
+/// The returned timestamp MAY NOT be unique and MUST NOT go to "Date" header.
 pub(crate) fn smeared_time(context: &Context) -> i64 {
     let now = time();
     let ts = context.smeared_timestamp.current();


### PR DESCRIPTION
Fix #6729 