### PR TITLE
fix: Assign encrypted message to PGP chat if any PGP contacts found (#6856)

### DIFF
--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -419,6 +419,23 @@ async fn test_outgoing_mua_msg() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_outgoing_encrypted_msg() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    enable_verified_oneonone_chats(&[alice]).await;
+
+    mark_as_verified(alice, bob).await;
+    let chat_id = alice.create_chat(bob).await.id;
+    let raw = include_bytes!("../../test-data/message/thunderbird_with_autocrypt.eml");
+    receive_imf(alice, raw, false).await?;
+    alice
+        .golden_test_chat(chat_id, "test_outgoing_encrypted_msg")
+        .await;
+    Ok(())
+}
+
 /// If Bob answers unencrypted from another address with a classical MUA,
 /// the message is under some circumstances still assigned to the original
 /// chat (see lookup_chat_by_reply()); this is meant to make aliases

--- a/test-data/golden/test_outgoing_encrypted_msg
+++ b/test-data/golden/test_outgoing_encrypted_msg
@@ -1,0 +1,5 @@
+Single#Chat#10: bob@example.net [PGP bob@example.net] 🛡️
+--------------------------------------------------------------------------------
+Msg#10: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
+Msg#11🔒: Me (Contact#Contact#Self): Test – This is encrypted, signed, and has an Autocrypt Header without prefer-encrypt=mutual.  √
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Particularly, this fixes a scenario when the second device sends a message to the 1:1 chat right after SecureJoin.
Fix #6856

The only thing that i don't understand is whether the pgp-contacts Core adds the contact's fingerprint to 1:1 messages. I only see that this is done for groups (EDIT: looked into logs, can confirm this). If so, the bug isn't specific to the old/current Core, i.e. it can be reproduced with two pgp-contacts devices. And then the contact's fingerprint should be added to 1:1 messages (if there are no reasons not to do so).