### PR TITLE
feat: Don't apply chat name and avatar changes from non-members

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2882,17 +2882,17 @@ async fn apply_group_changes(
         }
     }
 
-    apply_chat_name_and_avatar_changes(
-        context,
-        mime_parser,
-        from_id,
-        chat,
-        &mut send_event_chat_modified,
-        &mut better_msg,
-    )
-    .await?;
-
     if is_from_in_chat {
+        apply_chat_name_and_avatar_changes(
+            context,
+            mime_parser,
+            from_id,
+            chat,
+            &mut send_event_chat_modified,
+            &mut better_msg,
+        )
+        .await?;
+
         if chat.member_list_is_stale(context).await? {
             info!(context, "Member list is stale.");
             let mut new_members: HashSet<ContactId> =


### PR DESCRIPTION
Non-members can't modify the member list (incl. adding themselves), modify an ephemeral timer, so they shouldn't be able to change the group name or avatar, just for consistency. Even if messages are reordered and a group name change from a new member arrives before its addition, the new group name will be applied on a receipt of the next message following the addition message because Chat-Group-Name-Timestamp increases. While Delta Chat groups aimed for chatting with trusted contacts, accepting group changes from everyone knowing Chat-Group-Id means that if any of the past members have the key compromised, the group should be recreated which looks impractical.

This is in continuation of the discussion in #6901.