### PR TITLE
docs: add hint about how to reset an invitation

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2641,6 +2641,8 @@ dc_lot_t*       dc_check_qr                  (dc_context_t* context, const char*
  * so that the QR code is useful also without Delta Chat being installed
  * or can be passed to contacts through other channels.
  *
+ * To reset invitations, pass the link to dc_set_config_from_qr().
+ *
  * @memberof dc_context_t
  * @param context The context object.
  * @param chat_id If set to a group-chat-id,

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -883,6 +883,8 @@ impl CommandApi {
 
     /// Get QR code text that will offer a [SecureJoin](https://securejoin.delta.chat/) invitation.
     ///
+    /// To reset invitations, pass the link to `set_config_from_qr()``.
+    ///
     /// If `chat_id` is a group chat ID, SecureJoin QR code for the group is returned.
     /// If `chat_id` is unset, setup contact QR code is returned.
     async fn get_chat_securejoin_qr_code(

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -883,7 +883,7 @@ impl CommandApi {
 
     /// Get QR code text that will offer a [SecureJoin](https://securejoin.delta.chat/) invitation.
     ///
-    /// To reset invitations, pass the link to `set_config_from_qr()``.
+    /// To reset invitations, pass the link to `set_config_from_qr()`.
     ///
     /// If `chat_id` is a group chat ID, SecureJoin QR code for the group is returned.
     /// If `chat_id` is unset, setup contact QR code is returned.


### PR DESCRIPTION
this PR adds a hint about how to reset a QR code. 

the API is as-is, just now, a refactoring here is also unwanted. the jsonrpc documentation needs to improved in general, this is known, and also not done by this PR

closes #7985