### PR TITLE
ci: Don't make ruff format quiet

### DIFF
--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -21,7 +21,7 @@ skip_install = True
 deps =
     ruff
 commands =
-    ruff format --quiet --diff src/ examples/ tests/
+    ruff format --diff src/ examples/ tests/
     ruff check src/ examples/ tests/
 
 [pytest]

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -45,7 +45,7 @@ deps =
     pygments
     restructuredtext_lint 
 commands =
-    ruff format --quiet --diff setup.py src/deltachat examples/ tests/
+    ruff format --diff setup.py src/deltachat examples/ tests/
     ruff check src/deltachat tests/ examples/
     rst-lint --encoding 'utf-8' README.rst
 


### PR DESCRIPTION
Before this PR, it was not possible to see why `ruff format` failed