### PR TITLE
build(nix): make it possible to build powerpc64le-linux and riscv64-linux builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -46,6 +46,8 @@ jobs:
           - deltachat-repl-armv6l-linux
           - deltachat-repl-armv7l-linux
           - deltachat-repl-i686-linux
+          - deltachat-repl-powerpc64le-linux
+          - deltachat-repl-riscv64-linux
           - deltachat-repl-win32
           - deltachat-repl-win64
           - deltachat-repl-x86_64-linux
@@ -63,6 +65,8 @@ jobs:
           - deltachat-rpc-server-armv7l-linux-wheel
           - deltachat-rpc-server-i686-linux
           - deltachat-rpc-server-i686-linux-wheel
+          - deltachat-rpc-server-powerpc64le-linux
+          - deltachat-rpc-server-riscv64-linux
           - deltachat-rpc-server-win32
           - deltachat-rpc-server-win32-wheel
           - deltachat-rpc-server-win64

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -48,6 +48,8 @@ jobs:
           - deltachat-repl-armv6l-linux
           - deltachat-repl-armv7l-linux
           - deltachat-repl-i686-linux
+          - deltachat-repl-powerpc64le-linux
+          - deltachat-repl-riscv64-linux
           - deltachat-repl-win32
           - deltachat-repl-win64
           - deltachat-repl-x86_64-linux
@@ -65,6 +67,8 @@ jobs:
           - deltachat-rpc-server-armv7l-linux-wheel
           - deltachat-rpc-server-i686-linux
           - deltachat-rpc-server-i686-linux-wheel
+          - deltachat-rpc-server-powerpc64le-linux
+          - deltachat-rpc-server-riscv64-linux
           - deltachat-rpc-server-win32
           - deltachat-rpc-server-win32-wheel
           - deltachat-rpc-server-win64

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
           "armv6l-linux" = "armv6l-unknown-linux-musleabihf";
           "aarch64-linux" = "aarch64-unknown-linux-musl";
           "i686-linux" = "i686-unknown-linux-musl";
+          "powerpc64le-linux" = "powerpc64le-unknown-linux-musl";
+          "riscv64-linux" = "riscv64-unknown-linux-musl";
           "x86_64-darwin" = "x86_64-darwin";
           "aarch64-darwin" = "aarch64-darwin";
         };
@@ -136,6 +138,8 @@
           mkRustPackages "x86_64-linux" //
           mkRustPackages "armv7l-linux" //
           mkRustPackages "armv6l-linux" //
+          mkRustPackages "powerpc64le-linux" //
+          mkRustPackages "riscv64-linux" //
           mkRustPackages "x86_64-darwin" //
           mkRustPackages "aarch64-darwin" //
           mkAndroidPackages "armeabi-v7a" //


### PR DESCRIPTION
Part of #8349 

Based on #8272 

Commit message copy-pasted for convenience:

---
I have checked locally with "nix repl nixpkgs",
these are the targets currently supported:
 - legacyPackages.aarch64-darwin
 - legacyPackages.aarch64-linux
 - legacyPackages.armv6l-linux
 - legacyPackages.armv7l-linux
 - legacyPackages.i686-linux
 - legacyPackages.powerpc64le-linux
 - legacyPackages.riscv64-linux
 - legacyPackages.x86_64-darwin
 - legacyPackages.x86_64-freebsd
 - legacyPackages.x86_64-linux

Now we have all supported targets in the flake except for x86_64-freebsd

I tested locally that the builds work, but have not tested if it is possible to run them.

After running "nix build .#deltachat-rpc-server-powerpc64le-linux"
"file result/bin/deltachat-rpc-server" prints:
```
result/bin/deltachat-rpc-server: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI, version 1 (SYSV), statically linked, stripped
```

After running "nix build .#deltachat-rpc-server-riscv64-linux"
"file result/bin/deltachat-rpc-server" prints:
```
result/bin/deltachat-rpc-server: ELF 64-bit LSB pie executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /nix/store/ba1gsm7zvwl7id5njwzdx1igbdqydhm3-musl-riscv64-unknown-linux-musl-1.2.5/lib/ld-musl-riscv64.so.1, stripped
```