### PR TITLE
fix!: use `Viewtype::File` for messages with invalid images, images of unknown size, huge images (#6825)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -193,6 +193,9 @@ pub(crate) const WORSE_AVATAR_BYTES: usize = 20_000; // this also fits to Outloo
 pub const BALANCED_IMAGE_SIZE: u32 = 1280;
 pub const WORSE_IMAGE_SIZE: u32 = 640;
 
+// Limit displayed images ~8.3 megapixels (3840 × 2160)
+pub const MAX_IMAGE_PIXELS: u32 = 8294400;
+
 // Key for the folder configuration version (see below).
 pub(crate) const DC_FOLDERS_CONFIGURED_KEY: &str = "folders_configured";
 // this value can be increased if the folder configuration is changed and must be redone on next program start

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1380,6 +1380,20 @@ impl MimeMessage {
             } else {
                 Viewtype::File
             }
+        } else if msg_type == Viewtype::Image
+            || msg_type == Viewtype::Gif
+            || msg_type == Viewtype::Sticker
+        {
+            match get_filemeta(decoded_data) {
+                // image size is known, not too big, keep msg_type:
+                Ok((width, height)) if width * height <= constants::MAX_IMAGE_PIXELS => {
+                    part.param.set_i64(Param::Width, width.into());
+                    part.param.set_i64(Param::Height, height.into());
+                    msg_type
+                }
+                // image is too big or size is unknown, display as file:
+                _ => Viewtype::File,
+            }
         } else {
             msg_type
         };
@@ -1399,13 +1413,6 @@ impl MimeMessage {
                 }
             };
         info!(context, "added blobfile: {:?}", blob.as_name());
-
-        if mime_type.type_() == mime::IMAGE {
-            if let Ok((width, height)) = get_filemeta(decoded_data) {
-                part.param.set_int(Param::Width, width as i32);
-                part.param.set_int(Param::Height, height as i32);
-            }
-        }
 
         part.typ = msg_type;
         part.org_filename = Some(filename.to_string());

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -827,15 +827,7 @@ Content-Transfer-Encoding: base64
 Content-Disposition: inline;
  filename="JPEG_filename.jpg"
 
-ISVb1L3m7z15Wy5w97a2cJg6W8P8YKOYfWn3PJ/UCSFcvCPtvBhcXieiN3M3ljguzG4XK7BnGgxG
-acAQdY8e0cWz1n+zKPNeNn4Iu3GXAXz4/IPksHk54inl1//0Lv8ggZjljfjnf0q1SPftYI7lpZWT
-/4aTCkimRrAIcwrQJPnZJRb7BPSC6kfn1QJHMv77mRMz2+4WbdfpyPQQ0CWLJsgVXtBsSMf2Awal
-n+zZzhGpXyCbWTEw1ccqZcK5KaiKNqWv51N4yVXw9dzJoCvxbYtCFGZZJdx7c+ObDotaF1/9KY4C
-xJjgK9/NgTXCZP1jYm0XIBnJsFSNg0pnMRETttTuGbOVi1/s/F1RGv5RNZsCUt21d9FhkWQQXsd2
-rOzDgTdag6BQCN3hSU9eKW/GhNBuMibRN9eS7Sm1y2qFU1HgGJBQfPPRPLKxXaNi++Zt0tnon2IU
-8pg5rP/IvStXYQNUQ9SiFdfAUkLU5b1j8ltnka8xl+oXsleSG44GPz6kM0RmwUrGkl4z/+NfHSsI
-K+TuvC7qOah0WLFhcsXWn2+dDV1bXuAeC769TkqkpHhdXfUHnVgK3Pv7u3rVPT5AMeFUGxRB2dP4
-CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
+iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAAAAABoYUP1AAAAAXNSR0IArs4c6QAAAo1JREFUKJFdkdFuG0UUhr/szuxkxtlduzVx00jGUAhcI56CF0DiHXgFHqDiMfoCvAJC4gIJEBdVaZoGOY5dJ45r7zozmRlvzIVDm3Iu//PpP7/+s/OC/0+UREkEGZGr5N6mAX78MwISQEYJ6j6QYqZf7fzsYyRGJDISuQ9g6uMjW00WRCSRCP4DwNSEg496v828fC++B4yBGro7h+PliiiJHtR9B1vrmbtg359cOk+UqA8cDJm+eHu8yDfii6sAxK0u3hlsnPFn1WvT4XxYUqqtKu8cTMNKT8+nz3/aaWft3svKecBD/O9ETu2O//G7fXt5mHX2xwGP32aIEUNNvX/uh3z2pAkcKD+9XOLVNoMESw7YC+aPP8nqqSluyiuVaZRXCKLEQK3PxsP27UHe1lXV9eczCu2V8ippJA2gz+YTNTK9ttZOoYr+aeXwHp+k245cnFRNt1tmMJg3XV0dXQd3F5LcGn5fDnVQgwINRyFvtddnNmwBSW1qXfzNSDwoM+2A+aTbShfDd89Ka9ybiiLvGa33gK8THrWfVNUSSGLTALMRo/xBXnLbACu3QtRXY+sgkWnawKxCcLjPtr29gVZdPTidBUcSaXJeTfUL+mW4631Fmse+772xIGjSza/KTW/MYE/UCXPbEWs//Xxvqf8qZgYhG0jt8cnTnJpEgfDQ6rvE0n9tq66ICafil5OnOYt0hY94FUPoxI136uPpw4VIYNd+M5utrqvGpg0hc50bRl6BvLanX4pb/3347uWi/WgNHtYyyrdwszsX5fjZtwghy7C5sK2WgUoErcjIoEWr4fAHHhoRP+XZ86L/uMAarLFgsMBaAJhM8Ief9Ey7yHSmyXTp0GRoF7KQEdD/ArmtONKkgCleAAAAAElFTkSuQmCC
 
 
 ----11019878869865180--
