### PR TITLE
fix: ignore case when trying to detect 'invalid unencrypted mail' 

### DIFF
--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -414,7 +414,11 @@ pub(crate) async fn send_msg_to_smtp(
                 .await?;
         }
         SendResult::Failure(ref err) => {
-            if err.to_string().contains("Invalid unencrypted mail") {
+            if err
+                .to_string()
+                .to_lowercase()
+                .contains("invalid unencrypted mail")
+            {
                 let res = context
                     .sql
                     .query_row_optional(


### PR DESCRIPTION
detection of 'invalid unencrypted mail'  is used as a condition to add a dedicated error info message to the chat, that UI even recognizes and show how information on tap

the string was recently changed from lowercase to Title Case at https://github.com/chatmail/relay/pull/538 - this PR ignores case.

with this PR, the info-message appears again as follows:

<img width=320 src=https://github.com/user-attachments/assets/ef071123-91a1-4176-bd3f-0fdd3e6c705b>
<img width=320 src=https://github.com/user-attachments/assets/0551dc76-5c79-484e-a598-b4f279974370>

makes sense to have a test with the real relay, however, just now, i am not deep enough into python