### PR TITLE
fix: Fix crash when receiving a verification-gossiping message

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3642,7 +3642,7 @@ async fn mark_recipients_as_verified(
         return Ok(());
     }
     for to_id in to_ids.iter().filter_map(|&x| x) {
-        if to_id == ContactId::SELF {
+        if to_id == ContactId::SELF || to_id == from_id {
             continue;
         }
 


### PR DESCRIPTION
This should fix https://github.com/chatmail/core/issues/7030; I didn't write a test yet, but @r10s you can already test whether it fixes your problem