### PR TITLE
api!: jsonrpc: remove `contacts` from `FullChat`. To migrate load contacts on demand via `get_contacts_by_ids` using `FullChat.contactIds`

### DIFF
--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use typescript_type_def::TypeDef;
 
 use super::color_int_to_hex_string;
-use super::contact::ContactObject;
 
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -61,7 +60,6 @@ pub struct FullChat {
     chat_type: u32,
     is_unpromoted: bool,
     is_self_talk: bool,
-    contacts: Vec<ContactObject>,
     contact_ids: Vec<u32>,
 
     /// Contact IDs of the past chat members.
@@ -88,20 +86,6 @@ impl FullChat {
 
         let contact_ids = get_chat_contacts(context, rust_chat_id).await?;
         let past_contact_ids = get_past_chat_contacts(context, rust_chat_id).await?;
-
-        let mut contacts = Vec::with_capacity(contact_ids.len());
-
-        for contact_id in &contact_ids {
-            contacts.push(
-                ContactObject::try_from_dc_contact(
-                    context,
-                    Contact::get_by_id(context, *contact_id)
-                        .await
-                        .context("failed to load contact")?,
-                )
-                .await?,
-            )
-        }
 
         let profile_image = match chat.get_profile_image(context).await? {
             Some(path_buf) => path_buf.to_str().map(|s| s.to_owned()),
@@ -139,7 +123,6 @@ impl FullChat {
             chat_type: chat.get_type().to_u32().context("unknown chat type id")?,
             is_unpromoted: chat.is_unpromoted(),
             is_self_talk: chat.is_self_talk(),
-            contacts,
             contact_ids: contact_ids.iter().map(|id| id.to_u32()).collect(),
             past_contact_ids: past_contact_ids.iter().map(|id| id.to_u32()).collect(),
             color,
@@ -157,7 +140,6 @@ impl FullChat {
 }
 
 /// cheaper version of fullchat, omits:
-/// - contacts
 /// - contact_ids
 /// - fresh_message_counter
 /// - ephemeral_timer


### PR DESCRIPTION
TO DO:
- [ ] check if tests pass
- [ ] check if example bots use this (echo bot)
- [ ] desktop pr

closes #6945

### Why not deprecate it instead?
Because empty contact list is a more annoying-to-find bug in your app than failing to build or getting undefined at runtime.

Also you would not see the deprecated hints anyway because for that you need autogenerated types and those only exist for typescript currently.
