### PR TITLE
feat: Log failed debug assertions in all configurations

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -27,6 +27,7 @@ use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::imap::{FolderMeaning, Imap, ServerMetadata};
 use crate::key::{load_self_secret_key, self_fingerprint};
 use crate::log::{info, warn};
+use crate::logged_debug_assert;
 use crate::login_param::{ConfiguredLoginParam, EnteredLoginParam};
 use crate::message::{self, Message, MessageState, MsgId};
 use crate::param::{Param, Params};
@@ -660,8 +661,16 @@ impl Context {
     /// or [`Self::emit_msgs_changed_without_msg_id`] should be used
     /// instead of this function.
     pub fn emit_msgs_changed(&self, chat_id: ChatId, msg_id: MsgId) {
-        debug_assert!(!chat_id.is_unset());
-        debug_assert!(!msg_id.is_unset());
+        logged_debug_assert!(
+            self,
+            !chat_id.is_unset(),
+            "emit_msgs_changed: chat_id is unset."
+        );
+        logged_debug_assert!(
+            self,
+            !msg_id.is_unset(),
+            "emit_msgs_changed: msg_id is unset."
+        );
 
         self.emit_event(EventType::MsgsChanged { chat_id, msg_id });
         chatlist_events::emit_chatlist_changed(self);
@@ -670,7 +679,11 @@ impl Context {
 
     /// Emits a MsgsChanged event with specified chat and without message id.
     pub fn emit_msgs_changed_without_msg_id(&self, chat_id: ChatId) {
-        debug_assert!(!chat_id.is_unset());
+        logged_debug_assert!(
+            self,
+            !chat_id.is_unset(),
+            "emit_msgs_changed_without_msg_id: chat_id is unset."
+        );
 
         self.emit_event(EventType::MsgsChanged {
             chat_id,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -31,6 +31,7 @@ use crate::key::self_fingerprint_opt;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey};
 use crate::log::LogExt;
 use crate::log::{info, warn};
+use crate::logged_debug_assert;
 use crate::message::{
     self, Message, MessageState, MessengerMessage, MsgId, Viewtype, rfc724_mid_exists,
 };
@@ -3835,7 +3836,11 @@ async fn lookup_key_contact_by_fingerprint(
     context: &Context,
     fingerprint: &str,
 ) -> Result<Option<ContactId>> {
-    debug_assert!(!fingerprint.is_empty());
+    logged_debug_assert!(
+        context,
+        !fingerprint.is_empty(),
+        "lookup_key_contact_by_fingerprint: fingerprint is empty."
+    );
     if fingerprint.is_empty() {
         // Avoid accidentally looking up a non-key-contact.
         return Ok(None);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -16,6 +16,7 @@ use crate::events::EventType;
 use crate::headerdef::HeaderDef;
 use crate::key::{DcKey, Fingerprint, load_self_public_key};
 use crate::log::{error, info, warn};
+use crate::logged_debug_assert;
 use crate::message::{Message, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::param::Param;
@@ -32,9 +33,10 @@ use qrinvite::QrInvite;
 use crate::token::Namespace;
 
 fn inviter_progress(context: &Context, contact_id: ContactId, progress: usize) {
-    debug_assert!(
+    logged_debug_assert!(
+        context,
         progress <= 1000,
-        "value in range 0..1000 expected with: 0=error, 1..999=progress, 1000=success"
+        "inviter_progress: contact {contact_id}, progress={progress}, but value in range 0..1000 expected with: 0=error, 1..999=progress, 1000=success."
     );
     context.emit_event(EventType::SecurejoinInviterProgress {
         contact_id,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -754,7 +754,7 @@ impl TestContext {
     pub async fn add_or_lookup_address_contact(&self, other: &TestContext) -> Contact {
         let contact_id = self.add_or_lookup_address_contact_id(other).await;
         let contact = Contact::get_by_id(&self.ctx, contact_id).await.unwrap();
-        debug_assert_eq!(contact.is_key_contact(), false);
+        assert_eq!(contact.is_key_contact(), false);
         contact
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -801,5 +801,17 @@ macro_rules! ensure_and_debug_assert_ne {
     };
 }
 
+/// Logs a warning if a condition is not satisfied.
+/// In non-optimized builds, panics also if so.
+#[macro_export]
+macro_rules! logged_debug_assert {
+    ($ctx:expr, $cond:expr, $($arg:tt)*) => {
+        if !$cond {
+            warn!($ctx, $($arg)*);
+        }
+        debug_assert!($cond, $($arg)*);
+    };
+}
+
 #[cfg(test)]
 mod tools_tests;


### PR DESCRIPTION
Add `logged_debug_assert` macro logging a warning if a condition is not satisfied, before invoking `debug_assert!`, and use this macro where `Context` is accessible (i.e. don't change function signatures for now).
Follow-up to 0359481ba487d7eea7747a4c401dfdd97423e68a.