### PR TITLE
feat: Put the debug/release build version into the info

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -334,17 +334,12 @@ impl Default for RunningState {
 pub fn get_info() -> BTreeMap<&'static str, String> {
     let mut res = BTreeMap::new();
 
-    let mut version = format!("v{}", &*DC_VERSION_STR);
     #[cfg(debug_assertions)]
-    {
-        version += " [debug build]";
-    }
+    res.insert("build_profile", "debug".to_string());
     #[cfg(not(debug_assertions))]
-    {
-        version += " [release build]";
-    }
-    res.insert("deltachat_core_version", version);
+    res.insert("build_profile", "release".to_string());
 
+    res.insert("deltachat_core_version", format!("v{}", &*DC_VERSION_STR));
     res.insert("sqlite_version", rusqlite::version().to_string());
     res.insert("arch", (std::mem::size_of::<usize>() * 8).to_string());
     res.insert("num_cpus", num_cpus::get().to_string());

--- a/src/context.rs
+++ b/src/context.rs
@@ -335,9 +335,12 @@ pub fn get_info() -> BTreeMap<&'static str, String> {
     let mut res = BTreeMap::new();
 
     #[cfg(debug_assertions)]
-    res.insert("build_profile", "debug".to_string());
+    res.insert(
+        "debug_assertions",
+        "On - DO NOT RELEASE THIS BUILD".to_string(),
+    );
     #[cfg(not(debug_assertions))]
-    res.insert("build_profile", "release".to_string());
+    res.insert("debug_assertions", "Off".to_string());
 
     res.insert("deltachat_core_version", format!("v{}", &*DC_VERSION_STR));
     res.insert("sqlite_version", rusqlite::version().to_string());

--- a/src/context.rs
+++ b/src/context.rs
@@ -333,7 +333,18 @@ impl Default for RunningState {
 /// about the context on top of the information here.
 pub fn get_info() -> BTreeMap<&'static str, String> {
     let mut res = BTreeMap::new();
-    res.insert("deltachat_core_version", format!("v{}", &*DC_VERSION_STR));
+
+    let mut version = format!("v{}", &*DC_VERSION_STR);
+    #[cfg(debug_assertions)]
+    {
+        version += " [debug build]";
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        version += " [release build]";
+    }
+    res.insert("deltachat_core_version", version);
+
     res.insert("sqlite_version", rusqlite::version().to_string());
     res.insert("arch", (std::mem::size_of::<usize>() * 8).to_string());
     res.insert("num_cpus", num_cpus::get().to_string());


### PR DESCRIPTION
The info will look like:

```
debug_assertions=On - DO NOT RELEASE THIS BUILD
```
or:
```
debug_assertions=Off
```

I tested that this actually works when compiling on Android.

<details><summary>This is how it looked before the second commit</summary>
<p>


The deltachat_core_version line in the info will look like:

```
deltachat_core_version=v2.5.0 [debug build]
```
or:
```
deltachat_core_version=v2.5.0 [release build]
```

I tested that this actually works when compiling on Android.



</p>
</details> 