### PR TITLE
chore: move ASM strings to core, point to "Add Second Device"

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6912,12 +6912,12 @@ void dc_event_unref(dc_event_t* event);
 
 /// "Autocrypt Setup Message"
 ///
-/// Used in subjects of outgoing Autocrypt Setup Messages.
+/// @deprecated 2025-04
 #define DC_STR_AC_SETUP_MSG_SUBJECT       42
 
 /// "This is the Autocrypt Setup Message, open it in a compatible client to use your setup"
 ///
-/// Used as message text of outgoing Autocrypt Setup Messages.
+/// @deprecated 2025-04
 #define DC_STR_AC_SETUP_MSG_BODY          43
 
 /// "Cannot login as %1$s."

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -220,6 +220,16 @@ pub(crate) const SECUREJOIN_WAIT_TIMEOUT: u64 = 15;
 // Newer Delta Chats will remove the prefix as needed.
 pub(crate) const EDITED_PREFIX: &str = "✏️";
 
+// Strings needed to render the Autocrypt Setup Message.
+// Left untranslated as not being supported/recommended workflow and as translations would require deep knowledge.
+pub(crate) const ASM_SUBJECT: &str = "Autocrypt Setup Message";
+pub(crate) const ASM_BODY: &str = "This is the Autocrypt Setup Message \
+    used to transfer your end-to-end setup between clients.
+
+    To decrypt and use your setup, \
+    open the message in an Autocrypt-compliant client \
+    and enter the setup code presented on the generating device.";
+
 #[cfg(test)]
 mod tests {
     use num_traits::FromPrimitive;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -228,7 +228,10 @@ pub(crate) const ASM_BODY: &str = "This is the Autocrypt Setup Message \
 
     To decrypt and use your setup, \
     open the message in an Autocrypt-compliant client \
-    and enter the setup code presented on the generating device.";
+    and enter the setup code presented on the generating device.
+
+    If you see this message in a chatmail client (Delta Chat, Arcane Chat, Delta Touch ...), \
+    use \"Settings / Add Second Device\" instead.";
 
 #[cfg(test)]
 mod tests {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -16,6 +16,7 @@ use tokio::fs;
 use crate::blob::BlobObject;
 use crate::chat::{self, Chat};
 use crate::config::Config;
+use crate::constants::ASM_SUBJECT;
 use crate::constants::{Chattype, DC_FROM_HANDSHAKE};
 use crate::contact::{Contact, ContactId, Origin};
 use crate::context::Context;
@@ -1303,7 +1304,7 @@ impl MimeFactory {
                     mail_builder::headers::raw::Raw::new("v1").into(),
                 ));
 
-                placeholdertext = Some(stock_str::ac_setup_msg_body(context).await);
+                placeholdertext = Some(ASM_SUBJECT.to_string());
             }
             SystemMessage::SecurejoinMessage => {
                 let step = msg.param.get(Param::Arg).unwrap_or_default();

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -95,14 +95,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "Archived chats"))]
     ArchivedChats = 40,
 
-    #[strum(props(fallback = "Autocrypt Setup Message"))]
-    AcSetupMsgSubject = 42,
-
-    #[strum(props(
-        fallback = "This is the Autocrypt Setup Message used to transfer your key between clients.\n\nTo decrypt and use your key, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device."
-    ))]
-    AcSetupMsgBody = 43,
-
     #[strum(props(
         fallback = "Cannot login as \"%1$s\". Please check if the email address and the password are correct."
     ))]
@@ -887,16 +879,6 @@ pub(crate) async fn contact_setup_changed(context: &Context, contact_addr: &str)
 /// Stock string: `Archived chats`.
 pub(crate) async fn archived_chats(context: &Context) -> String {
     translated(context, StockMessage::ArchivedChats).await
-}
-
-/// Stock string: `Autocrypt Setup Message`.
-pub(crate) async fn ac_setup_msg_subject(context: &Context) -> String {
-    translated(context, StockMessage::AcSetupMsgSubject).await
-}
-
-/// Stock string: `This is the Autocrypt Setup Message used to transfer...`.
-pub(crate) async fn ac_setup_msg_body(context: &Context) -> String {
-    translated(context, StockMessage::AcSetupMsgBody).await
 }
 
 /// Stock string: `Multi Device Synchronization`.

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -204,17 +204,10 @@ impl Message {
                 append_text = true
             }
             Viewtype::File => {
-                if self.param.get_cmd() == SystemMessage::AutocryptSetupMessage {
-                    emoji = None;
-                    type_name = Some(stock_str::ac_setup_msg_subject(context).await);
-                    type_file = None;
-                    append_text = false;
-                } else {
-                    emoji = Some("📎");
-                    type_name = Some(stock_str::file(context).await);
-                    type_file = self.get_filename();
-                    append_text = true
-                }
+                emoji = Some("📎");
+                type_name = Some(stock_str::file(context).await);
+                type_file = self.get_filename();
+                append_text = true
             }
             Viewtype::VideochatInvitation => {
                 emoji = None;
@@ -469,10 +462,10 @@ mod tests {
         ); // skipping prefix used for reactions summaries
 
         let mut msg = Message::new(Viewtype::File);
-        msg.set_text(some_text.clone());
-        msg.set_file_from_bytes(ctx, "foo.bar", b"data", None)
+        msg.set_file_from_bytes(ctx, "autocrypt-setup-message.html", b"data", None)
             .unwrap();
         msg.param.set_cmd(SystemMessage::AutocryptSetupMessage);
-        assert_summary_texts(&msg, ctx, "Autocrypt Setup Message").await; // file name is not added for autocrypt setup messages
+        assert_summary_texts(&msg, ctx, "📎 autocrypt-setup-message.html").await;
+        // no special handling of ASM
     }
 }


### PR DESCRIPTION
this PR moves now advanced/unsupported ASM strings to core, removing work from translations, esp. as another hint is added which would require retranslations. it is better to have that just in english, it is a nerd feature anyways.

moverover, this PR removes special rendering of ASM in the summary, which might be confusion, but mainly it is now unneeded, dead code

i'll do another android PR that will point to "Add Second Device" already on ASM generation EDIT: done at https://github.com/deltachat/deltachat-android/pull/3726

targets https://github.com/deltachat/deltachat-desktop/issues/4946