### PR TITLE
docs: deprecate protection-broken and related stuff

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3860,7 +3860,7 @@ int             dc_chat_is_encrypted         (const dc_chat_t *chat);
  * The UI should let the user confirm that this is OK with a message like
  * `Bob sent a message from another device. Tap to learn more` and then call dc_accept_chat().
  *
- * @deprecated 2025-17 chats protection cannot break any longer
+ * @deprecated 2025-07 chats protection cannot break any longer
  * @memberof dc_chat_t
  * @param chat The chat object.
  * @return 1=chat protection broken, 0=otherwise.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -503,13 +503,6 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `gossip_period` = How often to gossip Autocrypt keys in chats with multiple recipients, in
  *                    seconds. 2 days by default.
  *                    This is not supposed to be changed by UIs and only used for testing.
- * - `verified_one_on_one_chats` = Feature flag for verified 1:1 chats; the UI should set it
- *                    to 1 if it supports verified 1:1 chats.
- *                    Regardless of this setting, `dc_chat_is_protected()` returns true while the key is verified,
- *                    and when the key changes, an info message is posted into the chat.
- *                    0=Nothing else happens when the key changes.
- *                    1=After the key changed, `dc_chat_can_send()` returns false and `dc_chat_is_protection_broken()` returns true
- *                    until `dc_accept_chat()` is called.
  * - `is_chatmail` = 1 if the the server is a chatmail server, 0 otherwise.
  * - `is_muted`     = Whether a context is muted by the user.
  *                    Muted contexts should not sound, vibrate or show notifications.
@@ -3818,15 +3811,12 @@ int             dc_chat_can_send              (const dc_chat_t* chat);
 /**
  * Check if a chat is protected.
  *
- * End-to-end encryption is guaranteed in protected chats
- * and only verified contacts
+ * Only verified contacts
  * as determined by dc_contact_is_verified()
  * can be added to protected chats.
  *
  * Protected chats are created using dc_create_group_chat()
  * by setting the 'protect' parameter to 1.
- * 1:1 chats become protected or unprotected automatically
- * if `verified_one_on_one_chats` setting is enabled.
  *
  * UI should display a green checkmark
  * in the chat title,
@@ -3869,6 +3859,8 @@ int             dc_chat_is_encrypted         (const dc_chat_t *chat);
  *
  * The UI should let the user confirm that this is OK with a message like
  * `Bob sent a message from another device. Tap to learn more` and then call dc_accept_chat().
+ *
+ * @deprecated 2025-17 chats protection cannot break any longer
  * @memberof dc_chat_t
  * @param chat The chat object.
  * @return 1=chat protection broken, 0=otherwise.

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -70,7 +70,7 @@ pub struct FullChat {
     fresh_message_counter: usize,
     // is_group - please check over chat.type in frontend instead
     is_contact_request: bool,
-    is_protection_broken: bool, // deprecated
+    is_protection_broken: bool, // deprecated 2025-07
     is_device_chat: bool,
     self_in_group: bool,
     is_muted: bool,

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -70,7 +70,7 @@ pub struct FullChat {
     fresh_message_counter: usize,
     // is_group - please check over chat.type in frontend instead
     is_contact_request: bool,
-    is_protection_broken: bool,
+    is_protection_broken: bool, // deprecated
     is_device_chat: bool,
     self_in_group: bool,
     is_muted: bool,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -118,7 +118,7 @@ pub(crate) enum CantSendReason {
     /// The chat is a contact request, it needs to be accepted before sending a message.
     ContactRequest,
 
-    /// The chat was protected, but now a new message came in
+    /// Deprecated. The chat was protected, but now a new message came in
     /// which was not encrypted / signed correctly.
     ProtectionBroken,
 
@@ -1935,7 +1935,7 @@ impl Chat {
         Ok(is_encrypted)
     }
 
-    /// Returns true if the chat was protected, and then an incoming message broke this protection.
+    /// Deprecated. Returns true if the chat was protected, and then an incoming message broke this protection.
     ///
     /// This function is only useful if the UI enabled the `verified_one_on_one_chats` feature flag,
     /// otherwise it will return false for all chats.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1935,7 +1935,7 @@ impl Chat {
         Ok(is_encrypted)
     }
 
-    /// Deprecated. Returns true if the chat was protected, and then an incoming message broke this protection.
+    /// Deprecated 2025-07. Returns true if the chat was protected, and then an incoming message broke this protection.
     ///
     /// This function is only useful if the UI enabled the `verified_one_on_one_chats` feature flag,
     /// otherwise it will return false for all chats.

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,7 +417,7 @@ pub enum Config {
     #[strum(props(default = "172800"))]
     GossipPeriod,
 
-    /// Deprecated. Feature flag for verified 1:1 chats; the UI should set it
+    /// Deprecated 2025-07. Feature flag for verified 1:1 chats; the UI should set it
     /// to 1 if it supports verified 1:1 chats.
     /// Regardless of this setting, `chat.is_protected()` returns true while the key is verified,
     /// and when the key changes, an info message is posted into the chat.

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,7 +417,7 @@ pub enum Config {
     #[strum(props(default = "172800"))]
     GossipPeriod,
 
-    /// Feature flag for verified 1:1 chats; the UI should set it
+    /// Deprecated. Feature flag for verified 1:1 chats; the UI should set it
     /// to 1 if it supports verified 1:1 chats.
     /// Regardless of this setting, `chat.is_protected()` returns true while the key is verified,
     /// and when the key changes, an info message is posted into the chat.

--- a/src/context.rs
+++ b/src/context.rs
@@ -1043,7 +1043,7 @@ impl Context {
             self.get_config_int(Config::GossipPeriod).await?.to_string(),
         );
         res.insert(
-            "verified_one_on_one_chats", // deprecated
+            "verified_one_on_one_chats", // deprecated 2025-07
             self.get_config_bool(Config::VerifiedOneOnOneChats)
                 .await?
                 .to_string(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -1043,7 +1043,7 @@ impl Context {
             self.get_config_int(Config::GossipPeriod).await?.to_string(),
         );
         res.insert(
-            "verified_one_on_one_chats",
+            "verified_one_on_one_chats", // deprecated
             self.get_config_bool(Config::VerifiedOneOnOneChats)
                 .await?
                 .to_string(),

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -804,7 +804,7 @@ async fn export_database(
                 "UPDATE backup.config SET value='0' WHERE keyname='verified_one_on_one_chats';",
                 [],
             )
-            .ok(); // Deprecated. If verified_one_on_one_chats was not set, this errors, which we ignore
+            .ok(); // Deprecated 2025-07. If verified_one_on_one_chats was not set, this errors, which we ignore
             conn.execute("DETACH DATABASE backup", [])
                 .context("failed to detach backup database")?;
             res?;

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -804,7 +804,7 @@ async fn export_database(
                 "UPDATE backup.config SET value='0' WHERE keyname='verified_one_on_one_chats';",
                 [],
             )
-            .ok(); // If verified_one_on_one_chats was not set, this errors, which we ignore
+            .ok(); // Deprecated. If verified_one_on_one_chats was not set, this errors, which we ignore
             conn.execute("DETACH DATABASE backup", [])
                 .context("failed to detach backup database")?;
             res?;


### PR DESCRIPTION
came over these parts while targeting the new info message of https://github.com/chatmail/core/pull/7008 in https://github.com/deltachat/deltachat-ios/pull/2778 and https://github.com/deltachat/deltachat-android/pull/3822