### PR TITLE
feat: create_group_ex(): Log and replace invalid chat name with "…"

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3697,8 +3697,13 @@ pub async fn create_group_ex(
     encryption: Option<ProtectionStatus>,
     name: &str,
 ) -> Result<ChatId> {
-    let chat_name = sanitize_single_line(name);
-    ensure!(!chat_name.is_empty(), "Invalid chat name");
+    let mut chat_name = sanitize_single_line(name);
+    if chat_name.is_empty() {
+        // We can't just fail because the user would lose the work already done in the UI like
+        // selecting members.
+        error!(context, "Invalid chat name: {name}.");
+        chat_name = "…".to_string();
+    }
 
     let grpid = match encryption {
         Some(_) => create_id(),

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1798,7 +1798,7 @@ impl Chat {
     /// Returns chat avatar color.
     ///
     /// For 1:1 chats, the color is calculated from the contact's address.
-    /// For group chats the color is calculated from the chat name.
+    /// For group chats the color is calculated from the grpid, if present, or the chat name.
     pub async fn get_color(&self, context: &Context) -> Result<u32> {
         let mut color = 0;
 
@@ -1809,6 +1809,8 @@ impl Chat {
                     color = contact.get_color();
                 }
             }
+        } else if !self.grpid.is_empty() {
+            color = str_to_color(&self.grpid);
         } else {
             color = str_to_color(&self.name);
         }

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -4749,6 +4749,16 @@ async fn test_create_unencrypted_group_chat() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_group_invalid_name() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let chat_id = create_group_ex(alice, None, " ").await?;
+    let chat = Chat::load_from_db(alice, chat_id).await?;
+    assert_eq!(chat.get_name(), "…");
+    Ok(())
+}
+
 /// Tests that avatar cannot be set in ad hoc groups.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_no_avatar_in_adhoc_chats() -> Result<()> {


### PR DESCRIPTION
See commit messages.

Will add a test for `feat: Chat::get_color(): Use grpid, if present, instead of name` if the commit is agreed... Done.