### PR TITLE
fix: improve connectivity HTML if quota info error

### DIFF
--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -421,7 +421,8 @@ impl Context {
                     // If not supported by the provider,
                     // just skip the "quota" section.
                     if !matches!(e, crate::quota::Error::NotSupportedByProvider) {
-                        ret += &escaper::encode_minimal(&e.to_string());
+                        // TODO translate "Quota".
+                        ret += &format!("Quota: {}", &*escaper::encode_minimal(&e.to_string()));
                     }
                 }
                 Ok(quota) => {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -421,7 +421,6 @@ impl Context {
                     // If not supported by the provider,
                     // just skip the "quota" section.
                     if !matches!(e, crate::quota::Error::NotSupportedByProvider) {
-                        // TODO translate "Quota".
                         ret += &format!("Quota: {}", &*escaper::encode_minimal(&e.to_string()));
                     }
                 }

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -449,7 +449,6 @@ impl Context {
                     // If not supported by the provider,
                     // just skip the "quota" section.
                     if !matches!(e, crate::quota::Error::NotSupportedByProvider) {
-                        // TODO translate "Quota".
                         ret += &format!("Quota: {}", &*escaper::encode_minimal(&e.to_string()));
                     }
                 }

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -449,7 +449,8 @@ impl Context {
                     // If not supported by the provider,
                     // just skip the "quota" section.
                     if !matches!(e, crate::quota::Error::NotSupportedByProvider) {
-                        ret += &escaper::encode_minimal(&e.to_string());
+                        // TODO translate "Quota".
+                        ret += &format!("Quota: {}", &*escaper::encode_minimal(&e.to_string()));
                     }
                 }
                 Ok(quota) => {


### PR DESCRIPTION
Currently if
~~the provider doesn't support quota info~~
there is an error fetching quota
then the HTML displays something like

```
example.com: Connected
Failed to parse
```

<img width="462" height="269" alt="image" src="https://github.com/user-attachments/assets/21b5b901-16f9-4c8a-a0ed-717bd1d33d54" />

It's not clear that "Failed to parse" only refers to quota info.
