### PR TITLE
api!: jsonrpc: `chat_type` now contains a variant of a string enum/union. Affected places: `FullChat.chat_type`, `BasicChat.chat_type`, `ChatListItemFetchResult::ChatListItem.chat_type`, `Event:: SecurejoinInviterProgress.chat_type` and `MessageSearchResult.chat_type`

### DIFF
--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -6,7 +6,6 @@ use deltachat::chat::{Chat, ChatId};
 use deltachat::constants::Chattype;
 use deltachat::contact::{Contact, ContactId};
 use deltachat::context::Context;
-use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use typescript_type_def::TypeDef;
 
@@ -58,7 +57,7 @@ pub struct FullChat {
     archived: bool,
     pinned: bool,
     // subtitle  - will be moved to frontend because it uses translation functions
-    chat_type: u32,
+    chat_type: JSONRPCChatType,
     is_unpromoted: bool,
     is_self_talk: bool,
     contacts: Vec<ContactObject>,
@@ -136,7 +135,7 @@ impl FullChat {
             profile_image, //BLOBS ?
             archived: chat.get_visibility() == chat::ChatVisibility::Archived,
             pinned: chat.get_visibility() == chat::ChatVisibility::Pinned,
-            chat_type: chat.get_type().to_u32().context("unknown chat type id")?,
+            chat_type: chat.get_type().into(),
             is_unpromoted: chat.is_unpromoted(),
             is_self_talk: chat.is_self_talk(),
             contacts,
@@ -210,7 +209,7 @@ pub struct BasicChat {
     profile_image: Option<String>, //BLOBS ?
     archived: bool,
     pinned: bool,
-    chat_type: u32,
+    chat_type: JSONRPCChatType,
     is_unpromoted: bool,
     is_self_talk: bool,
     color: String,
@@ -239,7 +238,7 @@ impl BasicChat {
             profile_image, //BLOBS ?
             archived: chat.get_visibility() == chat::ChatVisibility::Archived,
             pinned: chat.get_visibility() == chat::ChatVisibility::Pinned,
-            chat_type: chat.get_type().to_u32().context("unknown chat type id")?,
+            chat_type: chat.get_type().into(),
             is_unpromoted: chat.is_unpromoted(),
             is_self_talk: chat.is_self_talk(),
             color,
@@ -290,6 +289,40 @@ impl JSONRPCChatVisibility {
             JSONRPCChatVisibility::Normal => ChatVisibility::Normal,
             JSONRPCChatVisibility::Archived => ChatVisibility::Archived,
             JSONRPCChatVisibility::Pinned => ChatVisibility::Pinned,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, TypeDef, schemars::JsonSchema)]
+#[serde(rename = "ChatType")]
+pub enum JSONRPCChatType {
+    Single,
+    Group,
+    Mailinglist,
+    OutBroadcast,
+    InBroadcast,
+}
+
+impl From<Chattype> for JSONRPCChatType {
+    fn from(chattype: Chattype) -> Self {
+        match chattype {
+            Chattype::Single => JSONRPCChatType::Single,
+            Chattype::Group => JSONRPCChatType::Group,
+            Chattype::Mailinglist => JSONRPCChatType::Mailinglist,
+            Chattype::OutBroadcast => JSONRPCChatType::OutBroadcast,
+            Chattype::InBroadcast => JSONRPCChatType::InBroadcast,
+        }
+    }
+}
+
+impl From<JSONRPCChatType> for Chattype {
+    fn from(chattype: JSONRPCChatType) -> Self {
+        match chattype {
+            JSONRPCChatType::Single => Chattype::Single,
+            JSONRPCChatType::Group => Chattype::Group,
+            JSONRPCChatType::Mailinglist => Chattype::Mailinglist,
+            JSONRPCChatType::OutBroadcast => Chattype::OutBroadcast,
+            JSONRPCChatType::InBroadcast => Chattype::InBroadcast,
         }
     }
 }

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -11,6 +11,7 @@ use num_traits::cast::ToPrimitive;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
 
+use super::chat::JSONRPCChatType;
 use super::color_int_to_hex_string;
 use super::message::MessageViewtype;
 
@@ -23,7 +24,7 @@ pub enum ChatListItemFetchResult {
         name: String,
         avatar_path: Option<String>,
         color: String,
-        chat_type: u32,
+        chat_type: JSONRPCChatType,
         last_updated: Option<i64>,
         summary_text1: String,
         summary_text2: String,
@@ -155,7 +156,7 @@ pub(crate) async fn get_chat_list_item_by_id(
         name: chat.get_name().to_owned(),
         avatar_path,
         color,
-        chat_type: chat.get_type().to_u32().context("unknown chat type id")?,
+        chat_type: chat.get_type().into(),
         last_updated,
         summary_text1,
         summary_text2,

--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -1,7 +1,8 @@
 use deltachat::{Event as CoreEvent, EventType as CoreEventType};
-use num_traits::ToPrimitive;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
+
+use super::chat::JSONRPCChatType;
 
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -307,7 +308,7 @@ pub enum EventType {
         /// The type of the joined chat.
         /// This can take the same values
         /// as `BasicChat.chatType` ([`crate::api::types::chat::BasicChat::chat_type`]).
-        chat_type: u32,
+        chat_type: JSONRPCChatType,
         /// ID of the chat in case of success.
         chat_id: u32,
 
@@ -570,7 +571,7 @@ impl From<CoreEventType> for EventType {
                 progress,
             } => SecurejoinInviterProgress {
                 contact_id: contact_id.to_u32(),
-                chat_type: chat_type.to_u32().unwrap_or(0),
+                chat_type: chat_type.into(),
                 chat_id: chat_id.to_u32(),
                 progress,
             },

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -16,6 +16,7 @@ use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use typescript_type_def::TypeDef;
 
+use super::chat::JSONRPCChatType;
 use super::color_int_to_hex_string;
 use super::contact::ContactObject;
 use super::reactions::JSONRPCReactions;
@@ -531,7 +532,7 @@ pub struct MessageSearchResult {
     chat_profile_image: Option<String>,
     chat_color: String,
     chat_name: String,
-    chat_type: u32,
+    chat_type: JSONRPCChatType,
     is_chat_protected: bool,
     is_chat_contact_request: bool,
     is_chat_archived: bool,
@@ -570,7 +571,7 @@ impl MessageSearchResult {
             chat_id: chat.id.to_u32(),
             chat_name: chat.get_name().to_owned(),
             chat_color,
-            chat_type: chat.get_type().to_u32().context("unknown chat type id")?,
+            chat_type: chat.get_type().into(),
             chat_profile_image,
             is_chat_protected: chat.is_protected(),
             is_chat_contact_request: chat.is_contact_request(),


### PR DESCRIPTION
trying the breaking change.
Actually it will be not as breaking if you used the constants, because this pr will also change the constants.

- [x] jsonrpc change
- [ ] change typescript client constants (and deprecate them because we don't need them for typescript, string unions work fine there)
- [ ] update constants in python bindings
- [ ] make a pr to go bindings: github.com/chatmail/rpc-client-go

closes #7029 
