### PR TITLE
fix: Correct condition for re-encoding avatar-images that include exif-data

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -410,6 +410,7 @@ impl<'a> BlobObject<'a> {
             let do_scale = exceeds_max_bytes
                 || is_avatar
                     && (exceeds_wh || exif.is_some() || {
+                        // Check if the file-size of the avatar would be too large with a white background added to it.
                         if mem::take(&mut add_white_bg) {
                             self::add_white_bg(&mut img);
                         }
@@ -442,6 +443,7 @@ impl<'a> BlobObject<'a> {
                         img.thumbnail(img_wh, img_wh)
                     };
 
+                    // This also encodes the image for use, not only for checking the file-size.
                     if encoded_img_exceeds_bytes(
                         context,
                         &new_img,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -409,19 +409,18 @@ impl<'a> BlobObject<'a> {
             // images.
             let do_scale = exceeds_max_bytes
                 || is_avatar
-                    && (exceeds_wh
-                        || exif.is_some() && {
-                            if mem::take(&mut add_white_bg) {
-                                self::add_white_bg(&mut img);
-                            }
-                            encoded_img_exceeds_bytes(
-                                context,
-                                &img,
-                                ofmt.clone(),
-                                max_bytes,
-                                &mut encoded,
-                            )?
-                        });
+                    && (exceeds_wh || exif.is_some() || {
+                        if mem::take(&mut add_white_bg) {
+                            self::add_white_bg(&mut img);
+                        }
+                        encoded_img_exceeds_bytes(
+                            context,
+                            &img,
+                            ofmt.clone(),
+                            max_bytes,
+                            &mut encoded,
+                        )?
+                    });
 
             if do_scale {
                 loop {


### PR DESCRIPTION
When exif-data is found in the avatar-image, it should be re-encoded to remove it.
When the avatar-image will be too large with a white background added, it should be re-encoded to fit within the file-size-limit.

The check for exif-data and for wether or not the image would be too large if encoded with a white background, currently depend on each other.

Both of these would set `do_scale` to `false`:

file-size is too large = false || is an avatar = true && (too high resolution = false || contains exif-data = true && is too large with a white background = false)

file-size is too large = false || is an avatar = true && (too high resolution = false || contains exif-data = false && is too large with a white background = true)

