### PR TITLE
api(CFFI): Add dc_contact_is_key_contact()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5286,6 +5286,20 @@ int             dc_contact_is_bot            (dc_contact_t* contact);
 
 
 /**
+ * Returns whether contact is a key-contact,
+ * i.e. it is identified by the public key
+ * rather than the email address.
+ *
+ * If so, all messages to and from this contact are encrypted.
+ *
+ * @memberof dc_contact_t
+ * @param contact The contact object.
+ * @return 1 if the contact is a key-contact, 0 if it is an address-contact.
+ */
+int             dc_contact_is_key_contact    (dc_contact_t* contact);
+
+
+/**
  * Return the contact ID that verified a contact.
  *
  * If the function returns non-zero result,

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4304,6 +4304,15 @@ pub unsafe extern "C" fn dc_contact_is_bot(contact: *mut dc_contact_t) -> libc::
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_contact_is_key_contact(contact: *mut dc_contact_t) -> libc::c_int {
+    if contact.is_null() {
+        eprintln!("ignoring careless call to dc_contact_is_key_contact()");
+        return 0;
+    }
+    (*contact).contact.is_key_contact() as libc::c_int
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_verifier_id()");


### PR DESCRIPTION
We need this for https://github.com/deltachat/deltachat-android/pull/3793 because it's not clear whether Android should switch to JsonRPC for everything, because of concerns that JsonRPC might be a lot slower than the CFFI (although we still need to measure that precisely - I only did some rough measurements, in which JsonRPC was very slow).