@@ -900,15 +892,7 @@ Content-ID: <part1.9DFA679B.52A88D69@example.org>
 Content-Disposition: inline;
  filename="1.png"
 
-ISVb1L3m7z15Wy5w97a2cJg6W8P8YKOYfWn3PJ/UCSFcvCPtvBhcXieiN3M3ljguzG4XK7BnGgxG
-acAQdY8e0cWz1n+zKPNeNn4Iu3GXAXz4/IPksHk54inl1//0Lv8ggZjljfjnf0q1SPftYI7lpZWT
-/4aTCkimRrAIcwrQJPnZJRb7BPSC6kfn1QJHMv77mRMz2+4WbdfpyPQQ0CWLJsgVXtBsSMf2Awal
-n+zZzhGpXyCbWTEw1ccqZcK5KaiKNqWv51N4yVXw9dzJoCvxbYtCFGZZJdx7c+ObDotaF1/9KY4C
-xJjgK9/NgTXCZP1jYm0XIBnJsFSNg0pnMRETttTuGbOVi1/s/F1RGv5RNZsCUt21d9FhkWQQXsd2
-rOzDgTdag6BQCN3hSU9eKW/GhNBuMibRN9eS7Sm1y2qFU1HgGJBQfPPRPLKxXaNi++Zt0tnon2IU
-8pg5rP/IvStXYQNUQ9SiFdfAUkLU5b1j8ltnka8xl+oXsleSG44GPz6kM0RmwUrGkl4z/+NfHSsI
-K+TuvC7qOah0WLFhcsXWn2+dDV1bXuAeC769TkqkpHhdXfUHnVgK3Pv7u3rVPT5AMeFUGxRB2dP4
-CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
+iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAAAAABoYUP1AAAAAXNSR0IArs4c6QAAAo1JREFUKJFdkdFuG0UUhr/szuxkxtlduzVx00jGUAhcI56CF0DiHXgFHqDiMfoCvAJC4gIJEBdVaZoGOY5dJ45r7zozmRlvzIVDm3Iu//PpP7/+s/OC/0+UREkEGZGr5N6mAX78MwISQEYJ6j6QYqZf7fzsYyRGJDISuQ9g6uMjW00WRCSRCP4DwNSEg496v828fC++B4yBGro7h+PliiiJHtR9B1vrmbtg359cOk+UqA8cDJm+eHu8yDfii6sAxK0u3hlsnPFn1WvT4XxYUqqtKu8cTMNKT8+nz3/aaWft3svKecBD/O9ETu2O//G7fXt5mHX2xwGP32aIEUNNvX/uh3z2pAkcKD+9XOLVNoMESw7YC+aPP8nqqSluyiuVaZRXCKLEQK3PxsP27UHe1lXV9eczCu2V8ippJA2gz+YTNTK9ttZOoYr+aeXwHp+k245cnFRNt1tmMJg3XV0dXQd3F5LcGn5fDnVQgwINRyFvtddnNmwBSW1qXfzNSDwoM+2A+aTbShfDd89Ka9ybiiLvGa33gK8THrWfVNUSSGLTALMRo/xBXnLbACu3QtRXY+sgkWnawKxCcLjPtr29gVZdPTidBUcSaXJeTfUL+mW4631Fmse+772xIGjSza/KTW/MYE/UCXPbEWs//Xxvqf8qZgYhG0jt8cnTnJpEgfDQ6rvE0n9tq66ICafil5OnOYt0hY94FUPoxI136uPpw4VIYNd+M5utrqvGpg0hc50bRl6BvLanX4pb/3347uWi/WgNHtYyyrdwszsX5fjZtwghy7C5sK2WgUoErcjIoEWr4fAHHhoRP+XZ86L/uMAarLFgsMBaAJhM8Ief9Ey7yHSmyXTp0GRoF7KQEdD/ArmtONKkgCleAAAAAElFTkSuQmCC
 --------------10CC6C2609EB38DA782C5CA9--
 
 --------------779C1631600DF3DB8C02E53A--"#;
