### PR TITLE
fix: Allow to send to chats after failed securejoin again

### DIFF
--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -149,7 +149,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
     );
     if case == SetupContactCase::SecurejoinWaitTimeout {
         SystemTime::shift(Duration::from_secs(constants::SECUREJOIN_WAIT_TIMEOUT));
-        assert_eq!(bob_chat.can_send(&bob).await.unwrap(), false);
+        assert_eq!(bob_chat.can_send(&bob).await.unwrap(), true);
     }
 
     // Step 4: Bob receives vc-auth-required, sends vc-request-with-auth
@@ -318,7 +318,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
                 .check_securejoin_wait(&bob, constants::SECUREJOIN_WAIT_TIMEOUT)
                 .await
                 .unwrap(),
-            (true, 0)
+            0
         );
     }
 


### PR DESCRIPTION
Revert the biggest part of https://github.com/chatmail/core/pull/6722/ in order to fix #6816. Reopens https://github.com/chatmail/core/issues/6706.

Rationale for reverting instead of fixing is that it's not trivial to implement "if the chat is encrypted, can_send() returns true": When sending a message, in order to check whether to encrypt, we load all peerstates and check whether all of them can be encrypted to (`should_encrypt()`). We could do this in `can_send()`, but this would make it quite slow for groups. With multi-transport, the ways of checking whether to encrypt will be different, so in order not to do unnecessary work now, this PR just revert parts of [https://github.com/chatmail/core/pull/6722/](https://github.com/chatmail/core/pull/6817#), so that we can make things work nicely when multi-transport is merged.

As a quick mitigation, we could increase the timeout from 15s to something like 1 minute or 1 day: Long enough that usually securejoin will finish before, but short enough that it's possible to send to old chats that had a failed securejoin long in the past.