### PR TITLE
[WIP] feat: Also lookup key contacts in lookup_id_by_addr()

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -795,8 +795,8 @@ impl Contact {
             .query_get_value(
                 "SELECT id FROM contacts
                  WHERE addr=?1 COLLATE NOCASE
-                 AND fingerprint='' -- Do not lookup key-contacts
-                 AND id>?2 AND origin>=?3 AND (? OR blocked=?)",
+                 AND id>?2 AND origin>=?3 AND (? OR blocked=?)
+                 ORDER BY last_seen DESC LIMIT 1",
                 (
                     &addr_normalized,
                     ContactId::LAST_SPECIAL,


### PR DESCRIPTION
If there is both a key and an address contact, return the most recently seen one.

TODO: Test this

Also TODO: Write a regression test, though this can also come later, if we want to release this as a hotpatch.