### PR TITLE
feat: Use `resize` when resampling images with up to 4 megapixels

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -457,19 +457,17 @@ impl<'a> BlobObject<'a> {
                         self::add_white_bg(&mut img);
                     }
 
-                    // resize() results in often slightly better quality,
-                    // however, comes at high price of being 4+ times slower than thumbnail().
-                    // for a typical camera image that is sent, this may be a change from "instant" (500ms) to "long time waiting" (3s).
-                    // as we do not have recoding in background while chat has already a preview,
-                    // we vote for speed.
-                    // exception is the avatar image: this is far more often sent than recoded,
-                    // usually has less pixels by cropping, UI that needs to wait anyways,
-                    // and also benefits from slightly better (5%) encoding of Triangle-filtered images.
-                    let new_img = if is_avatar {
-                        img.resize(target_wh, target_wh, image::imageops::FilterType::Triangle)
-                    } else {
-                        img.thumbnail(target_wh, target_wh)
-                    };
+                    // resize() results in better quality than thumbnail(); however, when using resize(),
+                    // sending images can require about 60% more time.
+                    // As we do not have recoding in the background, while the chat already has a preview,
+                    // and the processing-time is proportional to the original resolution,
+                    // we choose the faster resampling, if the original image has a high resolution.
+                    let new_img =
+                        if is_avatar || img.width().saturating_mul(img.height()) <= 2000 * 2000 {
+                            img.resize(target_wh, target_wh, image::imageops::FilterType::Triangle)
+                        } else {
+                            img.thumbnail(target_wh, target_wh)
+                        };
 
                     if encoded_img_exceeds_bytes(
                         context,

--- a/src/blob/blob_tests.rs
+++ b/src/blob/blob_tests.rs
@@ -517,8 +517,8 @@ async fn test_recode_image_huge_jpg() {
         has_exif: true,
         original_width: 1920,
         original_height: 1080,
-        compressed_width: 1704,
-        compressed_height: 959,
+        compressed_width: 1808,
+        compressed_height: 1017,
         ..Default::default()
     }
     .test()

--- a/src/blob/blob_tests.rs
+++ b/src/blob/blob_tests.rs
@@ -406,8 +406,8 @@ async fn test_recode_image_balanced_png() {
         extension: "png",
         original_width: 1920,
         original_height: 1080,
-        compressed_width: 848,
-        compressed_height: 477,
+        compressed_width: 904,
+        compressed_height: 509,
         ..Default::default()
     }
     .test()
@@ -497,8 +497,8 @@ async fn test_recode_image_rgba_png_to_jpeg() {
         extension: "png",
         original_width: 1920,
         original_height: 1080,
-        compressed_width: 848,
-        compressed_height: 477,
+        compressed_width: 904,
+        compressed_height: 509,
         ..Default::default()
     }
     .test()

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -193,7 +193,7 @@ pub(crate) const WORSE_AVATAR_BYTES: usize = 20_000; // this also fits to Outloo
 
 // max. width/height of images scaled down because of being too huge
 pub const BALANCED_IMAGE_SIZE: u32 = 1360;
-pub const WORSE_IMAGE_SIZE: u32 = 640;
+pub const WORSE_IMAGE_SIZE: u32 = 680;
 
 /// Limit for received images size. Bigger images become `Viewtype::File` to avoid excessive memory
 /// usage by UIs.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -192,7 +192,7 @@ pub(crate) const WORSE_AVATAR_SIZE: u32 = 256;
 pub(crate) const WORSE_AVATAR_BYTES: usize = 20_000; // this also fits to Outlook servers don't allowing headers larger than 32k.
 
 // max. width/height of images scaled down because of being too huge
-pub const BALANCED_IMAGE_SIZE: u32 = 1280;
+pub const BALANCED_IMAGE_SIZE: u32 = 1360;
 pub const WORSE_IMAGE_SIZE: u32 = 640;
 
 /// Limit for received images size. Bigger images become `Viewtype::File` to avoid excessive memory

--- a/src/tests/pre_messages/additional_text.rs
+++ b/src/tests/pre_messages/additional_text.rs
@@ -34,7 +34,7 @@ async fn test_additional_text_on_different_viewtypes() -> Result<()> {
     let (pre_message, _, _) = send_large_image_message(alice, a_group_id).await?;
     let msg = bob.recv_msg(&pre_message).await;
     assert_eq!(msg.text, "test".to_owned());
-    assert_eq!(msg.get_text(), "test [Image – 228.45 KiB]".to_owned());
+    assert_eq!(msg.get_text(), "test [Image – 210.38 KiB]".to_owned());
 
     Ok(())
 }

--- a/src/tests/pre_messages/additional_text.rs
+++ b/src/tests/pre_messages/additional_text.rs
@@ -34,7 +34,7 @@ async fn test_additional_text_on_different_viewtypes() -> Result<()> {
     let (pre_message, _, _) = send_large_image_message(alice, a_group_id).await?;
     let msg = bob.recv_msg(&pre_message).await;
     assert_eq!(msg.text, "test".to_owned());
-    assert_eq!(msg.get_text(), "test [Image – 210.38 KiB]".to_owned());
+    assert_eq!(msg.get_text(), "test [Image – 225.81 KiB]".to_owned());
 
     Ok(())
 }

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -402,9 +402,9 @@ async fn test_receive_pre_message_image() -> Result<()> {
     // test that metadata is correctly returned by methods
     assert_eq!(msg.get_post_message_viewtype(), Some(Viewtype::Image));
     // recoded image dimensions
-    assert_eq!(msg.get_filebytes(bob).await?, Some(215424));
-    assert_eq!(msg.get_height(), 1704);
-    assert_eq!(msg.get_width(), 959);
+    assert_eq!(msg.get_filebytes(bob).await?, Some(231228));
+    assert_eq!(msg.get_height(), 1808);
+    assert_eq!(msg.get_width(), 1017);
 
     Ok(())
 }

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -402,7 +402,7 @@ async fn test_receive_pre_message_image() -> Result<()> {
     // test that metadata is correctly returned by methods
     assert_eq!(msg.get_post_message_viewtype(), Some(Viewtype::Image));
     // recoded image dimensions
-    assert_eq!(msg.get_filebytes(bob).await?, Some(233935));
+    assert_eq!(msg.get_filebytes(bob).await?, Some(215424));
     assert_eq!(msg.get_height(), 1704);
     assert_eq!(msg.get_width(), 959);
 


### PR DESCRIPTION
The `thumbnail`-function can resample images quickly, but with very noticeable aliasing when it is used to resample images to a close resolution (~80% of the original resolution per dimension, for example). Even if the resolution-difference is large, the quality of the resampling is rather flawed. The function seems to be for quickly resampling lots of images into tiny preview-images (less than about 2 x 2 cm , when considering that "Thumbnail" is a reference to the intended size), for which the quality is not particularly important, and the resolution-difference is usually large (~25% of the original resolution per dimension, for example).

The amount of processing/time (including decoding and encoding) required to resample images, depends on the resolution of the original image.

By using the `thumbnail`-function only for images with a high resolution, many images will be resampled with the better resampling of the `resize`-function, while images with a high resolution, will still be resampled more quickly.

#### Quality-comparison:

<details><summary>Original image (2626 x 974 | 2.558 MP | 2.7MB)</summary>

<img width="2626" height="974" alt="original" src="https://github.com/user-attachments/assets/456df700-cb85-49f7-b40f-4b22f159a3f6" />

</details>

`main`-branch:

<img width="2096" height="777" alt="thumbnail" src="https://github.com/user-attachments/assets/5bf0e06f-bf2f-4a1b-b1ad-7bcdada0624d" />

This PR:
<img width="2096" height="777" alt="triangle" src="https://github.com/user-attachments/assets/1fdb3085-4a78-497b-a8dd-34834e7f0d3c" />