### PR TITLE
fix: Don't change webxdc self-addr when saving and loading draft

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -995,6 +995,7 @@ impl ChatId {
                 transaction.execute(
                     "INSERT INTO msgs (
                  chat_id,
+                 rfc724_mid,
                  from_id,
                  timestamp,
                  type,
@@ -1004,9 +1005,10 @@ impl ChatId {
                  param,
                  hidden,
                  mime_in_reply_to)
-         VALUES (?,?,?,?,?,?,?,?,?,?);",
+         VALUES (?,?,?,?,?,?,?,?,?,?,?);",
                     (
                         self,
+                        &msg.rfc724_mid,
                         ContactId::SELF,
                         time(),
                         msg.viewtype,

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -2210,6 +2210,7 @@ async fn test_self_addr_consistency() -> Result<()> {
         include_bytes!("../../test-data/webxdc/minimal.xdc"),
     )?;
     alice_chat.set_draft(alice, Some(&mut instance)).await?;
+    let mut instance = alice_chat.get_draft(alice).await?.unwrap();
     let self_addr = instance.get_webxdc_self_addr(alice).await?;
     let sent = alice.send_msg(alice_chat, &mut instance).await;
     let db_msg = Message::load_from_db(alice, sent.sender_msg_id).await?;


### PR DESCRIPTION
Fix https://github.com/chatmail/core/issues/6621; I also tested on Android that the webxdc self-addr actually stays the same when staging a draft and then sending.

Follow-up to https://github.com/chatmail/core/pull/6704; #6704 made sure that the webxdc self-addr doesn't change when creating a message and then sending it. This PR here makes sure that the rfc724_mid (which is needed to compute the self-addr) is saved when setting a draft, so that it's loaded properly after a call to get_draft().

cc @adbenitez @r10s @Septias 