### PR TITLE
chore(cargo): bump tokio from 1.43.0 to 1.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,9 +6025,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
For some reason I don't understand, when I update tokio to 1.44.*, cargo deny complains about openssl.

This is needed to fix CI.