### PR TITLE
fix: log and set imex progress error

### DIFF
--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -250,7 +250,7 @@ impl BackupProvider {
                                 Err(format_err!("Backup provider dropped"))
                             }
                         ).await {
-                            warn!(context, "Error while handling backup connection: {err:#}.");
+                            error!(context, "Error while handling backup connection: {err:#}.");
                             context.emit_event(EventType::ImexProgress(0));
                             break;
                         } else {
@@ -368,6 +368,7 @@ pub async fn get_backup(context: &Context, qr: Qr) -> Result<()> {
                 })
                 .await;
             if res.is_err() {
+                error!(context, "get_backup2 failed");
                 context.emit_event(EventType::ImexProgress(0));
             }
             context.free_ongoing().await;


### PR DESCRIPTION
IMEX_PROGRESS(0) event is fired in case of errors, however, the last error was not set in this case.

this is similar to the fix at #4195
and improves the error shown in the dialog for android and iOS; desktop does not show an error dialog at all.

<img width="320" alt="IMG_9995" src="https://github.com/user-attachments/assets/7065fc3d-3f30-4691-b1b2-1950564a25e2" />
