### PR TITLE
fix: get_chat_msgs_ex(): Report local midnight in ChatItem::DayMarker

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1332,12 +1332,14 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
  * Optionally, some special markers added to the ID array may help to
  * implement virtual lists.
  *
+ * To get the concrete time of the message, use dc_array_get_timestamp().
+ *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
  * @param chat_id The chat ID of which the messages IDs should be queried.
  * @param flags If set to DC_GCM_ADDDAYMARKER, the marker DC_MSG_ID_DAYMARKER will
  *     be added before each day (regarding the local timezone). Set this to 0 if you do not want this behaviour.
- *     To get the concrete time of the marker, use dc_array_get_timestamp().
+ *     The day marker timestamp is the midnight one for the corresponding (following) day in the local timezone.
  *     If set to DC_GCM_INFO_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
  * @param marker1before Deprecated, set this to 0.
  * @return Array of message IDs, must be dc_array_unref()'d when no longer used.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1227,8 +1227,10 @@ impl CommandApi {
     }
 
     /// Returns all messages of a particular chat.
-    /// If `add_daymarker` is `true`, it will return them as
-    /// `DC_MSG_ID_DAYMARKER`, e.g. [1234, 1237, 9, 1239].
+    ///
+    /// * `add_daymarker` - If `true`, add day markers as `DC_MSG_ID_DAYMARKER` to the result,
+    ///   e.g. [1234, 1237, 9, 1239]. The day marker timestamp is the midnight one for the
+    ///   corresponding (following) day in the local timezone.
     async fn get_message_ids(
         &self,
         account_id: u32,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3323,10 +3323,11 @@ pub async fn get_chat_msgs_ex(
         for (ts, curr_id) in sorted_rows {
             if add_daymarker {
                 let curr_local_timestamp = ts + cnv_to_local;
-                let curr_day = curr_local_timestamp / 86400;
+                let secs_in_day = 86400;
+                let curr_day = curr_local_timestamp / secs_in_day;
                 if curr_day != last_day {
                     ret.push(ChatItem::DayMarker {
-                        timestamp: curr_day * 86400, // Convert day back to Unix timestamp
+                        timestamp: curr_day * secs_in_day - cnv_to_local,
                     });
                     last_day = curr_day;
                 }


### PR DESCRIPTION
Fixes https://github.com/deltachat/deltachat-desktop/issues/5215.

Tested in DC Desktop by hand. Would be nice to add a Rust test. Also needs testing in DC Android at least, it somehow works correctly even w/o this fix, so it can break.