@@ -971,15 +955,7 @@ Content-Type: image/jpeg;
 Content-Transfer-Encoding: base64
 Content-ID: <image001.jpg@01D622B3.C9D8D750>
 
-ISVb1L3m7z15Wy5w97a2cJg6W8P8YKOYfWn3PJ/UCSFcvCPtvBhcXieiN3M3ljguzG4XK7BnGgxG
-acAQdY8e0cWz1n+zKPNeNn4Iu3GXAXz4/IPksHk54inl1//0Lv8ggZjljfjnf0q1SPftYI7lpZWT
-/4aTCkimRrAIcwrQJPnZJRb7BPSC6kfn1QJHMv77mRMz2+4WbdfpyPQQ0CWLJsgVXtBsSMf2Awal
-n+zZzhGpXyCbWTEw1ccqZcK5KaiKNqWv51N4yVXw9dzJoCvxbYtCFGZZJdx7c+ObDotaF1/9KY4C
-xJjgK9/NgTXCZP1jYm0XIBnJsFSNg0pnMRETttTuGbOVi1/s/F1RGv5RNZsCUt21d9FhkWQQXsd2
-rOzDgTdag6BQCN3hSU9eKW/GhNBuMibRN9eS7Sm1y2qFU1HgGJBQfPPRPLKxXaNi++Zt0tnon2IU
-8pg5rP/IvStXYQNUQ9SiFdfAUkLU5b1j8ltnka8xl+oXsleSG44GPz6kM0RmwUrGkl4z/+NfHSsI
-K+TuvC7qOah0WLFhcsXWn2+dDV1bXuAeC769TkqkpHhdXfUHnVgK3Pv7u3rVPT5AMeFUGxRB2dP4
-CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
+iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAAAAABoYUP1AAAAAXNSR0IArs4c6QAAAo1JREFUKJFdkdFuG0UUhr/szuxkxtlduzVx00jGUAhcI56CF0DiHXgFHqDiMfoCvAJC4gIJEBdVaZoGOY5dJ45r7zozmRlvzIVDm3Iu//PpP7/+s/OC/0+UREkEGZGr5N6mAX78MwISQEYJ6j6QYqZf7fzsYyRGJDISuQ9g6uMjW00WRCSRCP4DwNSEg496v828fC++B4yBGro7h+PliiiJHtR9B1vrmbtg359cOk+UqA8cDJm+eHu8yDfii6sAxK0u3hlsnPFn1WvT4XxYUqqtKu8cTMNKT8+nz3/aaWft3svKecBD/O9ETu2O//G7fXt5mHX2xwGP32aIEUNNvX/uh3z2pAkcKD+9XOLVNoMESw7YC+aPP8nqqSluyiuVaZRXCKLEQK3PxsP27UHe1lXV9eczCu2V8ippJA2gz+YTNTK9ttZOoYr+aeXwHp+k245cnFRNt1tmMJg3XV0dXQd3F5LcGn5fDnVQgwINRyFvtddnNmwBSW1qXfzNSDwoM+2A+aTbShfDd89Ka9ybiiLvGa33gK8THrWfVNUSSGLTALMRo/xBXnLbACu3QtRXY+sgkWnawKxCcLjPtr29gVZdPTidBUcSaXJeTfUL+mW4631Fmse+772xIGjSza/KTW/MYE/UCXPbEWs//Xxvqf8qZgYhG0jt8cnTnJpEgfDQ6rvE0n9tq66ICafil5OnOYt0hY94FUPoxI136uPpw4VIYNd+M5utrqvGpg0hc50bRl6BvLanX4pb/3347uWi/WgNHtYyyrdwszsX5fjZtwghy7C5sK2WgUoErcjIoEWr4fAHHhoRP+XZ86L/uMAarLFgsMBaAJhM8Ief9Ey7yHSmyXTp0GRoF7KQEdD/ArmtONKkgCleAAAAAElFTkSuQmCC
 
 ------=_NextPart_000_0003_01D622B3.CA753E60--
 "#;
