### PR TITLE
doc: Adapt the comment on `MessageObject.showPadlock`

### DIFF
--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -61,6 +61,13 @@ pub struct MessageObject {
 
     // summary - use/create another function if you need it
     subject: String,
+
+    /// True if the message was correctly encrypted&signed, false otherwise.
+    /// Historically, UIs showed a small padlock on the message then.
+    ///
+    /// Today, the UIs should instead show a small email-icon on the message
+    /// if `show_padlock` is `false`,
+    /// and nothing if it is `true`.
     show_padlock: bool,
     is_setupmessage: bool,
     is_info: bool,


### PR DESCRIPTION
We want to remove the padlock-icon from messages, and instead show an icon if the message was unencrypted: https://github.com/deltachat/deltachat-ios/pull/2746/

Now, it's confusing for implementers that there is a field `showPadlock` in the jsonrpc. This PR adapts the comment.

Two alternatives to this PR would be:
- Deprecated `showPadlock`, and introduce a field `wasEncrypted`
- Deprecated `showPadlock`, and introduce a field `showLetterIcon`, which is the inverse of `showPadlock`.