### PR TITLE
fix: Make "end-to-end encryption not setup" message work again

### DIFF
--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -414,7 +414,10 @@ pub(crate) async fn send_msg_to_smtp(
                 .await?;
         }
         SendResult::Failure(ref err) => {
-            if err.to_string().contains("Invalid unencrypted mail") {
+            if err
+                .to_string()
+                .to_lowercase()
+                .contains("invalid unencrypted mail") {
                 let res = context
                     .sql
                     .query_row_optional(


### PR DESCRIPTION
Reported by adbenitez in the release coordination group:

The "end-to-end encryption not setup" message didn't appear anymore when trying to send an unencrypted message with a chatmail account. This was because on the server side, the casing of the error message changed ("Inalid unencrypted mail" -> "Invalid Unencrypted mail").

This PR ignores the casing.