### PR TITLE
refactor: split flake.nix into multiple files

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - flake.nix
       - flake.lock
+      - nix/**
       - .github/workflows/nix.yml
   push:
     paths:
       - flake.nix
       - flake.lock
+      - nix/**
       - .github/workflows/nix.yml
     branches:
       - main
@@ -26,7 +28,7 @@ jobs:
           show-progress: false
           persist-credentials: false
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-      - run: nix fmt flake.nix -- --check
+      - run: nix fmt flake.nix nix/ -- --check
 
   build:
     name: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,7 @@
           rustc = fenixToolchain;
         };
         manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
-        androidSdk = android.sdk.${system} (sdkPkgs:
-          builtins.attrValues {
-            inherit (sdkPkgs) ndk-27-2-12479018 cmdline-tools-latest;
-          });
-        androidNdkRoot = "${androidSdk}/share/android-sdk/ndk/27.2.12479018";
+        version = manifest.version;
 
         rustSrc = nix-filter.lib {
           root = ./.;
@@ -83,7 +79,7 @@
           naersk'.buildPackage {
             pname = packageName;
             cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
+            inherit version;
             src = pkgs.lib.cleanSource ./.;
             nativeBuildInputs = [
               pkgs.perl # Needed to build vendored OpenSSL.
@@ -91,221 +87,22 @@
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
           };
-        mkWin64RustPackage = packageName:
-          let
-            pkgsWin64 = pkgs.pkgsCross.mingwW64;
-            rustTarget = pkgsWin64.stdenv.hostPlatform.rust.rustcTarget;
-            toolchainWin = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naerskWin = pkgs.callPackage naersk {
-              cargo = toolchainWin;
-              rustc = toolchainWin;
-            };
-          in
-          naerskWin.buildPackage rec {
-            pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
-            strictDeps = true;
-            src = pkgs.lib.cleanSource ./.;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-            ];
-            depsBuildBuild = [
-              pkgsWin64.stdenv.cc
-            ];
-            buildInputs = [
-              pkgsWin64.windows.pthreads
-            ];
-            auditable = false; # Avoid cargo-auditable failures.
-            doCheck = false; # Disable test as it requires network access.
 
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-            CFLAGS_x86_64_pc_windows_gnu = "-I${pkgsWin64.windows.pthreads}/include";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-              "-L"
-              "native=${pkgsWin64.windows.pthreads}/lib"
-            ];
-
-            CC = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-            LD = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-          };
-
-        mkWin32RustPackage = packageName:
-          let
-            pkgsWin32 = pkgs.pkgsCross.mingw32;
-            rustTarget = pkgsWin32.stdenv.hostPlatform.rust.rustcTarget;
-            toolchainWin = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naerskWin = pkgs.callPackage naersk {
-              cargo = toolchainWin;
-              rustc = toolchainWin;
-            };
-
-            # Get rid of MCF Gthread library.
-            # See <https://github.com/NixOS/nixpkgs/issues/156343>
-            # and <https://discourse.nixos.org/t/statically-linked-mingw-binaries/38395>
-            # for details.
-            #
-            # Use DWARF-2 instead of SJLJ for exception handling.
-            winCC = pkgsWin32.buildPackages.wrapCC (
-              (pkgsWin32.buildPackages.gcc-unwrapped.override
-                ({
-                  threadsCross = {
-                    model = "win32";
-                    package = null;
-                  };
-                })).overrideAttrs (oldAttr: {
-                configureFlags = oldAttr.configureFlags ++ [
-                  "--disable-sjlj-exceptions"
-                  "--with-dwarf2"
-                ];
-              })
-            );
-          in
-          naerskWin.buildPackage rec {
-            pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
-            strictDeps = true;
-            src = pkgs.lib.cleanSource ./.;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-              pkgs.nasm # aws-lc-sys requires it
-            ];
-            depsBuildBuild = [
-              winCC
-            ];
-            buildInputs = [
-              pkgsWin32.windows.pthreads
-            ];
-            auditable = false; # Avoid cargo-auditable failures.
-            doCheck = false; # Disable test as it requires network access.
-
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${winCC}/bin/${winCC.targetPrefix}cc";
-            CFLAGS_i686_pc_windows_gnu = "-I${pkgsWin32.windows.pthreads}/include";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-              "-L"
-              "native=${pkgsWin32.windows.pthreads}/lib"
-            ];
-
-            CC = "${winCC}/bin/${winCC.targetPrefix}cc";
-            LD = "${winCC}/bin/${winCC.targetPrefix}cc";
-          };
-
-        mkCrossRustPackage = arch: packageName:
-          let
-            crossTarget = arch2targets."${arch}";
-            pkgsCross = import nixpkgs {
-              system = system;
-              crossSystem.config = crossTarget;
-            };
-            rustTarget = pkgsCross.stdenv.hostPlatform.rust.rustcTarget;
-            toolchain = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naersk-lib = pkgs.callPackage naersk {
-              cargo = toolchain;
-              rustc = toolchain;
-            };
-          in
-          naersk-lib.buildPackage rec {
-            pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
-            strictDeps = true;
-            src = rustSrc;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-            ];
-            auditable = false; # Avoid cargo-auditable failures.
-            doCheck = false; # Disable test as it requires network access.
-
-            CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
-            CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
-
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-            ];
-
-            CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-            LD = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-          };
-
-        androidAttrs = {
-          armeabi-v7a = {
-            cc = "armv7a-linux-androideabi21-clang";
-            rustTarget = "armv7-linux-androideabi";
-          };
-          arm64-v8a = {
-            cc = "aarch64-linux-android21-clang";
-            rustTarget = "aarch64-linux-android";
-          };
-          x86 = {
-            cc = "i686-linux-android21-clang";
-            rustTarget = "i686-linux-android";
-          };
-          x86_64 = {
-            cc = "x86_64-linux-android21-clang";
-            rustTarget = "x86_64-linux-android";
-          };
+        mkWin64RustPackage = pkgs.callPackage ./nix/win64-package.nix {
+          inherit naersk system fenixPkgs version;
         };
 
-        mkAndroidRustPackage = arch: packageName:
-          let
-            rustTarget = androidAttrs.${arch}.rustTarget;
-            toolchain = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naersk-lib = pkgs.callPackage naersk {
-              cargo = toolchain;
-              rustc = toolchain;
-            };
-            targetToolchain = "${androidNdkRoot}/toolchains/llvm/prebuilt/linux-x86_64";
-            targetCcName = androidAttrs.${arch}.cc;
-            targetCc = "${targetToolchain}/bin/${targetCcName}";
-          in
-          naersk-lib.buildPackage rec {
-            pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
-            strictDeps = true;
-            src = rustSrc;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-            ];
-            auditable = false; # Avoid cargo-auditable failures.
-            doCheck = false; # Disable test as it requires network access.
+        mkWin32RustPackage = pkgs.callPackage ./nix/win32-package.nix {
+          inherit naersk system fenixPkgs version;
+        };
 
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${targetCc}";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-            ];
+        mkCrossRustPackage = pkgs.callPackage ./nix/cross-rust-package.nix {
+          inherit nixpkgs arch2targets naersk fenixPkgs system rustSrc version;
+        };
 
-            CC = "${targetCc}";
-            LD = "${targetCc}";
-          };
+        mkAndroidRustPackage = pkgs.callPackage ./nix/android-package.nix {
+          inherit naersk fenixPkgs system rustSrc android version;
+        };
 
         mkAndroidPackages = arch:
           let
@@ -315,32 +112,7 @@
             "deltachat-rpc-server-${arch}-android" = rpc-server;
             "deltachat-repl-${arch}-android" = mkAndroidRustPackage arch "deltachat-repl";
             "deltachat-rpc-server-${arch}-android-wheel" =
-              pkgs.stdenv.mkDerivation {
-                pname = "deltachat-rpc-server-${arch}-android-wheel";
-                version = manifest.version;
-                src = nix-filter.lib {
-                  root = ./.;
-                  include = [
-                    "scripts/wheel-rpc-server.py"
-                    "deltachat-rpc-server/README.md"
-                    "LICENSE"
-                    "Cargo.toml"
-                  ];
-                };
-                nativeBuildInputs = [
-                  pkgs.python3
-                  pkgs.python3Packages.wheel
-                ];
-                buildInputs = [
-                  rpc-server
-                ];
-                buildPhase = ''
-                  mkdir tmp
-                  cp ${rpc-server}/bin/deltachat-rpc-server tmp/deltachat-rpc-server
-                  python3 scripts/wheel-rpc-server.py ${arch}-android tmp/deltachat-rpc-server
-                '';
-                installPhase = ''mkdir -p $out; cp -av deltachat_rpc_server-*.whl $out'';
-              };
+              mkWheel { inherit rpc-server; arch = "${arch}-android"; };
           };
 
         mkRustPackages = arch:
@@ -350,34 +122,10 @@
           {
             "deltachat-repl-${arch}" = mkCrossRustPackage arch "deltachat-repl";
             "deltachat-rpc-server-${arch}" = rpc-server;
-            "deltachat-rpc-server-${arch}-wheel" =
-              pkgs.stdenv.mkDerivation {
-                pname = "deltachat-rpc-server-${arch}-wheel";
-                version = manifest.version;
-                src = nix-filter.lib {
-                  root = ./.;
-                  include = [
-                    "scripts/wheel-rpc-server.py"
-                    "deltachat-rpc-server/README.md"
-                    "LICENSE"
-                    "Cargo.toml"
-                  ];
-                };
-                nativeBuildInputs = [
-                  pkgs.python3
-                  pkgs.python3Packages.wheel
-                ];
-                buildInputs = [
-                  rpc-server
-                ];
-                buildPhase = ''
-                  mkdir tmp
-                  cp ${rpc-server}/bin/deltachat-rpc-server tmp/deltachat-rpc-server
-                  python3 scripts/wheel-rpc-server.py ${arch} tmp/deltachat-rpc-server
-                '';
-                installPhase = ''mkdir -p $out; cp -av deltachat_rpc_server-*.whl $out'';
-              };
+            "deltachat-rpc-server-${arch}-wheel" = mkWheel { inherit rpc-server; arch = "${arch}"; };
           };
+
+        mkWheel = pkgs.callPackage ./nix/wheel.nix { inherit nix-filter version; root = ./.; };
       in
       {
         formatter = pkgs.nixpkgs-fmt;
@@ -401,116 +149,29 @@
             deltachat-repl-win64 = mkWin64RustPackage "deltachat-repl";
             deltachat-rpc-server-win64 = mkWin64RustPackage "deltachat-rpc-server";
             deltachat-rpc-server-win64-wheel =
-              pkgs.stdenv.mkDerivation {
-                pname = "deltachat-rpc-server-win64-wheel";
-                version = manifest.version;
-                src = nix-filter.lib {
-                  root = ./.;
-                  include = [
-                    "scripts/wheel-rpc-server.py"
-                    "deltachat-rpc-server/README.md"
-                    "LICENSE"
-                    "Cargo.toml"
-                  ];
-                };
-                nativeBuildInputs = [
-                  pkgs.python3
-                  pkgs.python3Packages.wheel
-                ];
-                buildInputs = [
-                  deltachat-rpc-server-win64
-                ];
-                buildPhase = ''
-                  mkdir tmp
-                  cp ${deltachat-rpc-server-win64}/bin/deltachat-rpc-server.exe tmp/deltachat-rpc-server.exe
-                  python3 scripts/wheel-rpc-server.py win64 tmp/deltachat-rpc-server.exe
-                '';
-                installPhase = ''mkdir -p $out; cp -av deltachat_rpc_server-*.whl $out'';
-              };
+              mkWheel { rpc-server = deltachat-rpc-server-win64; arch = "win64"; binaryName = "deltachat-rpc-server.exe"; };
 
             deltachat-repl-win32 = mkWin32RustPackage "deltachat-repl";
             deltachat-rpc-server-win32 = mkWin32RustPackage "deltachat-rpc-server";
             deltachat-rpc-server-win32-wheel =
-              pkgs.stdenv.mkDerivation {
-                pname = "deltachat-rpc-server-win32-wheel";
-                version = manifest.version;
-                src = nix-filter.lib {
-                  root = ./.;
-                  include = [
-                    "scripts/wheel-rpc-server.py"
-                    "deltachat-rpc-server/README.md"
-                    "LICENSE"
-                    "Cargo.toml"
-                  ];
-                };
-                nativeBuildInputs = [
-                  pkgs.python3
-                  pkgs.python3Packages.wheel
-                ];
-                buildInputs = [
-                  deltachat-rpc-server-win32
-                ];
-                buildPhase = ''
-                  mkdir tmp
-                  cp ${deltachat-rpc-server-win32}/bin/deltachat-rpc-server.exe tmp/deltachat-rpc-server.exe
-                  python3 scripts/wheel-rpc-server.py win32 tmp/deltachat-rpc-server.exe
-                '';
-                installPhase = ''mkdir -p $out; cp -av deltachat_rpc_server-*.whl $out'';
-              };
+              mkWheel
+                { rpc-server = deltachat-rpc-server-win32; arch = "win32"; binaryName = "deltachat-rpc-server.exe"; };
+
             # Run `nix build .#docs` to get C docs generated in `./result/`.
-            docs =
-              pkgs.stdenv.mkDerivation {
-                pname = "docs";
-                version = manifest.version;
-                src = pkgs.lib.cleanSource ./.;
-                nativeBuildInputs = [ pkgs.doxygen ];
-                buildPhase = ''scripts/run-doxygen.sh'';
-                installPhase = ''mkdir -p $out; cp -av deltachat-ffi/html deltachat-ffi/xml $out'';
-              };
+            docs = pkgs.callPackage ./nix/c-docs.nix { inherit version; };
 
-            libdeltachat =
-              let
-                rustPlatform = (pkgs.makeRustPlatform {
-                  cargo = fenixToolchain;
-                  rustc = fenixToolchain;
-                });
-              in
-              pkgs.stdenv.mkDerivation {
-                pname = "libdeltachat";
-                version = manifest.version;
-                src = rustSrc;
-                cargoDeps = pkgs.rustPlatform.importCargoLock cargoLock;
+            libdeltachat = pkgs.callPackage ./nix/libdeltachat.nix {
+              inherit fenixToolchain rustSrc cargoLock fenixPkgs version;
+            };
 
-                nativeBuildInputs = [
-                  pkgs.perl # Needed to build vendored OpenSSL.
-                  pkgs.cmake
-                  rustPlatform.cargoSetupHook
-                  fenixPkgs.stable.rustc
-                  fenixPkgs.stable.cargo
-                ];
-
-                postInstall = ''
-                  substituteInPlace $out/include/deltachat.h \
-                    --replace __FILE__ '"${placeholder "out"}/include/deltachat.h"'
-                '';
-              };
-
-            deltachat-rpc-client =
-              pkgs.python3Packages.buildPythonPackage {
-                pname = "deltachat-rpc-client";
-                version = manifest.version;
-                src = pkgs.lib.cleanSource ./deltachat-rpc-client;
-                format = "pyproject";
-                propagatedBuildInputs = [
-                  pkgs.python3Packages.setuptools
-                  pkgs.python3Packages.imap-tools
-                ];
-              };
+            deltachat-rpc-client = pkgs.callPackage ./nix/deltachat-rpc-client.nix {
+              inherit version;
+            };
 
             deltachat-python =
               pkgs.python3Packages.buildPythonPackage {
                 pname = "deltachat-python";
-                version = manifest.version;
+                inherit version;
                 src = pkgs.lib.cleanSource ./python;
                 format = "pyproject";
                 buildInputs = [
@@ -528,51 +189,12 @@
                   pkgs.python3Packages.requests
                 ];
               };
-            python-docs =
-              pkgs.stdenv.mkDerivation {
-                pname = "docs";
-                version = manifest.version;
-                src = pkgs.lib.cleanSource ./.;
-                buildInputs = [
-                  deltachat-python
-                  deltachat-rpc-client
-                  pkgs.python3Packages.breathe
-                  pkgs.python3Packages.sphinx-rtd-theme
-                ];
-                nativeBuildInputs = [ pkgs.sphinx ];
-                buildPhase = ''sphinx-build -b html -a python/doc/ dist/html'';
-                installPhase = ''mkdir -p $out; cp -av dist/html $out'';
-              };
-          };
-
-        devShells.default =
-          let
-            pkgs = import nixpkgs {
-              system = system;
-              overlays = [ fenix.overlays.default ];
+            python-docs = pkgs.callPackage ./nix/python-docs.nix {
+              inherit deltachat-python deltachat-rpc-client version;
             };
-          in
-          pkgs.mkShell {
-
-            buildInputs = with pkgs; [
-              (fenix.packages.${system}.complete.withComponents [
-                "cargo"
-                "clippy"
-                "rust-src"
-                "rustc"
-                "rustfmt"
-              ])
-              cargo-deny
-              rust-analyzer-nightly
-              cargo-nextest
-              perl # needed to build vendored OpenSSL
-              git-cliff
-              (python3.withPackages (pypkgs: with pypkgs; [
-                tox
-              ]))
-              nodejs
-            ];
           };
+
+        devShells.default = import ./nix/shell.nix { inherit nixpkgs fenix system; };
       }
     );
 }

--- a/nix/android-package.nix
+++ b/nix/android-package.nix
@@ -1,0 +1,63 @@
+{ pkgs, naersk, fenixPkgs, system, version, rustSrc, android }:
+arch: packageName:
+let
+  androidSdk = android.sdk.${system} (sdkPkgs:
+    builtins.attrValues {
+      inherit (sdkPkgs) ndk-27-2-12479018 cmdline-tools-latest;
+    });
+  androidNdkRoot = "${androidSdk}/share/android-sdk/ndk/27.2.12479018";
+  androidAttrs = {
+    armeabi-v7a = {
+      cc = "armv7a-linux-androideabi21-clang";
+      rustTarget = "armv7-linux-androideabi";
+    };
+    arm64-v8a = {
+      cc = "aarch64-linux-android21-clang";
+      rustTarget = "aarch64-linux-android";
+    };
+    x86 = {
+      cc = "i686-linux-android21-clang";
+      rustTarget = "i686-linux-android";
+    };
+    x86_64 = {
+      cc = "x86_64-linux-android21-clang";
+      rustTarget = "x86_64-linux-android";
+    };
+  };
+
+  rustTarget = androidAttrs.${arch}.rustTarget;
+  toolchain = fenixPkgs.combine [
+    fenixPkgs.stable.rustc
+    fenixPkgs.stable.cargo
+    fenixPkgs.targets.${rustTarget}.stable.rust-std
+  ];
+  naersk-lib = pkgs.callPackage naersk {
+    cargo = toolchain;
+    rustc = toolchain;
+  };
+  targetToolchain = "${androidNdkRoot}/toolchains/llvm/prebuilt/linux-x86_64";
+  targetCcName = androidAttrs.${arch}.cc;
+  targetCc = "${targetToolchain}/bin/${targetCcName}";
+in
+naersk-lib.buildPackage {
+  pname = packageName;
+  cargoBuildOptions = x: x ++ [ "--package" packageName ];
+  inherit version;
+  strictDeps = true;
+  src = rustSrc;
+  nativeBuildInputs = [
+    pkgs.perl # Needed to build vendored OpenSSL.
+  ];
+  auditable = false; # Avoid cargo-auditable failures.
+  doCheck = false; # Disable test as it requires network access.
+
+  CARGO_BUILD_TARGET = rustTarget;
+  TARGET_CC = "${targetCc}";
+  CARGO_BUILD_RUSTFLAGS = [
+    "-C"
+    "linker=${targetCc}"
+  ];
+
+  CC = "${targetCc}";
+  LD = "${targetCc}";
+}

--- a/nix/c-docs.nix
+++ b/nix/c-docs.nix
@@ -1,0 +1,9 @@
+{ pkgs, version }:
+pkgs.stdenv.mkDerivation {
+  pname = "docs";
+  inherit version;
+  src = pkgs.lib.cleanSource ../.;
+  nativeBuildInputs = [ pkgs.doxygen ];
+  buildPhase = ''scripts/run-doxygen.sh'';
+  installPhase = ''mkdir -p $out; cp -av deltachat-ffi/html deltachat-ffi/xml $out'';
+}

--- a/nix/cross-rust-package.nix
+++ b/nix/cross-rust-package.nix
@@ -1,0 +1,45 @@
+{ pkgs, nixpkgs, arch2targets, naersk, fenixPkgs, system, rustSrc, version }:
+arch: packageName:
+let
+  crossTarget = arch2targets."${arch}";
+  pkgsCross = import nixpkgs {
+    system = system;
+    crossSystem.config = crossTarget;
+  };
+  rustTarget = pkgsCross.stdenv.hostPlatform.rust.rustcTarget;
+  toolchain = fenixPkgs.combine [
+    fenixPkgs.stable.rustc
+    fenixPkgs.stable.cargo
+    fenixPkgs.targets.${rustTarget}.stable.rust-std
+  ];
+  naersk-lib = pkgs.callPackage naersk {
+    cargo = toolchain;
+    rustc = toolchain;
+  };
+  targetCc = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+in
+naersk-lib.buildPackage {
+  pname = packageName;
+  cargoBuildOptions = x: x ++ [ "--package" packageName ];
+  inherit version;
+  strictDeps = true;
+  src = rustSrc;
+  nativeBuildInputs = [
+    pkgs.perl # Needed to build vendored OpenSSL.
+  ];
+  auditable = false; # Avoid cargo-auditable failures.
+  doCheck = false; # Disable test as it requires network access.
+
+  CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
+  CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
+
+  CARGO_BUILD_TARGET = rustTarget;
+  TARGET_CC = "${targetCc}";
+  CARGO_BUILD_RUSTFLAGS = [
+    "-C"
+    "linker=${targetCc}"
+  ];
+
+  CC = "${targetCc}";
+  LD = "${targetCc}";
+}

--- a/nix/deltachat-rpc-client.nix
+++ b/nix/deltachat-rpc-client.nix
@@ -1,0 +1,11 @@
+{ pkgs, version }:
+pkgs.python3Packages.buildPythonPackage {
+  pname = "deltachat-rpc-client";
+  inherit version;
+  src = pkgs.lib.cleanSource ../deltachat-rpc-client;
+  format = "pyproject";
+  propagatedBuildInputs = [
+    pkgs.python3Packages.setuptools
+    pkgs.python3Packages.imap-tools
+  ];
+}

--- a/nix/libdeltachat.nix
+++ b/nix/libdeltachat.nix
@@ -1,0 +1,26 @@
+{ pkgs, fenixToolchain, rustSrc, cargoLock, fenixPkgs, version }:
+let
+  rustPlatform = (pkgs.makeRustPlatform {
+    cargo = fenixToolchain;
+    rustc = fenixToolchain;
+  });
+in
+pkgs.stdenv.mkDerivation {
+  pname = "libdeltachat";
+  inherit version;
+  src = rustSrc;
+  cargoDeps = pkgs.rustPlatform.importCargoLock cargoLock;
+
+  nativeBuildInputs = [
+    pkgs.perl # Needed to build vendored OpenSSL.
+    pkgs.cmake
+    rustPlatform.cargoSetupHook
+    fenixPkgs.stable.rustc
+    fenixPkgs.stable.cargo
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/include/deltachat.h \
+      --replace __FILE__ '"${placeholder "out"}/include/deltachat.h"'
+  '';
+}

--- a/nix/python-docs.nix
+++ b/nix/python-docs.nix
@@ -1,0 +1,15 @@
+{ pkgs, version, deltachat-python, deltachat-rpc-client }:
+pkgs.stdenv.mkDerivation {
+  pname = "docs";
+  inherit version;
+  src = pkgs.lib.cleanSource ../.;
+  buildInputs = [
+    deltachat-python
+    deltachat-rpc-client
+    pkgs.python3Packages.breathe
+    pkgs.python3Packages.sphinx-rtd-theme
+  ];
+  nativeBuildInputs = [ pkgs.sphinx ];
+  buildPhase = ''sphinx-build -b html -a python/doc/ dist/html'';
+  installPhase = ''mkdir -p $out; cp -av dist/html $out'';
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,27 @@
+{ nixpkgs, fenix, system }:
+let
+  pkgs = import nixpkgs {
+    inherit system;
+    overlays = [ fenix.overlays.default ];
+  };
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    (fenix.packages.${system}.complete.withComponents [
+      "cargo"
+      "clippy"
+      "rust-src"
+      "rustc"
+      "rustfmt"
+    ])
+    cargo-deny
+    rust-analyzer-nightly
+    cargo-nextest
+    perl # needed to build vendored OpenSSL
+    git-cliff
+    (python3.withPackages (pypkgs: [
+      pypkgs.tox
+    ]))
+    nodejs
+  ];
+}

--- a/nix/wheel.nix
+++ b/nix/wheel.nix
@@ -1,0 +1,28 @@
+{ pkgs, nix-filter, version, root }:
+{ rpc-server, arch, binaryName ? "deltachat-rpc-server" }:
+pkgs.stdenv.mkDerivation {
+  pname = "deltachat-rpc-server-${arch}-wheel";
+  inherit version;
+  src = nix-filter.lib {
+    inherit root;
+    include = [
+      "scripts/wheel-rpc-server.py"
+      "deltachat-rpc-server/README.md"
+      "LICENSE"
+      "Cargo.toml"
+    ];
+  };
+  nativeBuildInputs = [
+    pkgs.python3
+    pkgs.python3Packages.wheel
+  ];
+  buildInputs = [
+    rpc-server
+  ];
+  buildPhase = ''
+    mkdir tmp
+    cp ${rpc-server}/bin/${binaryName} tmp/${binaryName}
+    python3 scripts/wheel-rpc-server.py ${arch} tmp/${binaryName}
+  '';
+  installPhase = ''mkdir -p $out; cp -av deltachat_rpc_server-*.whl $out'';
+}

--- a/nix/win32-package.nix
+++ b/nix/win32-package.nix
@@ -1,0 +1,69 @@
+{ pkgs, naersk, fenixPkgs, system, version }:
+packageName:
+let
+  pkgsWin32 = pkgs.pkgsCross.mingw32;
+  rustTarget = pkgsWin32.stdenv.hostPlatform.rust.rustcTarget;
+  toolchainWin = fenixPkgs.combine [
+    fenixPkgs.stable.rustc
+    fenixPkgs.stable.cargo
+    fenixPkgs.targets.${rustTarget}.stable.rust-std
+  ];
+  naerskWin = pkgs.callPackage naersk {
+    cargo = toolchainWin;
+    rustc = toolchainWin;
+  };
+
+  # Get rid of MCF Gthread library.
+  # See <https://github.com/NixOS/nixpkgs/issues/156343>
+  # and <https://discourse.nixos.org/t/statically-linked-mingw-binaries/38395>
+  # for details.
+  #
+  # Use DWARF-2 instead of SJLJ for exception handling.
+  winCC = pkgsWin32.buildPackages.wrapCC (
+    (pkgsWin32.buildPackages.gcc-unwrapped.override
+      ({
+        threadsCross = {
+          model = "win32";
+          package = null;
+        };
+      })).overrideAttrs (oldAttr: {
+      configureFlags = oldAttr.configureFlags ++ [
+        "--disable-sjlj-exceptions"
+        "--with-dwarf2"
+      ];
+    })
+  );
+  targetCc = "${winCC}/bin/${winCC.targetPrefix}cc";
+in
+naerskWin.buildPackage {
+  pname = packageName;
+  cargoBuildOptions = x: x ++ [ "--package" packageName ];
+  inherit version;
+  strictDeps = true;
+  src = pkgs.lib.cleanSource ../.;
+  nativeBuildInputs = [
+    pkgs.perl # Needed to build vendored OpenSSL.
+    pkgs.nasm # aws-lc-sys requires it
+  ];
+  depsBuildBuild = [
+    winCC
+  ];
+  buildInputs = [
+    pkgsWin32.windows.pthreads
+  ];
+  auditable = false; # Avoid cargo-auditable failures.
+  doCheck = false; # Disable test as it requires network access.
+
+  CARGO_BUILD_TARGET = rustTarget;
+  TARGET_CC = "${targetCc}";
+  CFLAGS_i686_pc_windows_gnu = "-I${pkgsWin32.windows.pthreads}/include";
+  CARGO_BUILD_RUSTFLAGS = [
+    "-C"
+    "linker=${targetCc}"
+    "-L"
+    "native=${pkgsWin32.windows.pthreads}/lib"
+  ];
+
+  CC = "${targetCc}";
+  LD = "${targetCc}";
+}

--- a/nix/win64-package.nix
+++ b/nix/win64-package.nix
@@ -1,0 +1,47 @@
+{ pkgs, naersk, fenixPkgs, system, version }:
+packageName:
+let
+  pkgsWin64 = pkgs.pkgsCross.mingwW64;
+  rustTarget = pkgsWin64.stdenv.hostPlatform.rust.rustcTarget;
+  toolchainWin = fenixPkgs.combine [
+    fenixPkgs.stable.rustc
+    fenixPkgs.stable.cargo
+    fenixPkgs.targets.${rustTarget}.stable.rust-std
+  ];
+  naerskWin = pkgs.callPackage naersk {
+    cargo = toolchainWin;
+    rustc = toolchainWin;
+  };
+  targetCc = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
+in
+naerskWin.buildPackage {
+  pname = packageName;
+  cargoBuildOptions = x: x ++ [ "--package" packageName ];
+  inherit version;
+  strictDeps = true;
+  src = pkgs.lib.cleanSource ../.;
+  nativeBuildInputs = [
+    pkgs.perl # Needed to build vendored OpenSSL.
+  ];
+  depsBuildBuild = [
+    pkgsWin64.stdenv.cc
+  ];
+  buildInputs = [
+    pkgsWin64.windows.pthreads
+  ];
+  auditable = false; # Avoid cargo-auditable failures.
+  doCheck = false; # Disable test as it requires network access.
+
+  CARGO_BUILD_TARGET = rustTarget;
+  TARGET_CC = "${targetCc}";
+  CFLAGS_x86_64_pc_windows_gnu = "-I${pkgsWin64.windows.pthreads}/include";
+  CARGO_BUILD_RUSTFLAGS = [
+    "-C"
+    "linker=${targetCc}"
+    "-L"
+    "native=${pkgsWin64.windows.pthreads}/lib"
+  ];
+
+  CC = "${targetCc}";
+  LD = "${targetCc}";
+}


### PR DESCRIPTION
There are more things to split out, cleanup and refactor e.g. around rustPlatform and rust toolchains, but i'm not going to do it now, so this PR is finished.

I tried to split out everything without changes and refactoring, the only minimal changes are for relative paths and replacing `manifest.version` with `inherit version` where the version is passed as an argument.