### PR TITLE
fix: add missing ChatDeleted event to python jsonrpc client

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/const.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/const.py
@@ -48,6 +48,7 @@ class EventType(str, Enum):
     MSG_READ = "MsgRead"
     MSG_DELETED = "MsgDeleted"
     CHAT_MODIFIED = "ChatModified"
+    CHAT_DELETED = "ChatDeleted"
     CHAT_EPHEMERAL_TIMER_MODIFIED = "ChatEphemeralTimerModified"
     CONTACTS_CHANGED = "ContactsChanged"
     LOCATION_CHANGED = "LocationChanged"


### PR DESCRIPTION
Fixing this crash:

```
Traceback (most recent call last):
  File "/home/user/code/keyserver-bot/venv/bin/keyserver-bot", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/code/keyserver-bot/src/keyserver_bot/hooks.py", line 53, in main
    run_bot_cli(hooks)
  File "/home/user/code/keyserver-bot/venv/lib/python3.12/site-packages/deltachat_rpc_client/_utils.py", line 71, in run_bot_cli
    _run_cli(Bot, hooks, argv, **kwargs)
  File "/home/user/code/keyserver-bot/venv/lib/python3.12/site-packages/deltachat_rpc_client/_utils.py", line 113, in _run_cli
    client.run_forever()
  File "/home/user/code/keyserver-bot/venv/lib/python3.12/site-packages/deltachat_rpc_client/client.py", line 92, in run_forever
    self.run_until(lambda _: False)
  File "/home/user/code/keyserver-bot/venv/lib/python3.12/site-packages/deltachat_rpc_client/client.py", line 107, in run_until
    event["kind"] = EventType(event.kind)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 757, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/enum.py", line 1171, in __new__
    raise ve_exc
ValueError: 'ChatDeleted' is not a valid EventType
```