### PR TITLE
fix: List e-mail contacts in repl listcontacts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,26 +84,29 @@ Create a contact:
 
 ```
 > addcontact yourfriends@email.org
-Command executed successfully.
 ```
 
 List contacts:
 
 ```
 > listcontacts
-Contact#10: <name unset> <yourfriends@email.org>
-Contact#1: Me √√ <your@email.org>
+Contact#Contact#Self: Me √ <your@email.org>
+1 key contacts.
+Contact#Contact#10: yourfriends@email.org <yourfriends@email.org>
+1 address contacts.
 ```
 
 Create a chat with your friend and send a message:
 
 ```
 > createchat 10
-Single#10 created successfully.
-> chat 10
-Single#10: yourfriends@email.org [yourfriends@email.org]
+Single#Chat#12 created successfully.
+> chat 12
+Selecting chat Chat#12
+Single#Chat#12: yourfriends@email.org [yourfriends@email.org] Icon: profile-db-blobs/4138c52e5bc1c576cda7dd44d088c07.png
+0 messages.
+81.252µs to create this list, 123.625µs to mark all messages as noticed.
 > send hi
-Message sent.
 ```
 
 List messages when inside a chat:

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -1151,7 +1151,10 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         "listcontacts" | "contacts" => {
             let contacts = Contact::get_all(&context, DC_GCL_ADD_SELF, Some(arg1)).await?;
             log_contactlist(&context, &contacts).await?;
-            println!("{} contacts.", contacts.len());
+            println!("{} key contacts.", contacts.len());
+            let addrcontacts = Contact::get_all(&context, DC_GCL_ADDRESS, Some(arg1)).await?;
+            log_contactlist(&context, &addrcontacts).await?;
+            println!("{} address contacts.", addrcontacts.len());
         }
         "addcontact" => {
             ensure!(!arg1.is_empty(), "Arguments [<name>] <addr> expected.");


### PR DESCRIPTION
- After the revisions to support key contacts, the 'listcontacts' command in the repl only lists key-contacts.  A separate flag now has to be passed to Contact::get_all() to list address contacts. This makes it difficult to run the example in README.md because we need to see the new contact so we can get its ID for the next command in the example, that creates a chat by ID.
- Revised 'listcontacts' command to make a second call to Contact::get_all() with the DC_GCL_ADDRESS flag, then print the e-mail contacts after the key contacts.
- Revised configuration example in top-level README.md to reflect current command output.

fixes #7011