### PR TITLE
remove: remove unused websocket dependencies from `@deltachat/jsonrpc-client`

### DIFF
--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -2,14 +2,12 @@
   "author": "Delta Chat Developers (ML) <delta@codespeak.net>",
   "dependencies": {
     "@deltachat/tiny-emitter": "3.0.0",
-    "isomorphic-ws": "^5.0.0",
     "yerpc": "^0.6.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.10",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.4",
-    "@types/ws": "^8.5.9",
     "c8": "^8.0.1",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
@@ -19,8 +17,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",
     "typedoc": "^0.28.5",
-    "typescript": "^5.8.3",
-    "ws": "^8.5.0"
+    "typescript": "^5.8.3"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Follow up to #6655, looks like it was forgotten there.

~~Let's keep it as draft until we make sure that this doesn't break
anything in desktop dependency resolution or bundling.~~ with the `yerpc` fix it will be safe.

To be on the safe side I also removed the web socket dependencies from `yerpc` in https://github.com/chatmail/yerpc/issues/74.
Turns out those extra wrapper dependencies are not needed anymore in nodejs[^1]. So as soon as we release and use a new `yerpc` version with this fix we can merge this PR without any worries. And then we can also remove the `ws` dependency from desktop[^2] .


Another reason for removing these dependencies is that they triggered irrelevant dependabot PRs, for a dependency that was not even used.

[^1]: since version 22 there is official support for web sockets and browser already had native support anyway, so this wrapper library is not used anymore
[^2]: and then we can also remove the we dependency from desktop packages: it can just be removed from frontend and electron. and in the browser version we need a mini refactoring to migrate to the standard web sockets)