### PR TITLE
feat: Add import-vcard and make-vcard commands to repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,26 @@ Connect to your mail server (if already configured):
 > connect
 ```
 
-Create a contact:
+Export your public key to a vCard file:
+
+```
+> make-vcard my.vcard 1
+```
+
+Create contacts by address or vCard file:
 
 ```
 > addcontact yourfriends@email.org
+> import-vcard keyfriend.vcard
 ```
 
 List contacts:
 
 ```
 > listcontacts
+Contact#Contact#11: keyfriend@email.org <keyfriend@email.org>
 Contact#Contact#Self: Me √ <your@email.org>
-1 key contacts.
+2 key contacts.
 Contact#Contact#10: yourfriends@email.org <yourfriends@email.org>
 1 address contacts.
 ```

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -403,6 +403,8 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  block <contact-id>\n\
                  unblock <contact-id>\n\
                  listblocked\n\
+                 import-vcard <file>\n\
+                 make-vcard <file> <contact-id> [contact-id ...]\n\
                  ======================================Misc.==\n\
                  getqr [<chat-id>]\n\
                  getqrsvg [<chat-id>]\n\
@@ -1217,6 +1219,24 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let contacts = Contact::get_all_blocked(&context).await?;
             log_contactlist(&context, &contacts).await?;
             println!("{} blocked contacts.", contacts.len());
+        }
+        "import-vcard" => {
+            ensure!(!arg1.is_empty(), "Argument <file> missing.");
+            let vcard_content = fs::read_to_string(&arg1.to_string()).await?;
+            let contacts = import_vcard(&context, &vcard_content).await?;
+            println!("vCard contacts imported to:");
+            log_contactlist(&context, &contacts).await?;
+        }
+        "make-vcard" => {
+            ensure!(!arg1.is_empty(), "Argument <file> missing.");
+            ensure!(!arg2.is_empty(), "Argument <contact-id> missing.");
+            let mut contact_ids = vec![];
+            for x in arg2.split(' ') {
+                contact_ids.push(ContactId::new(x.parse()?))
+            }
+            let vcard_content = make_vcard(&context, &contact_ids).await?;
+            fs::write(&arg1.to_string(), vcard_content).await?;
+            println!("vCard written to: {}", arg1);
         }
         "checkqr" => {
             ensure!(!arg1.is_empty(), "Argument <qr-content> missing.");

--- a/deltachat-repl/src/main.rs
+++ b/deltachat-repl/src/main.rs
@@ -232,7 +232,7 @@ const MESSAGE_COMMANDS: [&str; 10] = [
     "delmsg",
     "react",
 ];
-const CONTACT_COMMANDS: [&str; 7] = [
+const CONTACT_COMMANDS: [&str; 9] = [
     "listcontacts",
     "addcontact",
     "contactinfo",
@@ -240,6 +240,8 @@ const CONTACT_COMMANDS: [&str; 7] = [
     "block",
     "unblock",
     "listblocked",
+    "import-vcard",
+    "make-vcard",
 ];
 const MISC_COMMANDS: [&str; 14] = [
     "getqr",


### PR DESCRIPTION
- Added import-vcard and make-vcard commands to deltachat-repl.  These wrap the corresponding import_vcard() and make_vcard() operations from src/contact.rs.  Each command takes a file path argument specifying the location of the vCard file to be read or written. The make-vcard command takes one or more IDs to write to the file.
- Documented commands in "Using the CLI client" section of README.md.

closes #7047