### PR TITLE
fix: Remove listverified from repl

### DIFF
--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -396,7 +396,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  react <msg-id> [<reaction>]\n\
                  ===========================Contact commands==\n\
                  listcontacts [<query>]\n\
-                 listverified [<query>]\n\
                  addcontact [<name>] <addr>\n\
                  contactinfo <contact-id>\n\
                  delcontact <contact-id>\n\

--- a/deltachat-repl/src/main.rs
+++ b/deltachat-repl/src/main.rs
@@ -228,9 +228,8 @@ const MESSAGE_COMMANDS: [&str; 9] = [
     "download",
     "react",
 ];
-const CONTACT_COMMANDS: [&str; 9] = [
+const CONTACT_COMMANDS: [&str; 8] = [
     "listcontacts",
-    "listverified",
     "addcontact",
     "contactinfo",
     "delcontact",


### PR DESCRIPTION
- The implementation of listverified was removed in commit 37dc1f5ca05bdae8cd911ad495faa2f0e1c6d52a, but it still shows up in the help and in the auto-complete grammar.
- Removed listverified where it still appears.

closes #6971