### PR TITLE
feat: get_showpadlock() returns true for device messages

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -834,6 +834,7 @@ impl Message {
     /// Returns true if padlock indicating message encryption should be displayed in the UI.
     pub fn get_showpadlock(&self) -> bool {
         self.param.get_int(Param::GuaranteeE2ee).unwrap_or_default() != 0
+            || self.from_id == ContactId::DEVICE
     }
 
     /// Returns true if message is auto-generated.


### PR DESCRIPTION
Follow-up to https://github.com/chatmail/core/pull/6925, reasoning is in this comment: https://github.com/chatmail/core/pull/6925#issuecomment-2988282425