### PR TITLE
refactor: remove unused prop (TS, `BaseDeltaChat`)

### DIFF
--- a/deltachat-jsonrpc/typescript/src/client.ts
+++ b/deltachat-jsonrpc/typescript/src/client.ts
@@ -28,7 +28,6 @@ export class BaseDeltaChat<
   Transport extends BaseTransport<any>,
 > extends TinyEmitter<Events> {
   rpc: RawClient;
-  account?: T.Account;
   private contextEmitters: { [key: number]: TinyEmitter<ContextEvents> } = {};
 
   //@ts-ignore


### PR DESCRIPTION
Apparently it has been unused ever since the introduction
of JSON-RPC, 0887acf1bf59188775042cd2806777f282c53a67
(https://github.com/chatmail/core/pull/3463).
