### PR TITLE
api: Put the chattype into the SecurejoinInviterProgress event

### DIFF
--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -1,4 +1,5 @@
 use deltachat::{Event as CoreEvent, EventType as CoreEventType};
+use num_traits::ToPrimitive;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
 
@@ -303,6 +304,11 @@ pub enum EventType {
         /// ID of the contact that wants to join.
         contact_id: u32,
 
+        /// The type of the joined chat.
+        /// This can take the same values
+        /// as `BasicChat.chatType` ([`crate::api::types::chat::BasicChat::chat_type`]).
+        chat_type: u32,
+
         /// Progress as:
         /// 300=vg-/vc-request received, typically shown as "bob@addr joins".
         /// 600=vg-/vc-request-with-auth received and verified, typically shown as "bob@addr verified".
@@ -553,9 +559,11 @@ impl From<CoreEventType> for EventType {
             },
             CoreEventType::SecurejoinInviterProgress {
                 contact_id,
+                chat_type,
                 progress,
             } => SecurejoinInviterProgress {
                 contact_id: contact_id.to_u32(),
+                chat_type: chat_type.to_u32().unwrap_or(0),
                 progress,
             },
             CoreEventType::SecurejoinJoinerProgress {

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::chat::ChatId;
 use crate::config::Config;
+use crate::constants::Chattype;
 use crate::contact::ContactId;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::message::MsgId;
@@ -271,6 +272,9 @@ pub enum EventType {
     SecurejoinInviterProgress {
         /// ID of the contact that wants to join.
         contact_id: ContactId,
+
+        /// The type of the joined chat.
+        chat_type: Chattype,
 
         /// Progress as:
         /// 300=vg-/vc-request received, typically shown as "bob@addr joins".

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -32,16 +32,29 @@ use qrinvite::QrInvite;
 
 use crate::token::Namespace;
 
-fn inviter_progress(context: &Context, contact_id: ContactId, progress: usize) {
+fn inviter_progress(
+    context: &Context,
+    contact_id: ContactId,
+    progress: usize,
+    step: &str,
+) -> Result<()> {
     logged_debug_assert!(
         context,
         progress <= 1000,
         "inviter_progress: contact {contact_id}, progress={progress}, but value in range 0..1000 expected with: 0=error, 1..999=progress, 1000=success."
     );
+    let chat_type = match step.get(..3) {
+        Some("vc-") => Chattype::Single,
+        Some("vg-") => Chattype::Group,
+        _ => bail!("Unknown securejoin step {step}"),
+    };
     context.emit_event(EventType::SecurejoinInviterProgress {
         contact_id,
+        chat_type,
         progress,
     });
+
+    Ok(())
 }
 
 /// Generates a Secure Join QR code.
@@ -310,7 +323,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 return Ok(HandshakeMessage::Ignore);
             }
 
-            inviter_progress(context, contact_id, 300);
+            inviter_progress(context, contact_id, 300, step)?;
 
             let from_addr = ContactAddress::new(&mime_message.from.addr)?;
             let autocrypt_fingerprint = mime_message.autocrypt_fingerprint.as_deref().unwrap_or("");
@@ -405,7 +418,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 ChatId::create_for_contact(context, contact_id).await?;
             }
             context.emit_event(EventType::ContactsChanged(Some(contact_id)));
-            inviter_progress(context, contact_id, 600);
+            inviter_progress(context, contact_id, 600, step)?;
             if let Some(group_chat_id) = group_chat_id {
                 // Join group.
                 secure_connection_established(
@@ -417,8 +430,8 @@ pub(crate) async fn handle_securejoin_handshake(
                 .await?;
                 chat::add_contact_to_chat_ex(context, Nosync, group_chat_id, contact_id, true)
                     .await?;
-                inviter_progress(context, contact_id, 800);
-                inviter_progress(context, contact_id, 1000);
+                inviter_progress(context, contact_id, 800, step)?;
+                inviter_progress(context, contact_id, 1000, step)?;
                 // IMAP-delete the message to avoid handling it by another device and adding the
                 // member twice. Another device will know the member's key from Autocrypt-Gossip.
                 Ok(HandshakeMessage::Done)
@@ -435,7 +448,7 @@ pub(crate) async fn handle_securejoin_handshake(
                     .await
                     .context("failed sending vc-contact-confirm message")?;
 
-                inviter_progress(context, contact_id, 1000);
+                inviter_progress(context, contact_id, 1000, step)?;
                 Ok(HandshakeMessage::Ignore) // "Done" would delete the message and break multi-device (the key from Autocrypt-header is needed)
             }
         }
@@ -555,10 +568,10 @@ pub(crate) async fn observe_securejoin_on_other_device(
     ChatId::set_protection_for_contact(context, contact_id, mime_message.timestamp_sent).await?;
 
     if step == "vg-member-added" {
-        inviter_progress(context, contact_id, 800);
+        inviter_progress(context, contact_id, 800, step)?;
     }
     if step == "vg-member-added" || step == "vc-contact-confirm" {
-        inviter_progress(context, contact_id, 1000);
+        inviter_progress(context, contact_id, 1000, step)?;
     }
 
     if step == "vg-request-with-auth" || step == "vc-request-with-auth" {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -35,8 +35,8 @@ use crate::token::Namespace;
 fn inviter_progress(
     context: &Context,
     contact_id: ContactId,
-    progress: usize,
     step: &str,
+    progress: usize,
 ) -> Result<()> {
     logged_debug_assert!(
         context,
@@ -323,7 +323,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 return Ok(HandshakeMessage::Ignore);
             }
 
-            inviter_progress(context, contact_id, 300, step)?;
+            inviter_progress(context, contact_id, step, 300)?;
 
             let from_addr = ContactAddress::new(&mime_message.from.addr)?;
             let autocrypt_fingerprint = mime_message.autocrypt_fingerprint.as_deref().unwrap_or("");
@@ -418,7 +418,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 ChatId::create_for_contact(context, contact_id).await?;
             }
             context.emit_event(EventType::ContactsChanged(Some(contact_id)));
-            inviter_progress(context, contact_id, 600, step)?;
+            inviter_progress(context, contact_id, step, 600)?;
             if let Some(group_chat_id) = group_chat_id {
                 // Join group.
                 secure_connection_established(
@@ -430,8 +430,8 @@ pub(crate) async fn handle_securejoin_handshake(
                 .await?;
                 chat::add_contact_to_chat_ex(context, Nosync, group_chat_id, contact_id, true)
                     .await?;
-                inviter_progress(context, contact_id, 800, step)?;
-                inviter_progress(context, contact_id, 1000, step)?;
+                inviter_progress(context, contact_id, step, 800)?;
+                inviter_progress(context, contact_id, step, 1000)?;
                 // IMAP-delete the message to avoid handling it by another device and adding the
                 // member twice. Another device will know the member's key from Autocrypt-Gossip.
                 Ok(HandshakeMessage::Done)
@@ -448,7 +448,7 @@ pub(crate) async fn handle_securejoin_handshake(
                     .await
                     .context("failed sending vc-contact-confirm message")?;
 
-                inviter_progress(context, contact_id, 1000, step)?;
+                inviter_progress(context, contact_id, step, 1000)?;
                 Ok(HandshakeMessage::Ignore) // "Done" would delete the message and break multi-device (the key from Autocrypt-header is needed)
             }
         }
@@ -568,10 +568,10 @@ pub(crate) async fn observe_securejoin_on_other_device(
     ChatId::set_protection_for_contact(context, contact_id, mime_message.timestamp_sent).await?;
 
     if step == "vg-member-added" {
-        inviter_progress(context, contact_id, 800, step)?;
+        inviter_progress(context, contact_id, step, 800)?;
     }
     if step == "vg-member-added" || step == "vc-contact-confirm" {
-        inviter_progress(context, contact_id, 1000, step)?;
+        inviter_progress(context, contact_id, step, 1000)?;
     }
 
     if step == "vg-request-with-auth" || step == "vc-request-with-auth" {

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -365,6 +365,29 @@ async fn test_setup_contact_bob_knows_alice() -> Result<()> {
     alice.recv_msg_trash(&sent).await;
     assert_eq!(contact_bob.is_verified(alice).await?, true);
 
+    // Check Alice signalled success via the SecurejoinInviterProgress event.
+    let event = alice
+        .evtracker
+        .get_matching(|evt| {
+            matches!(
+                evt,
+                EventType::SecurejoinInviterProgress { progress: 1000, .. }
+            )
+        })
+        .await;
+    match event {
+        EventType::SecurejoinInviterProgress {
+            contact_id,
+            chat_type,
+            progress,
+        } => {
+            assert_eq!(contact_id, contact_bob.id);
+            assert_eq!(chat_type, Chattype::Single);
+            assert_eq!(progress, 1000);
+        }
+        _ => unreachable!(),
+    }
+
     let sent = alice.pop_sent_msg().await;
     let msg = bob.parse_msg(&sent).await;
     assert!(msg.was_encrypted());
@@ -514,6 +537,29 @@ async fn test_secure_join() -> Result<()> {
     tcm.section("Step 5+6: Alice receives vg-request-with-auth, sends vg-member-added");
     alice.recv_msg_trash(&sent).await;
     assert_eq!(contact_bob.is_verified(&alice).await?, true);
+
+    // Check Alice signalled success via the SecurejoinInviterProgress event.
+    let event = alice
+        .evtracker
+        .get_matching(|evt| {
+            matches!(
+                evt,
+                EventType::SecurejoinInviterProgress { progress: 1000, .. }
+            )
+        })
+        .await;
+    match event {
+        EventType::SecurejoinInviterProgress {
+            contact_id,
+            chat_type,
+            progress,
+        } => {
+            assert_eq!(contact_id, contact_bob.id);
+            assert_eq!(chat_type, Chattype::Group);
+            assert_eq!(progress, 1000);
+        }
+        _ => unreachable!(),
+    }
 
     let sent = alice.pop_sent_msg().await;
     let msg = bob.parse_msg(&sent).await;


### PR DESCRIPTION
Quoting @adbenitez:

> I have been using the SecurejoinInviterProgress event to show a welcome message when user scan the QR/link of the bot (== starts a chat with the bot) 

> but this have a big problem: in that event all you know is that a contact completed the secure-join process, you don't know if it was via certain 1:1 invite link or a group invitation, then a group-invite bot would send you a help message in 1:1 every time you join a group with it

Since it's easy enough to add this information to the SecurejoinInviterProgress event, I wrote a PR to do so.