### PR TITLE
feat: hide call status change messages

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1153,6 +1153,11 @@ async fn decide_chat_assignment(
     {
         info!(context, "Chat edit/delete/iroh/sync message (TRASH).");
         true
+    } else if mime_parser.is_system_message == SystemMessage::CallAccepted
+        || mime_parser.is_system_message == SystemMessage::CallEnded
+    {
+        info!(context, "Call state changed (TRASH).");
+        true
     } else if mime_parser.decrypting_failed && !mime_parser.incoming {
         // Outgoing undecryptable message.
         let last_time = context


### PR DESCRIPTION
this PR uses the initial "call messages" (that has a separate viewtype since #7174) to show all call status.

this is what most other messengers are doing as well. additional "info messages" after a call are no longer needed.

on the wire, as we cannot pickpack on visible info messages, we use hidden messages, similar to eg. webxdc status updates.

in future PR, it is planned to allow getting call state as a json, so that UI can render nicely. it is then decided if we want to translate the strings in the core.

<img width="320"  alt="IMG_0150" src="https://github.com/user-attachments/assets/41ee3fa3-8be4-42c3-8dd9-d20f49881650" />

successor of https://github.com/chatmail/core/pull/6650
