### PR TITLE
feat: sort apps by recently-updated

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3534,36 +3534,62 @@ pub async fn get_chat_media(
     msg_type2: Viewtype,
     msg_type3: Viewtype,
 ) -> Result<Vec<MsgId>> {
-    let list = context
-        .sql
-        .query_map(
-            "SELECT id
+    let list = if msg_type == Viewtype::Webxdc
+        && msg_type2 == Viewtype::Unknown
+        && msg_type3 == Viewtype::Unknown
+    {
+        context
+            .sql
+            .query_map(
+                "SELECT id
+               FROM msgs
+              WHERE (1=? OR chat_id=?)
+                AND chat_id != ?
+                AND type = ?
+                AND hidden=0
+              ORDER BY timestamp, id;",
+                (
+                    chat_id.is_none(),
+                    chat_id.unwrap_or_else(|| ChatId::new(0)),
+                    DC_CHAT_ID_TRASH,
+                    Viewtype::Webxdc,
+                ),
+                |row| row.get::<_, MsgId>(0),
+                |ids| Ok(ids.flatten().collect()),
+            )
+            .await?
+    } else {
+        context
+            .sql
+            .query_map(
+                "SELECT id
                FROM msgs
               WHERE (1=? OR chat_id=?)
                 AND chat_id != ?
                 AND type IN (?, ?, ?)
                 AND hidden=0
               ORDER BY timestamp, id;",
-            (
-                chat_id.is_none(),
-                chat_id.unwrap_or_else(|| ChatId::new(0)),
-                DC_CHAT_ID_TRASH,
-                msg_type,
-                if msg_type2 != Viewtype::Unknown {
-                    msg_type2
-                } else {
-                    msg_type
-                },
-                if msg_type3 != Viewtype::Unknown {
-                    msg_type3
-                } else {
-                    msg_type
-                },
-            ),
-            |row| row.get::<_, MsgId>(0),
-            |ids| Ok(ids.flatten().collect()),
-        )
-        .await?;
+                (
+                    chat_id.is_none(),
+                    chat_id.unwrap_or_else(|| ChatId::new(0)),
+                    DC_CHAT_ID_TRASH,
+                    msg_type,
+                    if msg_type2 != Viewtype::Unknown {
+                        msg_type2
+                    } else {
+                        msg_type
+                    },
+                    if msg_type3 != Viewtype::Unknown {
+                        msg_type3
+                    } else {
+                        msg_type
+                    },
+                ),
+                |row| row.get::<_, MsgId>(0),
+                |ids| Ok(ids.flatten().collect()),
+            )
+            .await?
+    };
     Ok(list)
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3534,7 +3534,6 @@ pub async fn get_chat_media(
     msg_type2: Viewtype,
     msg_type3: Viewtype,
 ) -> Result<Vec<MsgId>> {
-    // TODO This query could/should be converted to `AND type IN (?, ?, ?)`.
     let list = context
         .sql
         .query_map(
@@ -3542,7 +3541,7 @@ pub async fn get_chat_media(
                FROM msgs
               WHERE (1=? OR chat_id=?)
                 AND chat_id != ?
-                AND (type=? OR type=? OR type=?)
+                AND type IN (?, ?, ?)
                 AND hidden=0
               ORDER BY timestamp, id;",
             (

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3547,7 +3547,7 @@ pub async fn get_chat_media(
                 AND chat_id != ?
                 AND type = ?
                 AND hidden=0
-              ORDER BY timestamp, id;",
+              ORDER BY max(timestamp, timestamp_rcvd), id;",
                 (
                     chat_id.is_none(),
                     chat_id.unwrap_or_else(|| ChatId::new(0)),

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2958,7 +2958,7 @@ async fn test_get_chat_media_webxdc_order() -> Result<()> {
         Viewtype::Unknown,
     )
     .await?;
-    assert_eq!(media.get(0).unwrap(), &instance1_id);
+    assert_eq!(media.first().unwrap(), &instance1_id);
     assert_eq!(media.get(1).unwrap(), &instance2_id);
 
     // add a status update for the oder instance; that resorts the list
@@ -2973,7 +2973,7 @@ async fn test_get_chat_media_webxdc_order() -> Result<()> {
         Viewtype::Unknown,
     )
     .await?;
-    assert_eq!(media.get(0).unwrap(), &instance2_id);
+    assert_eq!(media.first().unwrap(), &instance2_id);
     assert_eq!(media.get(1).unwrap(), &instance1_id);
 
     Ok(())

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2925,6 +2925,61 @@ async fn test_get_chat_media() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_chat_media_webxdc_order() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = tcm.alice().await;
+    let bob = tcm.bob().await;
+    let chat = alice.create_chat(&bob).await;
+
+    let mut instance1 = Message::new(Viewtype::Webxdc);
+    instance1.set_file_from_bytes(
+        &alice,
+        "test1.xdc",
+        include_bytes!("../../test-data/webxdc/minimal.xdc"),
+        None,
+    )?;
+    let instance1_id = send_msg(&alice, chat.id, &mut instance1).await?;
+
+    let mut instance2 = Message::new(Viewtype::Webxdc);
+    instance2.set_file_from_bytes(
+        &alice,
+        "test2.xdc",
+        include_bytes!("../../test-data/webxdc/minimal.xdc"),
+        None,
+    )?;
+    let instance2_id = send_msg(&alice, chat.id, &mut instance2).await?;
+
+    // list is ordered oldest to newest, check that
+    let media = get_chat_media(
+        &alice,
+        Some(chat.id),
+        Viewtype::Webxdc,
+        Viewtype::Unknown,
+        Viewtype::Unknown,
+    )
+    .await?;
+    assert_eq!(media.get(0).unwrap(), &instance1_id);
+    assert_eq!(media.get(1).unwrap(), &instance2_id);
+
+    // add a status update for the oder instance; that resorts the list
+    alice
+        .send_webxdc_status_update(instance1_id, r#"{"payload": {"foo": "bar"}}"#)
+        .await?;
+    let media = get_chat_media(
+        &alice,
+        Some(chat.id),
+        Viewtype::Webxdc,
+        Viewtype::Unknown,
+        Viewtype::Unknown,
+    )
+    .await?;
+    assert_eq!(media.get(0).unwrap(), &instance2_id);
+    assert_eq!(media.get(1).unwrap(), &instance1_id);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_blob_renaming() -> Result<()> {
     let alice = TestContext::new_alice().await;
     let bob = TestContext::new_bob().await;


### PR DESCRIPTION
closes #6873 , see there for reasoning.

tested that on iOS already, works like a charm - and was much easier than expected as @iequidoo already updated `timestamp_rcvd` on status updates  in https://github.com/chatmail/core/pull/5388

~~a test is missing, ordering is not tested at all, will check if that is doable reasonably easy~~ EDIT: added a test