### PR TITLE
fix: Do not additionally reduce the resolution of images that fit into the resolution-limit and are larger than the file-size-limit

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,6 +1,5 @@
 //! # Blob directory management.
 
-use core::cmp::max;
 use std::io::{Cursor, Seek};
 use std::iter::FusedIterator;
 use std::mem;
@@ -425,15 +424,6 @@ impl<'a> BlobObject<'a> {
                         });
 
             if do_scale {
-                if !exceeds_wh {
-                    img_wh = max(img.width(), img.height());
-                    // PNGs and WebPs may be huge because of animation, which is lost by the `image`
-                    // crate when recoding, so don't scale them down.
-                    if matches!(fmt, ImageFormat::Jpeg) || !encoded.is_empty() {
-                        img_wh = img_wh * 2 / 3;
-                    }
-                }
-
                 loop {
                     if mem::take(&mut add_white_bg) {
                         self::add_white_bg(&mut img);


### PR DESCRIPTION
See: https://support.delta.chat/t/high-quality-avatar/1052/8

This removes an additional resolution-reduction for images that fit within the resolution-limit.

The additional reduction of the image-resolution was added in https://github.com/chatmail/core/commit/b7864f232bbac4c585e75f1a3073d1175727e2f9.
It seems that back then only resolution-reduction was used to make the file-size of images smaller, and the purpose was to skip an unnecessary encoding-step.

However, encoding images with [jpeg-quality set to `75`](https://github.com/72374/core/blob/a6b2a54e46157dd6694146bb9f109eb2c60462ef/src/blob.rs#L392), as it is currently done, can significantly reduce the file-size, even if the resolution is the same. As the resolution of the image that will be encoded is rather low when it fits within the resolution-limit, further reducing it can significantly reduce the quality of the image.
Thus it is better to not skip the encoding-step at the original resolution.