### PR TITLE
fix: Mark all email chats as unprotected in the migration

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1642,7 +1642,7 @@ fn migrate_key_contacts(
                 .collect::<Result<Vec<_>, _>>()
                 .context("Step 26")?;
 
-            let mut keep_address_contacts = |reason: &str| {
+            let mut keep_address_contacts = |reason: &str| -> Result<()> {
                 info!(
                     context,
                     "Chat {chat_id} will be an unencrypted chat with contacts identified by email address: {reason}."
@@ -1650,6 +1650,15 @@ fn migrate_key_contacts(
                 for (m, _) in &old_members {
                     orphaned_contacts.remove(m);
                 }
+
+                // Unprotect this chat if it was protected.
+                //
+                // Otherwise we get protected chat with address-contact(s).
+                transaction
+                    .execute("UPDATE chats SET protected=0 WHERE id=?", (chat_id,))
+                    .context("Step 26.0")?;
+
+                Ok(())
             };
             let old_and_new_members: Vec<(u32, bool, Option<u32>)> = match typ {
                 // 1:1 chats retain:
@@ -1669,19 +1678,13 @@ fn migrate_key_contacts(
                     };
 
                     let Some(new_contact) = map_to_key_contact(old_member) else {
-                        keep_address_contacts("No peerstate, or peerstate in 'reset' state");
+                        keep_address_contacts("No peerstate, or peerstate in 'reset' state")?;
                         continue;
                     };
                     if !addr_cmp_stmt
                         .query_row((old_member, new_contact), |row| row.get::<_, bool>(0))?
                     {
-                        // Unprotect this 1:1 chat if it was protected.
-                        //
-                        // Otherwise we get protected chat with address-contact.
-                        transaction
-                            .execute("UPDATE chats SET protected=0 WHERE id=?", (chat_id,))?;
-
-                        keep_address_contacts("key contact has different email");
+                        keep_address_contacts("key contact has different email")?;
                         continue;
                     }
                     vec![(*old_member, true, Some(new_contact))]
@@ -1692,7 +1695,7 @@ fn migrate_key_contacts(
                     if grpid.is_empty() {
                         // Ad-hoc group that has empty Chat-Group-ID
                         // because it was created in response to receiving a non-chat email.
-                        keep_address_contacts("Empty chat-Group-ID");
+                        keep_address_contacts("Empty chat-Group-ID")?;
                         continue;
                     } else if protected == 1 {
                         old_members
@@ -1711,7 +1714,7 @@ fn migrate_key_contacts(
 
                 // Mailinglist
                 140 => {
-                    keep_address_contacts("Mailinglist");
+                    keep_address_contacts("Mailinglist")?;
                     continue;
                 }
 
@@ -1750,7 +1753,7 @@ fn migrate_key_contacts(
                 transaction
                     .execute("UPDATE chats SET grpid='' WHERE id=?", (chat_id,))
                     .context("Step 26.1")?;
-                keep_address_contacts("Group contains contact without peerstate");
+                keep_address_contacts("Group contains contact without peerstate")?;
                 continue;
             }
 


### PR DESCRIPTION
Previously, chat protection was only removed if the chat became an email-chat because the key-contact has a different email, but not if the chat became an email-chat for a different reason.

Therefore, it could happen that the migration produced a protected, unencrypted chat, where you couldn't write any messages.

I tested that applying this fix actually fixes the bug I had.