### PR TITLE
fix: encrypt broadcast lists

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2552,7 +2552,7 @@ async fn test_broadcast() -> Result<()> {
         let msg = bob.recv_msg(&sent_msg).await;
         assert_eq!(msg.get_text(), "ola!");
         assert_eq!(msg.subject, "Broadcast list");
-        assert!(!msg.get_showpadlock()); // avoid leaking recipients in encryption data
+        assert!(msg.get_showpadlock());
         let chat = Chat::load_from_db(&bob, msg.chat_id).await?;
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_ne!(chat.id, chat_bob.id);

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -415,12 +415,10 @@ impl MimeFactory {
 
     fn should_force_plaintext(&self) -> bool {
         match &self.loaded {
-            Loaded::Message { chat, msg } => {
-                msg.param
-                    .get_bool(Param::ForcePlaintext)
-                    .unwrap_or_default()
-                    || chat.typ == Chattype::Broadcast
-            }
+            Loaded::Message { msg, .. } => msg
+                .param
+                .get_bool(Param::ForcePlaintext)
+                .unwrap_or_default(),
             Loaded::Mdn { .. } => false,
         }
     }


### PR DESCRIPTION
it was all the time questionable if not encrypting broadcast lists rules the issue that recipients may know each other cryptographically.

however, meanwhile with chatmail, unncrypted broadcasts are no longer possible, and we actively broke workflows eg. from this teacher: https://support.delta.chat/t/broadcast-funktioniert-nach-update-nicht-meht/3694

there will probably a much nicer "channel" update come this year, however, until then, we can support broadcasts again in its existing form. nb, they're still experimental

this basically reverts commit
https://github.com/chatmail/core/pull/2707/commits/7e5907daf2cec64769440a8a57aeb5fc479e4dd4 which was that time added last-minute and without lots discussions :)

let the students get their homework again :)