@@ -2009,5 +1985,50 @@ async fn test_protected_date() -> Result<()> {
     // Timestamp that the sender has put into the message
     // should always be displayed as is on the receiver.
     assert_eq!(alice_msg.get_timestamp(), bob_msg.get_timestamp());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_huge_image_becomes_file() -> Result<()> {
+    let t = TestContext::new_alice().await;
+    let msg_id = receive_imf(
+        &t,
+        include_bytes!("../../test-data/message/image_huge_36M.eml"),
+        false,
+    )
+    .await?
+    .unwrap()
+    .msg_ids[0];
+    let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
+    // Huge image should be treated as file:
+    assert_eq!(msg.viewtype, Viewtype::File);
+    assert!(msg.get_file(&t).is_some());
+    assert_eq!(msg.get_filename().unwrap(), "huge_image.png");
+    assert_eq!(msg.get_filemime().unwrap(), "image/png");
+    // File has no width or height
+    assert_eq!(msg.param.get_int(Param::Width).unwrap_or_default(), 0);
+    assert_eq!(msg.param.get_int(Param::Height).unwrap_or_default(), 0);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_4k_image_stays_image() -> Result<()> {
+    let t = TestContext::new_alice().await;
+    let msg_id = receive_imf(
+        &t,
+        include_bytes!("../../test-data/message/image_4k.eml"),
+        false,
+    )
+    .await?
+    .unwrap()
+    .msg_ids[0];
+    let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
+    // 4K image should be treated as image:
+    assert_eq!(msg.viewtype, Viewtype::Image);
+    assert!(msg.get_file(&t).is_some());
+    assert_eq!(msg.get_filename().unwrap(), "4k_image.png");
+    assert_eq!(msg.get_filemime().unwrap(), "image/png");
+    assert_eq!(msg.param.get_int(Param::Width).unwrap_or_default(), 3840);
+    assert_eq!(msg.param.get_int(Param::Height).unwrap_or_default(), 2160);
     Ok(())
 }

--- a/test-data/message/image_4k.eml
+++ b/test-data/message/image_4k.eml
@@ -1,0 +1,28 @@
+Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)
+From: Test Sender <sender@testrun.org>
+Subject: Large image test
+To: alice@example.org
+Message-ID: <big-image-test@testrun.org>
+Date: Thu, 17 Dec 2020 15:38:45 +0100
+User-Agent: Test-Agent/1.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------BIG_IMAGE_BOUNDARY"
+Content-Language: en-US
+
+This is a multi-part message in MIME format.
+--------------BIG_IMAGE_BOUNDARY
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Here is a 4k image
+
+--------------BIG_IMAGE_BOUNDARY
+Content-Type: image/png;
+ name="4k_image.png"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="4k_image.png"
+
+iVBORw0KGgoAAAANSUhEUgAADwAAAAhwCAIAAAAf3FwlAAAAEElEQVR4nAEFAPr/AP////8AAAAFCeiupAAAAABJRU5ErkJggg==
+--------------BIG_IMAGE_BOUNDARY--

--- a/test-data/message/image_huge_36M.eml
+++ b/test-data/message/image_huge_36M.eml
@@ -1,0 +1,28 @@
+Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)
+From: Test Sender <sender@testrun.org>
+Subject: Large image test
+To: alice@example.org
+Message-ID: <huge-image-test@testrun.org>
+Date: Thu, 17 Dec 2020 15:38:45 +0100
+User-Agent: Test-Agent/1.0
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="------------HUGE_IMAGE_BOUNDARY"
+Content-Language: en-US
+
+This is a multi-part message in MIME format.
+--------------HUGE_IMAGE_BOUNDARY
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Here is a huge image
+
+--------------HUGE_IMAGE_BOUNDARY
+Content-Type: image/png;
+ name="huge_image.png"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="huge_image.png"
+
+iVBORw0KGgoAAAANSUhEUgAAF3AAABdwCAIAAABsNhAUAAAAEElEQVR4nAEFAPr/AP////8AAAAFCeiupAAAAABJRU5ErkJggg==
+--------------HUGE_IMAGE_BOUNDARY--


### PR DESCRIPTION
BREAKING CHANGE: messages with invalid images, images of unknown size, huge images, will have Viewtype::File

After changing the logic of Viewtype selection, I had to fix 3 old tests that used invalid Base64 image data.