### PR TITLE
better string when using disappearing messages of one year 

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7598,6 +7598,18 @@ void dc_event_unref(dc_event_t* event);
 /// `%2$s` will be replaced by name and address of the contact.
 #define DC_STR_EPHEMERAL_TIMER_WEEKS_BY_OTHER 157
 
+/// "You set message deletion timer to 1 year."
+///
+/// Used in status messages.
+#define DC_STR_EPHEMERAL_TIMER_1_YEAR_BY_YOU 158
+
+/// "Message deletion timer is set to 1 year by %1$s."
+///
+/// `%1$s` will be replaced by name and address of the contact.
+///
+/// Used in status messages.
+#define DC_STR_EPHEMERAL_TIMER_1_YEAR_BY_OTHER 159
+
 /// "Scan to set up second device for %1$s"
 ///
 /// `%1$s` will be replaced by name and address of the account.

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -277,6 +277,7 @@ pub(crate) async fn stock_ephemeral_timer_changed(
                 .await
             }
             604_800 => stock_str::msg_ephemeral_timer_week(context, from_id).await,
+            31_536_000..31_708_800 => stock_str::msg_ephemeral_timer_year(context, from_id).await,
             _ => {
                 stock_str::msg_ephemeral_timer_weeks(
                     context,

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -277,7 +277,7 @@ pub(crate) async fn stock_ephemeral_timer_changed(
                 .await
             }
             604_800 => stock_str::msg_ephemeral_timer_week(context, from_id).await,
-            31_536_000..31_708_800 => stock_str::msg_ephemeral_timer_year(context, from_id).await,
+            31_536_000..=31_708_800 => stock_str::msg_ephemeral_timer_year(context, from_id).await,
             _ => {
                 stock_str::msg_ephemeral_timer_weeks(
                     context,

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -362,6 +362,12 @@ pub enum StockMessage {
     #[strum(props(fallback = "Message deletion timer is set to %1$s weeks by %2$s."))]
     MsgEphemeralTimerWeeksBy = 157,
 
+    #[strum(props(fallback = "You set message deletion timer to 1 year."))]
+    MsgYouEphemeralTimerYear = 158,
+
+    #[strum(props(fallback = "Message deletion timer is set to 1 year by %1$s."))]
+    MsgEphemeralTimerYearBy = 159,
+
     #[strum(props(fallback = "Scan to set up second device for %1$s"))]
     BackupTransferQr = 162,
 
@@ -987,6 +993,17 @@ pub(crate) async fn msg_ephemeral_timer_week(context: &Context, by_contact: Cont
         translated(context, StockMessage::MsgYouEphemeralTimerWeek).await
     } else {
         translated(context, StockMessage::MsgEphemeralTimerWeekBy)
+            .await
+            .replace1(&by_contact.get_stock_name(context).await)
+    }
+}
+
+/// Stock string: `Message deletion timer is set to 1 year.`.
+pub(crate) async fn msg_ephemeral_timer_year(context: &Context, by_contact: ContactId) -> String {
+    if by_contact == ContactId::SELF {
+        translated(context, StockMessage::MsgYouEphemeralTimerYear).await
+    } else {
+        translated(context, StockMessage::MsgEphemeralTimerYearBy)
             .await
             .replace1(&by_contact.get_stock_name(context).await)
     }


### PR DESCRIPTION
this PR adds strings for having disappearing messages set to "1 year".

"one year" is 365 ~ 367 days; the latter if we decide to have a little more than 1 year (there was some post about signal (?) doing that, so user can find the posts from exactly one year ago, but i cannot find that again)

counterpart of https://github.com/deltachat/deltachat-android/pull/3467 and many forum discussions