### PR TITLE
feat: Always allow non-DC reactions to create chats

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -781,7 +781,9 @@ async fn add_parts(
             ShowEmails::All => allow_creation = !is_mdn,
         }
     } else {
-        allow_creation = !is_mdn && !is_reaction;
+        // DC reaction messages don't contain extra parts, so they mustn't create chats.
+        let is_dc_reaction = is_dc_message == MessengerMessage::Yes && is_reaction;
+        allow_creation = !is_mdn && !is_dc_reaction;
     }
 
     // check if the message introduces a new chat:


### PR DESCRIPTION
This also unifies conditions for creating chats for chatmail and non-chatmail with
`ShowEmails::All`. As for DC reaction messages, they don't contain extra parts, so they mustn't
create chats.

Trying to resolve https://github.com/chatmail/core/pull/6767#issuecomment-2777517737