### PR TITLE
Fix(jsonrpc): Do not error on missign webxdc info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ result
 # direnv
 .envrc
 .direnv
+.aider*

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -8,6 +8,7 @@ use deltachat::chat::ChatVisibility;
 use deltachat::contact::Contact;
 use deltachat::context::Context;
 use deltachat::download;
+use deltachat::log::LogExt as _;
 use deltachat::message::Message;
 use deltachat::message::MsgId;
 use deltachat::message::Viewtype;
@@ -145,6 +146,7 @@ impl MessageObject {
         let webxdc_info = if message.get_viewtype() == Viewtype::Webxdc {
             WebxdcMessageInfo::get_for_message(context, msg_id)
                 .await
+                .log_err(context)
                 .ok()
         } else {
             None

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -143,7 +143,9 @@ impl MessageObject {
         let override_sender_name = message.get_override_sender_name();
 
         let webxdc_info = if message.get_viewtype() == Viewtype::Webxdc {
-            Some(WebxdcMessageInfo::get_for_message(context, msg_id).await?)
+            WebxdcMessageInfo::get_for_message(context, msg_id)
+                .await
+                .ok()
         } else {
             None
         };

--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@deltachat/tiny-emitter": "3.0.0",
     "isomorphic-ws": "^4.0.1",
+    "tmp": "^0.2.3",
     "yerpc": "^0.6.2"
   },
   "devDependencies": {

--- a/deltachat-jsonrpc/typescript/test/basic.ts
+++ b/deltachat-jsonrpc/typescript/test/basic.ts
@@ -1,6 +1,6 @@
-import { strictEqual } from "assert";
 import chai, { assert, expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { fileSync } from "tmp";
 chai.use(chaiAsPromised);
 import { StdioDeltaChat as DeltaChat } from "../deltachat.js";
 
@@ -97,6 +97,32 @@ describe("basic tests", () => {
       expect((await dc.rpc.getContact(accountId, contactId)).isBlocked).to.be
         .false;
       expect(await dc.rpc.getBlockedContacts(accountId)).to.have.length(0);
+    });
+  });
+
+  describe("webxdc", function () {
+    let invalidXdcPath: string;
+    let accountId: number;
+
+    before(async () => {
+      const tmpFile = fileSync({ postfix: ".xdc" });
+      invalidXdcPath = tmpFile.name;
+      accountId = await dc.rpc.addAccount();
+    });
+
+    it("should be able to draft set an invalid xdc", async function () {
+      const chat = await dc.rpc.createGroupChat(accountId, "xdc", false);
+      await expect(
+        dc.rpc.miscSetDraft(
+          accountId,
+          chat,
+          "",
+          invalidXdcPath,
+          "invalid.xdc",
+          null,
+          null
+        )
+      ).to.be.eventually.rejectedWith("Invalid xdc");
     });
   });
 

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -135,6 +135,7 @@ async fn test_set_draft_invalid_webxdc() -> Result<()> {
         include_bytes!("../../test-data/webxdc/invalid-no-zip-but-7z.xdc"),
     )?;
 
+    // draft should not fail
     chat_id.set_draft(&t, Some(&mut instance)).await?;
     chat_id.get_draft(&t).await.unwrap();
     Ok(())

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -129,7 +129,6 @@ async fn test_set_draft_invalid_webxdc() -> Result<()> {
     let t = TestContext::new_alice().await;
     let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "foo").await?;
 
-    // sending invalid .xdc as file is possible, but must not result in Viewtype::Webxdc
     let mut instance = create_webxdc_instance(
         &t,
         "invalid-no-zip-but-7z.xdc",
@@ -137,7 +136,7 @@ async fn test_set_draft_invalid_webxdc() -> Result<()> {
     )?;
 
     chat_id.set_draft(&t, Some(&mut instance)).await?;
-    let _draft = chat_id.get_draft(&t).await.unwrap();
+    chat_id.get_draft(&t).await.unwrap();
     Ok(())
 }
 

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -125,6 +125,23 @@ async fn test_send_invalid_webxdc() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_set_draft_invalid_webxdc() -> Result<()> {
+    let t = TestContext::new_alice().await;
+    let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "foo").await?;
+
+    // sending invalid .xdc as file is possible, but must not result in Viewtype::Webxdc
+    let mut instance = create_webxdc_instance(
+        &t,
+        "invalid-no-zip-but-7z.xdc",
+        include_bytes!("../../test-data/webxdc/invalid-no-zip-but-7z.xdc"),
+    )?;
+
+    chat_id.set_draft(&t, Some(&mut instance)).await?;
+    let _draft = chat_id.get_draft(&t).await.unwrap();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_send_special_webxdc_format() -> Result<()> {
     let t = TestContext::new_alice().await;
     let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "foo").await?;


### PR DESCRIPTION
When an invalid webxdc is set as draft, json-rpc's `get_draft` fails, because `get_webxdc_info` which it calls, fails because the zip reader can not read a non-zip file. With this change, any error occurring in `get_webxdc_info` is ignored and the None-variant is returned instead. I also added a test, that setting invalid xdcs is draft is fine core-wise and checked that the input field stays responsive when a fake.xdc produced like in #6826 is added to draft

close #6826