### PR TITLE
fix: Don't enable legacy decryption options

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -245,7 +245,7 @@ pub fn pk_decrypt(
     let skeys: Vec<&SignedSecretKey> = private_keys_for_decryption.iter().collect();
     let empty_pw = Password::empty();
 
-    let decrypt_options = DecryptionOptions::new().enable_legacy();
+    let decrypt_options = DecryptionOptions::new();
     let ring = TheRing {
         secret_keys: skeys,
         key_passwords: vec![&empty_pw],


### PR DESCRIPTION
Follow-up to https://github.com/chatmail/core/pull/7226/; I believe that this was enabled by accident? Previously, we had `allow_legacy: false`.