### PR TITLE
feat: Don't send system messages to unencrypted groups

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4235,11 +4235,16 @@ async fn rename_ex(
                     (new_name.to_string(), chat_id),
                 )
                 .await?;
-            if chat.is_promoted()
-                && !chat.is_mailing_list()
-                && chat.typ != Chattype::Broadcast
-                && sanitize_single_line(&chat.name) != new_name
+            if !chat.is_promoted()
+                || chat.is_mailing_list()
+                || chat.typ == Chattype::Broadcast
+                || sanitize_single_line(&chat.name) == new_name
             {
+            } else if chat.grpid.is_empty() {
+                chat_id
+                    .update_timestamp(context, Param::GroupNameTimestamp, smeared_time(context))
+                    .await?;
+            } else {
                 msg.viewtype = Viewtype::Text;
                 msg.text =
                     stock_str::msg_grp_name(context, &chat.name, &new_name, ContactId::SELF).await;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4312,7 +4312,7 @@ pub async fn set_chat_profile_image(
         msg.text = stock_str::msg_grp_img_changed(context, ContactId::SELF).await;
     }
     chat.update_param(context).await?;
-    if chat.is_promoted() && !chat.is_mailing_list() {
+    if chat.is_promoted() {
         msg.id = send_msg(context, chat_id, &mut msg).await?;
         context.emit_msgs_changed(chat_id, msg.id);
     }


### PR DESCRIPTION
See commit messages.
NB: Self-removal  from unencrypted (ad hoc) groups returns an error now, otherwise remaining members won't know about it. It should be disabled in UIs and the user should resolve it on their own (e.g. by asking other members).