### PR TITLE
handle classic emails as such only in classic profiles

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -770,6 +770,7 @@ async fn add_parts(
         && !context.get_config_bool(Config::IsChatmail).await?
     {
         // the message is a classic email in a classic profile
+        // (in chatmail profiles, we always show all messages, because shared dc-mua usage is not supported)
         match show_emails {
             ShowEmails::Off => {
                 info!(context, "Classical email not shown (TRASH).");

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -767,8 +767,9 @@ async fn add_parts(
     let allow_creation;
     if mime_parser.is_system_message != SystemMessage::AutocryptSetupMessage
         && is_dc_message == MessengerMessage::No
+        && !context.get_config_bool(Config::IsChatmail).await?
     {
-        // this message is a classic email not a chat-message nor a reply to one
+        // the message is a classic email in a classic profile
         match show_emails {
             ShowEmails::Off => {
                 info!(context, "Classical email not shown (TRASH).");


### PR DESCRIPTION
next android/desktop/ios releases won't have the "Show Classic Emails" option for chatmail.

to avoid issues with user that have set sth else than "All", we ignore the option alltogether for chatmail profiles.

ftr, i do not expect ppl having that option changed for chatmail much, it does not make much sense. so this PR is mainly to save our limited support resources :) (usecase: "look, i am using chatmail to sign up at SERVICE, but for security reasons i set show=all only when i reset my password" :)

one could also do that in a migration, however, (a) migrations always come with some risk, even the easiest ones, and (b) the show_emails option is subject to change or disappear anyways, subsequent changes are easier in code than in additional or removed migrations, and (c) it is really only one line, that does not add much with complexity