### PR TITLE
chore: clean up `deltachat-jsonrpc` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,6 @@ dependencies = [
  "deltachat",
  "deltachat-contact-tools",
  "futures",
- "log",
  "num-traits",
  "sanitize-filename",
  "schemars",

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -13,10 +13,7 @@ deltachat-contact-tools = { workspace = true }
 num-traits = { workspace = true }
 schemars = "0.8.22"
 serde = { workspace = true, features = ["derive"] }
-tempfile = { workspace = true }
-log = { workspace = true }
 async-channel = { workspace = true }
-futures = { workspace = true }
 serde_json = { workspace = true }
 yerpc = { workspace = true, features = ["anyhow_expose", "openrpc"] }
 typescript-type-def = { version = "0.5.13", features = ["json_value"] }
@@ -27,6 +24,8 @@ base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
+tempfile = { workspace = true }
+futures = { workspace = true }
 
 
 [features]


### PR DESCRIPTION
Move the dev dependencies to `[dev-dependencies]`,
remove the unused `log` dependency.
