### PR TITLE
broadcast channel reactions

### DIFF
--- a/deltachat-jsonrpc/src/api/types/reactions.rs
+++ b/deltachat-jsonrpc/src/api/types/reactions.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use deltachat::contact::ContactId;
 use deltachat::reaction::Reactions;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
@@ -34,30 +33,23 @@ pub struct JsonrpcReactions {
 impl From<Reactions> for JsonrpcReactions {
     fn from(reactions: Reactions) -> Self {
         let reactions_by_contact: BTreeMap<u32, Vec<String>> = reactions
-            .iter()
+            .by_contact.iter()
             .map(|(key, value)| (key.to_u32(), vec![value.as_str().to_string()]))
             .collect();
-        let self_reaction = reactions_by_contact.get(&ContactId::SELF.to_u32());
 
-        let mut reactions_v = Vec::new();
-        for (emoji, count) in reactions.emoji_sorted_by_frequency() {
-            let is_from_self = if let Some(self_reaction) = self_reaction {
-                self_reaction.contains(&emoji)
-            } else {
-                false
-            };
-
-            let reaction = JsonrpcReaction {
-                emoji,
-                count,
-                is_from_self,
-            };
-            reactions_v.push(reaction)
-        }
+        let reactions = reactions
+            .frequencies
+            .into_iter()
+            .map(|entry| JsonrpcReaction {
+                emoji: entry.reaction.as_str().to_string(),
+                count: entry.count,
+                is_from_self: entry.is_from_self,
+            })
+            .collect();
 
         JsonrpcReactions {
             reactions_by_contact,
-            reactions: reactions_v,
+            reactions,
         }
     }
 }

--- a/deltachat-jsonrpc/src/api/types/reactions.rs
+++ b/deltachat-jsonrpc/src/api/types/reactions.rs
@@ -33,7 +33,8 @@ pub struct JsonrpcReactions {
 impl From<Reactions> for JsonrpcReactions {
     fn from(reactions: Reactions) -> Self {
         let reactions_by_contact: BTreeMap<u32, Vec<String>> = reactions
-            .by_contact.iter()
+            .by_contact
+            .iter()
             .map(|(key, value)| (key.to_u32(), vec![value.as_str().to_string()]))
             .collect();
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3711,14 +3711,15 @@ pub(crate) async fn create_out_broadcast_ex(
 
         t.execute(
             "INSERT INTO chats
-            (type, name, name_normalized, grpid, created_timestamp, param)
-            VALUES(?, ?, ?, ?, ?, ?)",
+            (type, name, name_normalized, grpid, created_timestamp, muted_until, param)
+            VALUES(?, ?, ?, ?, ?, ?, ?)",
             (
                 Chattype::OutBroadcast,
                 &chat_name,
                 normalize_text(&chat_name),
                 &grpid,
                 timestamp,
+                MuteDuration::Forever,
                 params.to_string(),
             ),
         )?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2687,10 +2687,11 @@ async fn prepare_send_msg(
         // from the chat.
         CantSendReason::NotAMember => msg.param.get_cmd() == SystemMessage::MemberRemovedFromGroup,
         CantSendReason::InBroadcast => {
-            matches!(
-                msg.param.get_cmd(),
-                SystemMessage::MemberRemovedFromGroup | SystemMessage::SecurejoinMessage
-            )
+            msg.param.get_int(Param::Reaction).unwrap_or_default() != 0
+                || matches!(
+                    msg.param.get_cmd(),
+                    SystemMessage::MemberRemovedFromGroup | SystemMessage::SecurejoinMessage
+                )
         }
         CantSendReason::MissingKey => msg
             .param

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3057,6 +3057,29 @@ async fn test_broadcast_change_name() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_broadcast_muted() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    // Alice's new outgoing broadcast channel is muted after creation:
+    // Channel owners can only get reaction notifications; they are usually not of much interest.
+    let alice_chat_id = create_broadcast(alice, "Channel".to_string()).await?;
+    let qr = get_securejoin_qr(alice, Some(alice_chat_id)).await?;
+    let alice_chat = Chat::load_from_db(alice, alice_chat_id).await?;
+    assert!(alice_chat.is_muted());
+
+    // Bob joins the channel, for him, it is not muted:
+    // For channel subscribers, new messages to newly subscribed channels are often interesting.
+    let bob_chat_id = tcm.exec_securejoin_qr(bob, alice, &qr).await;
+    bob_chat_id.accept(bob).await?;
+    let bob_chat = Chat::load_from_db(bob, bob_chat_id).await?;
+    assert!(!bob_chat.is_muted());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_broadcast_resend_to_new_member() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,6 +346,9 @@ pub enum Config {
     /// Timestamp of the last time housekeeping was run
     LastHousekeeping,
 
+    /// Timestamp of the last time accumulated broadcast channel reactions were sent
+    LastReactionsBroadcast,
+
     /// Timestamp of the last `CantDecryptOutgoingMsgs` notification.
     LastCantDecryptOutgoingMsgs,
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -199,6 +199,9 @@ pub(crate) const EDITED_PREFIX: &str = "✏️";
 /// Period between `sql::housekeeping()` runs.
 pub(crate) const HOUSEKEEPING_PERIOD: i64 = 24 * 60 * 60;
 
+/// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
+pub(crate) const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
+
 pub(crate) const BROADCAST_INCOMPATIBILITY_MSG: &str = r#"The up to now "experimental channels feature" is about to become an officially supported one. By that, privacy will be improved, it will become faster, and less traffic will be consumed.
 
 As we do not guarantee feature-stability for such experiments, this means, that you will need to create the channel again. 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -199,9 +199,6 @@ pub(crate) const EDITED_PREFIX: &str = "✏️";
 /// Period between `sql::housekeeping()` runs.
 pub(crate) const HOUSEKEEPING_PERIOD: i64 = 24 * 60 * 60;
 
-/// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
-pub(crate) const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
-
 pub(crate) const BROADCAST_INCOMPATIBILITY_MSG: &str = r#"The up to now "experimental channels feature" is about to become an officially supported one. By that, privacy will be improved, it will become faster, and less traffic will be consumed.
 
 As we do not guarantee feature-stability for such experiments, this means, that you will need to create the channel again. 

--- a/src/context.rs
+++ b/src/context.rs
@@ -957,6 +957,12 @@ impl Context {
                 .to_string(),
         );
         res.insert(
+            "last_reactions_broadcast",
+            self.get_config_int(Config::LastReactionsBroadcast)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "last_cant_decrypt_outgoing_msgs",
             self.get_config_int(Config::LastCantDecryptOutgoingMsgs)
                 .await?

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -92,7 +92,7 @@ pub enum EventType {
         /// ID of the message for which reactions were changed.
         msg_id: MsgId,
 
-        /// ID of the contact whose reaction set is changed.
+        /// ID of the contact whose reaction set is changed. May be 0 eg. in case of broadcasted reactions.
         contact_id: ContactId,
     },
 

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -124,7 +124,7 @@ pub enum HeaderDef {
 
     /// Broadcasted reactions for this or other chat messages.
     /// See broadcast_reactions.rs for the wire format.
-    ChatReactions,
+    BroadcastReactions,
 
     /// [Autocrypt](https://autocrypt.org/) header.
     Autocrypt,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -124,7 +124,7 @@ pub enum HeaderDef {
 
     /// Broadcasted reactions for this or other chat messages.
     /// See broadcast_reactions.rs for the wire format.
-    BroadcastReactions,
+    ChatBroadcastReactions,
 
     /// [Autocrypt](https://autocrypt.org/) header.
     Autocrypt,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -122,8 +122,9 @@ pub enum HeaderDef {
     /// This is an unprotected header.
     ChatIsPostMessage,
 
-    /// Broadcasted reactions.
-    ChatReactionBroadcast,
+    /// Broadcasted reactions for this or other chat messages.
+    /// See broadcast_reactions.rs for the wire format.
+    ChatReactions,
 
     /// [Autocrypt](https://autocrypt.org/) header.
     Autocrypt,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -122,6 +122,9 @@ pub enum HeaderDef {
     /// This is an unprotected header.
     ChatIsPostMessage,
 
+    /// Broadcasted reactions.
+    ChatReactionBroadcast,
+
     /// [Autocrypt](https://autocrypt.org/) header.
     Autocrypt,
     AutocryptGossip,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1986,6 +1986,13 @@ impl MimeFactory {
             ))
         }
 
+        if let Some(chat_reactions) = msg.param.get(Param::ChatReactions) {
+            headers.push((
+                "Chat-Reactions",
+                mail_builder::headers::raw::Raw::new(b_encode(chat_reactions)).into(),
+            ));
+        }
+
         if msg.viewtype == Viewtype::Voice
             || msg.viewtype == Viewtype::Audio
             || msg.viewtype == Viewtype::Video

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1986,10 +1986,10 @@ impl MimeFactory {
             ))
         }
 
-        if let Some(chat_reactions) = msg.param.get(Param::ChatReactions) {
+        if let Some(broadcast_reactions) = msg.param.get(Param::BroadcastReactions) {
             headers.push((
-                "Chat-Reactions",
-                mail_builder::headers::raw::Raw::new(b_encode(chat_reactions)).into(),
+                "Broadcast-Reactions",
+                mail_builder::headers::raw::Raw::new(b_encode(broadcast_reactions)).into(),
             ));
         }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1988,7 +1988,7 @@ impl MimeFactory {
 
         if let Some(broadcast_reactions) = msg.param.get(Param::BroadcastReactions) {
             headers.push((
-                "Broadcast-Reactions",
+                "Chat-Broadcast-Reactions",
                 mail_builder::headers::raw::Raw::new(b_encode(broadcast_reactions)).into(),
             ));
         }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -116,7 +116,7 @@ pub(crate) struct MimeMessage {
     pub(crate) mdn_reports: Vec<Report>,
     pub(crate) delivery_report: Option<DeliveryReport>,
 
-    /// Parsed `Broadcast-Reactions` header, if any:
+    /// Parsed `Chat-Broadcast-Reactions` header, if any:
     /// accumulated reaction updates sent by a broadcast channel owner.
     pub(crate) broadcast_reactions: Option<String>,
 
@@ -800,7 +800,7 @@ impl MimeMessage {
 
     fn parse_broadcast_reactions_header(&mut self) {
         self.broadcast_reactions = self
-            .get_header(HeaderDef::BroadcastReactions)
+            .get_header(HeaderDef::ChatBroadcastReactions)
             .map(|s| s.to_string());
     }
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -116,6 +116,10 @@ pub(crate) struct MimeMessage {
     pub(crate) mdn_reports: Vec<Report>,
     pub(crate) delivery_report: Option<DeliveryReport>,
 
+    /// Parsed `Broadcast-Reactions` header, if any:
+    /// accumulated reaction updates sent by a broadcast channel owner.
+    pub(crate) broadcast_reactions: Option<String>,
+
     /// Standard USENET signature, if any.
     ///
     /// `None` means no text part was received, empty string means a text part without a footer is
@@ -657,6 +661,7 @@ impl MimeMessage {
             user_avatar: None,
             group_avatar: None,
             delivery_report: None,
+            broadcast_reactions: None,
             footer: None,
             is_mime_modified: false,
             decoded_data: Vec::new(),
@@ -793,6 +798,12 @@ impl MimeMessage {
         }
     }
 
+    fn parse_broadcast_reactions_header(&mut self) {
+        self.broadcast_reactions = self
+            .get_header(HeaderDef::BroadcastReactions)
+            .map(|s| s.to_string());
+    }
+
     /// Squashes mutitpart chat messages with attachment into single-part messages.
     ///
     /// Delta Chat sends attachments, such as images, in two-part messages, with the first message
@@ -874,6 +885,7 @@ impl MimeMessage {
         self.parse_system_message_headers();
         self.parse_avatar_headers(context)?;
         self.parse_videochat_headers();
+        self.parse_broadcast_reactions_header();
         if self.delivery_report.is_none() {
             self.squash_attachment_parts();
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -73,7 +73,7 @@ pub enum Param {
     /// For Messages: Render message as a RFC 9078 reaction.
     Reaction = b'x',
 
-    /// For Messages: Additional reactions that go to the BroadcastReactions: header
+    /// For Messages: Additional reactions that go to the Broadcast-Reactions: header
     BroadcastReactions = b'X',
 
     /// For Chats: the timestamp of the last reaction.

--- a/src/param.rs
+++ b/src/param.rs
@@ -70,8 +70,11 @@ pub enum Param {
     /// For Messages
     WantsMdn = b'r',
 
-    /// For Messages: the message is a reaction.
+    /// For Messages: Render message as a RFC 9078 reaction.
     Reaction = b'x',
+
+    /// For Messages: Additional reactions that go to the ChatReactions: header
+    ChatReactions = b'X',
 
     /// For Chats: the timestamp of the last reaction.
     LastReactionTimestamp = b'y',

--- a/src/param.rs
+++ b/src/param.rs
@@ -73,7 +73,7 @@ pub enum Param {
     /// For Messages: Render message as a RFC 9078 reaction.
     Reaction = b'x',
 
-    /// For Messages: Additional reactions that go to the Broadcast-Reactions: header
+    /// For Messages: Additional reactions that go to the `Chat-Broadcast-Reactions:` header
     BroadcastReactions = b'X',
 
     /// For Chats: the timestamp of the last reaction.

--- a/src/param.rs
+++ b/src/param.rs
@@ -73,8 +73,8 @@ pub enum Param {
     /// For Messages: Render message as a RFC 9078 reaction.
     Reaction = b'x',
 
-    /// For Messages: Additional reactions that go to the ChatReactions: header
-    ChatReactions = b'X',
+    /// For Messages: Additional reactions that go to the BroadcastReactions: header
+    BroadcastReactions = b'X',
 
     /// For Chats: the timestamp of the last reaction.
     LastReactionTimestamp = b'y',

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -469,9 +469,70 @@ pub(crate) async fn broadcast_reactions_for_all_chats(context: &Context) -> Resu
 }
 
 /// Sends out accumulated reactions for a single broadcast channel
-async fn broadcast_reactions_for_one_chat(_context: &Context, _chat_id: ChatId) -> Result<()> {
-    // TODO
+async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) -> Result<()> {
+    let msg_ids: Vec<MsgId> = context
+        .sql
+        .query_map_collect(
+            "SELECT DISTINCT msg_id FROM reactions_need_broadcast WHERE chat_id=?",
+            (chat_id,),
+            |row| {
+                let msg_id: MsgId = row.get(0)?;
+                Ok(msg_id)
+            },
+        )
+        .await?;
+
+    context
+        .sql
+        .execute(
+            "DELETE FROM reactions_need_broadcast WHERE chat_id=?",
+            (chat_id,),
+        )
+        .await?;
+
+    let mut messages: Vec<BroadcastReactionsMessage> = Vec::new();
+    for msg_id in &msg_ids {
+        let Some(msg) = Message::load_from_db_optional(context, *msg_id).await? else {
+            continue;
+        };
+        let reactions = get_msg_reactions(context, *msg_id).await?;
+        let entries: Vec<BroadcastReactionsEntry> = reactions
+            .emoji_sorted_by_frequency()
+            .into_iter()
+            .map(|(emoji, count)| BroadcastReactionsEntry { emoji, count })
+            .collect();
+        messages.push(BroadcastReactionsMessage {
+            id: msg.rfc724_mid,
+            reactions: entries, // can be empty if all reactions were removed
+        });
+    }
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    let payload = BroadcastReactionsPayload { messages };
+    let json = serde_json::to_string(&payload)?;
+    let mut msg = Message::new_text(json); // TOOD: maybe json is better put to the header
+    msg.hidden = true;
+    send_msg(context, chat_id, &mut msg).await?;
+
     Ok(())
+}
+
+/// Wire format for accumulated reactions
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsPayload {
+    messages: Vec<BroadcastReactionsMessage>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsMessage {
+    id: String,
+    reactions: Vec<BroadcastReactionsEntry>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsEntry {
+    emoji: String,
+    count: usize,
 }
 
 impl Chat {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::chat::{Chat, ChatId, send_msg};
 use crate::chatlist_events;
+use crate::constants::Chattype;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
@@ -188,6 +189,19 @@ async fn set_msg_id_reaction(
                 .set_i64(Param::LastReactionContactId, i64::from(contact_id.to_u32()));
             chat.update_param(context).await?;
         }
+    }
+
+    let chat = Chat::load_from_db(context, chat_id).await?;
+    if chat.typ == Chattype::OutBroadcast {
+        context
+            .sql
+            .execute(
+                "INSERT INTO reactions_need_broadcast (chat_id, msg_id)
+                 VALUES (?1, ?2)
+                 ON CONFLICT(msg_id, contact_id) DO NOTHING;",
+                (chat_id, msg_id),
+            )
+            .await?;
     }
 
     context.emit_event(EventType::ReactionsChanged {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -27,6 +27,7 @@ use crate::constants::Chattype;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::warn;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
 
@@ -435,6 +436,42 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         .await?;
     reactions.retain(|_contact, reaction| !reaction.is_empty());
     Ok(Reactions { reactions })
+}
+
+/// Sends out accumulated reactions
+/// for all broadcast channels with reactions in `reactions_need_broadcast`.
+///
+/// For every affected `chat_id`,
+/// a single hidden message is sent to all subscribers containing the full, current reaction state (not a diff)
+/// for every message that received a reaction change since the last broadcast.
+pub(crate) async fn broadcast_reactions_for_all_chats(context: &Context) -> Result<()> {
+    let chat_ids: Vec<ChatId> = context
+        .sql
+        .query_map_collect(
+            "SELECT DISTINCT chat_id FROM reactions_need_broadcast",
+            (),
+            |row| {
+                let chat_id: ChatId = row.get(0)?;
+                Ok(chat_id)
+            },
+        )
+        .await?;
+
+    for chat_id in chat_ids {
+        if let Err(err) = broadcast_reactions_for_one_chat(context, chat_id).await {
+            warn!(
+                context,
+                "Failed to broadcast reactions for chat {chat_id}: {err:#}."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Sends out accumulated reactions for a single broadcast channel
+async fn broadcast_reactions_for_one_chat(_context: &Context, _chat_id: ChatId) -> Result<()> {
+    // TODO
+    Ok(())
 }
 
 impl Chat {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -31,7 +31,7 @@ use crate::context::Context;
 use crate::events::EventType;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
-use crate::reaction::broadcast_reactions::load_broadcast_reactions;
+use crate::reaction::broadcast_reactions::{load_broadcast_reactions, refine_broadcast_reactions};
 
 /// A single reaction.
 #[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq, Serialize)]
@@ -432,17 +432,12 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         )
         .await?;
     by_contact.retain(|_contact, reaction| !reaction.is_empty());
-    let by_contact_frequencies = calc_frequencies(&by_contact);
 
     let frequencies =
         if let Some(broadcast_reactions) = load_broadcast_reactions(context, msg_id).await? {
-            broadcast_reactions
-            // TODO: add missing reactions from by_contact_frequencies to loaded_frequencies as follows:
-            // - if a Reaction-emoji is missing in loaded_frequencies, add it and set count to 1 (may happen because of races)
-            // - if a Reaction-emoji is already present in loaded_frequencies, do nothing (counts include usually every sender)
-            // - mark Reaction-emoji in loaded_frequencies as "is_self_reaction" if there is a corresponding in by_contact_frequencies
+            refine_broadcast_reactions(broadcast_reactions, by_contact.clone())?
         } else {
-            by_contact_frequencies
+            calc_frequencies(&by_contact)
         };
 
     Ok(Reactions {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -439,7 +439,7 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
 
     let frequencies =
         if let Some(broadcast_reactions) = load_broadcast_reactions(context, msg_id).await? {
-            refine_broadcast_reactions(broadcast_reactions, by_contact.clone())?
+            refine_broadcast_reactions(broadcast_reactions, &by_contact)?
         } else {
             calc_frequencies(&by_contact)
         };

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -158,6 +158,7 @@ async fn set_msg_id_reaction(
     timestamp: i64,
     reaction: &Reaction,
 ) -> Result<()> {
+    let mut chat = Chat::load_from_db(context, chat_id).await?;
     if reaction.is_empty() {
         // Simply remove the record instead of setting it to empty string.
         context
@@ -180,7 +181,6 @@ async fn set_msg_id_reaction(
                 (msg_id, contact_id, reaction.as_str()),
             )
             .await?;
-        let mut chat = Chat::load_from_db(context, chat_id).await?;
         if chat
             .param
             .update_timestamp(Param::LastReactionTimestamp, timestamp)?
@@ -193,7 +193,6 @@ async fn set_msg_id_reaction(
         }
     }
 
-    let chat = Chat::load_from_db(context, chat_id).await?;
     if chat.typ == Chattype::OutBroadcast {
         context
             .sql

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -410,11 +410,18 @@ fn calc_frequencies(by_contact: &BTreeMap<ContactId, Reaction>) -> Vec<ReactionF
         })
         .collect();
 
+    sort_frequencies(&mut frequencies);
+    frequencies
+}
+
+/// Sorts reaction frequencies by descending count. when equal, order by emoji string.
+///
+/// This is the order UIs shall use to display reactions in the message bubble.
+pub(crate) fn sort_frequencies(frequencies: &mut [ReactionFrequency]) {
     frequencies.sort_by(|a, b| match b.count.cmp(&a.count) {
         Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
         other => other,
     });
-    frequencies
 }
 
 /// Returns a structure containing all reactions to the message.

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -111,7 +111,7 @@ impl Reactions {
 
     /// Returns true if the message has no reactions.
     pub fn is_empty(&self) -> bool {
-        self.by_contact.is_empty()
+        self.frequencies.is_empty()
     }
 
     /// Returns a map from emojis to their frequencies.
@@ -132,7 +132,7 @@ impl Reactions {
     ///
     /// This function can be used to display the reactions in
     /// the message bubble in the UIs.
-    pub(crate) fn emoji_sorted_by_frequency(&self) -> Vec<(String, usize)> {
+    fn emoji_sorted_by_frequency(&self) -> Vec<(String, usize)> {
         let mut emoji_frequencies: Vec<(String, usize)> =
             self.emoji_frequencies().into_iter().collect();
         emoji_frequencies.sort_by(|(a, a_count), (b, b_count)| {
@@ -165,14 +165,13 @@ impl Reactions {
 
 impl fmt::Display for Reactions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let emoji_frequencies = self.emoji_sorted_by_frequency();
         let mut first = true;
-        for (emoji, frequency) in emoji_frequencies {
+        for entry in &self.frequencies {
             if !first {
                 write!(f, " ")?;
             }
             first = false;
-            write!(f, "{emoji}{frequency}")?;
+            write!(f, "{}{}", entry.reaction.as_str(), entry.count)?;
         }
         Ok(())
     }
@@ -897,11 +896,9 @@ Content-Disposition: reaction\n\
             .unwrap();
         let reactions = get_msg_reactions(&alice, alice_msg.sender_msg_id).await?;
         assert_eq!(reactions.to_string(), "👍2");
-
-        assert_eq!(
-            reactions.emoji_sorted_by_frequency(),
-            vec![("👍".to_string(), 2)]
-        );
+        assert_eq!(reactions.frequencies.len(), 1);
+        assert_eq!(reactions.frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(reactions.frequencies[0].count, 2);
 
         Ok(())
     }
@@ -1286,10 +1283,9 @@ Content-Transfer-Encoding: 7bit\r
         // MDN request was ignored, but reaction was not.
         let reactions = get_msg_reactions(bob, bob_msg.id).await?;
         assert_eq!(reactions.by_contact.len(), 1);
-        assert_eq!(
-            reactions.emoji_sorted_by_frequency(),
-            vec![("👀".to_string(), 1)]
-        );
+        assert_eq!(reactions.frequencies.len(), 1);
+        assert_eq!(reactions.frequencies[0].reaction.as_str(), "👀");
+        assert_eq!(reactions.frequencies[0].count, 1);
 
         Ok(())
     }

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -73,17 +73,34 @@ impl Reaction {
     }
 }
 
+/// A single reaction with frequency and sender flag.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReactionFrequency {
+    /// The reaction emoji.
+    pub reaction: Reaction,
+
+    /// Number of contacts that reacted with this emoji.
+    pub count: usize,
+
+    /// True if `ContactId::SELF` is among the contacts that reacted with this emoji.
+    pub is_from_self: bool,
+}
+
 /// Structure representing all reactions to a particular message.
 #[derive(Debug)]
 pub struct Reactions {
+    /// Unique reactions and their frequencies.
+    pub frequencies: Vec<ReactionFrequency>,
+
     /// Map from a contact to its reaction to message.
-    reactions: BTreeMap<ContactId, Reaction>,
+    /// For channels subscribers, this map is empty or contains `ContactId::SELF` only.
+    pub by_contact: BTreeMap<ContactId, Reaction>,
 }
 
 impl Reactions {
     /// Returns vector of contacts that reacted to the message.
     pub fn contacts(&self) -> Vec<ContactId> {
-        self.reactions.keys().copied().collect()
+        self.by_contact.keys().copied().collect()
     }
 
     /// Returns reaction of a given contact to message.
@@ -91,19 +108,22 @@ impl Reactions {
     /// If contact did not react to message or removed the reaction,
     /// this method returns an empty reaction.
     pub fn get(&self, contact_id: ContactId) -> Reaction {
-        self.reactions.get(&contact_id).cloned().unwrap_or_default()
+        self.by_contact
+            .get(&contact_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Returns true if the message has no reactions.
     pub fn is_empty(&self) -> bool {
-        self.reactions.is_empty()
+        self.by_contact.is_empty()
     }
 
     /// Returns a map from emojis to their frequencies.
     #[expect(clippy::arithmetic_side_effects)]
-    pub fn emoji_frequencies(&self) -> BTreeMap<String, usize> {
+    fn emoji_frequencies(&self) -> BTreeMap<String, usize> {
         let mut emoji_frequencies: BTreeMap<String, usize> = BTreeMap::new();
-        for reaction in self.reactions.values() {
+        for reaction in self.by_contact.values() {
             emoji_frequencies
                 .entry(reaction.as_str().to_string())
                 .and_modify(|x| *x += 1)
@@ -117,7 +137,7 @@ impl Reactions {
     ///
     /// This function can be used to display the reactions in
     /// the message bubble in the UIs.
-    pub fn emoji_sorted_by_frequency(&self) -> Vec<(String, usize)> {
+    pub(crate) fn emoji_sorted_by_frequency(&self) -> Vec<(String, usize)> {
         let mut emoji_frequencies: Vec<(String, usize)> =
             self.emoji_frequencies().into_iter().collect();
         emoji_frequencies.sort_by(|(a, a_count), (b, b_count)| {
@@ -129,9 +149,22 @@ impl Reactions {
         emoji_frequencies
     }
 
-    /// Returns an iterator of the contacts that reacted and their corresponding reactions.
-    pub fn iter(&self) -> impl Iterator<Item = (&ContactId, &Reaction)> {
-        self.reactions.iter()
+    /// Returns unique reactions with their frequency and whether self reacted,
+    /// sorted in descending order of frequency.
+    fn get_frequencies(&self) -> Vec<ReactionFrequency> {
+        let self_reaction = self.get(ContactId::SELF);
+        self.emoji_sorted_by_frequency()
+            .into_iter()
+            .map(|(emoji, count)| {
+                let is_from_self = !self_reaction.is_empty() && self_reaction.as_str() == emoji;
+                let reaction = Reaction::new(&emoji);
+                ReactionFrequency {
+                    reaction,
+                    count,
+                    is_from_self,
+                }
+            })
+            .collect()
     }
 }
 
@@ -422,7 +455,7 @@ pub(crate) async fn apply_pending_reactions(
 
 /// Returns a structure containing all reactions to the message.
 pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<Reactions> {
-    let mut reactions: BTreeMap<ContactId, Reaction> = context
+    let mut by_contact: BTreeMap<ContactId, Reaction> = context
         .sql
         .query_map_collect(
             "SELECT contact_id, reaction FROM reactions WHERE msg_id=?",
@@ -434,8 +467,14 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
             },
         )
         .await?;
-    reactions.retain(|_contact, reaction| !reaction.is_empty());
-    Ok(Reactions { reactions })
+    by_contact.retain(|_contact, reaction| !reaction.is_empty());
+
+    let mut ret = Reactions {
+        by_contact,
+        frequencies: Vec::new(),
+    };
+    ret.frequencies = ret.get_frequencies();
+    Ok(ret)
 }
 
 impl Chat {
@@ -891,7 +930,7 @@ Content-Disposition: reaction\n\
 
             bob.recv_msg_hidden(&reaction_msg).await;
             let msg = bob.recv_msg(&alice_msg).await;
-            assert_eq!(get_msg_reactions(&bob, msg.id).await?.reactions.len(), 1);
+            assert_eq!(get_msg_reactions(&bob, msg.id).await?.by_contact.len(), 1);
         }
 
         // group
@@ -909,7 +948,7 @@ Content-Disposition: reaction\n\
             bob.recv_msg_hidden(&reaction_msg_alice).await;
             bob.recv_msg_hidden(&reaction_msg_charlie).await;
             let msg = bob.recv_msg(&alice_msg).await;
-            assert_eq!(get_msg_reactions(&bob, msg.id).await?.reactions.len(), 2);
+            assert_eq!(get_msg_reactions(&bob, msg.id).await?.by_contact.len(), 2);
         }
 
         // react and remove reaction
@@ -926,7 +965,7 @@ Content-Disposition: reaction\n\
             bob.recv_msg_hidden(&reaction_msg).await;
             bob.recv_msg_hidden(&remove_reaction_msg).await;
             let msg = bob.recv_msg(&alice_msg).await;
-            assert_eq!(get_msg_reactions(&bob, msg.id).await?.reactions.len(), 0);
+            assert!(get_msg_reactions(&bob, msg.id).await?.is_empty());
         }
         Ok(())
     }
@@ -1041,7 +1080,7 @@ Content-Disposition: reaction\n\
         send_reaction(&alice, msg_id, "🐫").await?;
         assert_summary(&alice, "You reacted 🐫 to \"foo\"").await;
         let reactions = get_msg_reactions(&alice, msg_id).await?;
-        assert_eq!(reactions.reactions.len(), 1);
+        assert_eq!(reactions.by_contact.len(), 1);
 
         // Alice forwards that message to Bob: Reactions are not forwarded, the message is prefixed by "Forwarded".
         let bob_id = Contact::create(&alice, "", "bob@example.net").await?;
@@ -1051,7 +1090,7 @@ Content-Disposition: reaction\n\
         let chatlist = Chatlist::try_load(&alice, 0, None, None).await.unwrap();
         let forwarded_msg_id = chatlist.get_msg_id(0)?.unwrap();
         let reactions = get_msg_reactions(&alice, forwarded_msg_id).await?;
-        assert!(reactions.reactions.is_empty()); // reactions are not forwarded
+        assert!(reactions.is_empty()); // reactions are not forwarded
 
         // Alice reacts to forwarded message:
         // For reaction summary neither original message author nor "Forwarded" prefix is shown
@@ -1059,7 +1098,7 @@ Content-Disposition: reaction\n\
         send_reaction(&alice, forwarded_msg_id, "🐳").await?;
         assert_summary(&alice, "You reacted 🐳 to \"foo\"").await;
         let reactions = get_msg_reactions(&alice, msg_id).await?;
-        assert_eq!(reactions.reactions.len(), 1);
+        assert_eq!(reactions.by_contact.len(), 1);
 
         Ok(())
     }
@@ -1245,7 +1284,7 @@ Content-Transfer-Encoding: 7bit\r
 
         // MDN request was ignored, but reaction was not.
         let reactions = get_msg_reactions(bob, bob_msg.id).await?;
-        assert_eq!(reactions.reactions.len(), 1);
+        assert_eq!(reactions.by_contact.len(), 1);
         assert_eq!(
             reactions.emoji_sorted_by_frequency(),
             vec![("👀".to_string(), 1)]

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -98,11 +98,6 @@ pub struct Reactions {
 }
 
 impl Reactions {
-    /// Returns vector of contacts that reacted to the message.
-    pub fn contacts(&self) -> Vec<ContactId> {
-        self.by_contact.keys().copied().collect()
-    }
-
     /// Returns reaction of a given contact to message.
     ///
     /// If contact did not react to message or removed the reaction,
@@ -543,6 +538,12 @@ mod tests {
     use crate::test_utils::TestContextManager;
     use crate::tools::SystemTime;
     use std::time::Duration;
+
+    impl Reactions {
+        fn contacts(&self) -> Vec<ContactId> {
+            self.by_contact.keys().copied().collect()
+        }
+    }
 
     #[test]
     fn test_parse_reaction() {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -31,6 +31,7 @@ use crate::context::Context;
 use crate::events::EventType;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
+use crate::reaction::broadcast_reactions::load_broadcast_reactions;
 
 /// A single reaction.
 #[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq, Serialize)]
@@ -431,11 +432,22 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         )
         .await?;
     by_contact.retain(|_contact, reaction| !reaction.is_empty());
+    let by_contact_frequencies = calc_frequencies(&by_contact);
 
-    let frequencies = calc_frequencies(&by_contact);
+    let frequencies =
+        if let Some(broadcast_reactions) = load_broadcast_reactions(context, msg_id).await? {
+            broadcast_reactions
+            // TODO: add missing reactions from by_contact_frequencies to loaded_frequencies as follows:
+            // - if a Reaction-emoji is missing in loaded_frequencies, add it and set count to 1 (may happen because of races)
+            // - if a Reaction-emoji is already present in loaded_frequencies, do nothing (counts include usually every sender)
+            // - mark Reaction-emoji in loaded_frequencies as "is_self_reaction" if there is a corresponding in by_contact_frequencies
+        } else {
+            by_contact_frequencies
+        };
+
     Ok(Reactions {
-        by_contact,
         frequencies,
+        by_contact,
     })
 }
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -200,7 +200,7 @@ async fn set_msg_id_reaction(
             .execute(
                 "INSERT INTO reactions_need_broadcast (chat_id, msg_id)
                  VALUES (?1, ?2)
-                 ON CONFLICT(msg_id, contact_id) DO NOTHING;",
+                 ON CONFLICT(chat_id, msg_id) DO NOTHING;",
                 (chat_id, msg_id),
             )
             .await?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -98,68 +98,9 @@ pub struct Reactions {
 }
 
 impl Reactions {
-    /// Returns reaction of a given contact to message.
-    ///
-    /// If contact did not react to message or removed the reaction,
-    /// this method returns an empty reaction.
-    pub fn get(&self, contact_id: ContactId) -> Reaction {
-        self.by_contact
-            .get(&contact_id)
-            .cloned()
-            .unwrap_or_default()
-    }
-
     /// Returns true if the message has no reactions.
     pub fn is_empty(&self) -> bool {
         self.frequencies.is_empty()
-    }
-
-    /// Returns a map from emojis to their frequencies.
-    #[expect(clippy::arithmetic_side_effects)]
-    fn emoji_frequencies(&self) -> BTreeMap<String, usize> {
-        let mut emoji_frequencies: BTreeMap<String, usize> = BTreeMap::new();
-        for reaction in self.by_contact.values() {
-            emoji_frequencies
-                .entry(reaction.as_str().to_string())
-                .and_modify(|x| *x += 1)
-                .or_insert(1);
-        }
-        emoji_frequencies
-    }
-
-    /// Returns a vector of emojis
-    /// sorted in descending order of frequencies.
-    ///
-    /// This function can be used to display the reactions in
-    /// the message bubble in the UIs.
-    fn emoji_sorted_by_frequency(&self) -> Vec<(String, usize)> {
-        let mut emoji_frequencies: Vec<(String, usize)> =
-            self.emoji_frequencies().into_iter().collect();
-        emoji_frequencies.sort_by(|(a, a_count), (b, b_count)| {
-            match a_count.cmp(b_count).reverse() {
-                Ordering::Equal => a.cmp(b),
-                other => other,
-            }
-        });
-        emoji_frequencies
-    }
-
-    /// Returns unique reactions with their frequency and whether self reacted,
-    /// sorted in descending order of frequency.
-    fn get_frequencies(&self) -> Vec<ReactionFrequency> {
-        let self_reaction = self.get(ContactId::SELF);
-        self.emoji_sorted_by_frequency()
-            .into_iter()
-            .map(|(emoji, count)| {
-                let is_from_self = !self_reaction.is_empty() && self_reaction.as_str() == emoji;
-                let reaction = Reaction::new(&emoji);
-                ReactionFrequency {
-                    reaction,
-                    count,
-                    is_from_self,
-                }
-            })
-            .collect()
     }
 }
 
@@ -447,6 +388,34 @@ pub(crate) async fn apply_pending_reactions(
     Ok(())
 }
 
+/// Returns unique reactions with their frequency and whether self reacted,
+/// sorted in descending order of frequency.
+fn calc_frequencies(by_contact: &BTreeMap<ContactId, Reaction>) -> Vec<ReactionFrequency> {
+    let mut self_reaction = Reaction::new("");
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for (contact_id, reaction) in by_contact {
+        *counts.entry(reaction.as_str()).or_insert(0) += 1;
+        if *contact_id == ContactId::SELF {
+            self_reaction = reaction.clone();
+        }
+    }
+
+    let mut frequencies: Vec<ReactionFrequency> = counts
+        .into_iter()
+        .map(|(emoji, count)| ReactionFrequency {
+            reaction: Reaction::new(emoji),
+            count,
+            is_from_self: !self_reaction.is_empty() && self_reaction.as_str() == emoji,
+        })
+        .collect();
+
+    frequencies.sort_by(|a, b| match b.count.cmp(&a.count) {
+        Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
+        other => other,
+    });
+    frequencies
+}
+
 /// Returns a structure containing all reactions to the message.
 pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<Reactions> {
     let mut by_contact: BTreeMap<ContactId, Reaction> = context
@@ -463,12 +432,11 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         .await?;
     by_contact.retain(|_contact, reaction| !reaction.is_empty());
 
-    let mut ret = Reactions {
+    let frequencies = calc_frequencies(&by_contact);
+    Ok(Reactions {
         by_contact,
-        frequencies: Vec::new(),
-    };
-    ret.frequencies = ret.get_frequencies();
-    Ok(ret)
+        frequencies,
+    })
 }
 
 impl Chat {
@@ -541,6 +509,14 @@ mod tests {
     impl Reactions {
         fn contacts(&self) -> Vec<ContactId> {
             self.by_contact.keys().copied().collect()
+        }
+
+        // Returns reaction of a given contact to message or an empty reaction.
+        fn get(&self, contact_id: ContactId) -> Reaction {
+            self.by_contact
+                .get(&contact_id)
+                .cloned()
+                .unwrap_or_default()
         }
     }
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -407,7 +407,8 @@ fn calc_frequencies(by_contact: &BTreeMap<ContactId, Reaction>) -> Vec<ReactionF
     let mut self_reaction = Reaction::new("");
     let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
     for (contact_id, reaction) in by_contact {
-        *counts.entry(reaction.as_str()).or_insert(0) += 1;
+        let count = counts.entry(reaction.as_str()).or_insert(0);
+        *count = count.saturating_add(1);
         if *contact_id == ContactId::SELF {
             self_reaction = reaction.clone();
         }

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -418,6 +418,10 @@ fn calc_frequencies(by_contact: &BTreeMap<ContactId, Reaction>) -> Vec<ReactionF
 }
 
 /// Returns a structure containing all reactions to the message.
+///
+/// For displaying, UI shall use the `frequencies` field, which is already sorted accordingly.
+/// `frequencies` should also be used to check for SELF-reaction.
+/// For detailed reaction information outside broadcast channel subscribers, UI can use the `by_contact` table.
 pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<Reactions> {
     let mut by_contact: BTreeMap<ContactId, Reaction> = context
         .sql

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -439,7 +439,7 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
 
     let frequencies =
         if let Some(broadcast_reactions) = load_broadcast_reactions(context, msg_id).await? {
-            refine_broadcast_reactions(broadcast_reactions, &by_contact)?
+            refine_broadcast_reactions(broadcast_reactions, &by_contact)
         } else {
             calc_frequencies(&by_contact)
         };

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -444,12 +444,12 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         .await?;
     by_contact.retain(|_contact, reaction| !reaction.is_empty());
 
-    let frequencies =
-        if let Some(broadcast_reactions) = load_broadcast_reactions(context, msg_id).await? {
-            refine_broadcast_reactions(broadcast_reactions, &by_contact)
-        } else {
-            calc_frequencies(&by_contact)
-        };
+    let broadcasted_reactions = load_broadcast_reactions(context, msg_id).await?;
+    let frequencies = if !broadcasted_reactions.is_empty() {
+        refine_broadcast_reactions(broadcasted_reactions, &by_contact)
+    } else {
+        calc_frequencies(&by_contact)
+    };
 
     Ok(Reactions {
         frequencies,

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -14,6 +14,8 @@
 //! possible to remove the reaction by sending an empty string as a reaction,
 //! even though RFC 9078 requires at least one emoji to be sent.
 
+pub(crate) mod broadcast_reactions;
+
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt;
@@ -27,7 +29,6 @@ use crate::constants::Chattype;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
-use crate::log::warn;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
 
@@ -436,103 +437,6 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
         .await?;
     reactions.retain(|_contact, reaction| !reaction.is_empty());
     Ok(Reactions { reactions })
-}
-
-/// Sends out accumulated reactions
-/// for all broadcast channels with reactions in `reactions_need_broadcast`.
-///
-/// For every affected `chat_id`,
-/// a single hidden message is sent to all subscribers containing the full, current reaction state (not a diff)
-/// for every message that received a reaction change since the last broadcast.
-pub(crate) async fn broadcast_reactions_for_all_chats(context: &Context) -> Result<()> {
-    let chat_ids: Vec<ChatId> = context
-        .sql
-        .query_map_collect(
-            "SELECT DISTINCT chat_id FROM reactions_need_broadcast",
-            (),
-            |row| {
-                let chat_id: ChatId = row.get(0)?;
-                Ok(chat_id)
-            },
-        )
-        .await?;
-
-    for chat_id in chat_ids {
-        if let Err(err) = broadcast_reactions_for_one_chat(context, chat_id).await {
-            warn!(
-                context,
-                "Failed to broadcast reactions for chat {chat_id}: {err:#}."
-            );
-        }
-    }
-    Ok(())
-}
-
-/// Sends out accumulated reactions for a single broadcast channel
-async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) -> Result<()> {
-    let msg_ids: Vec<MsgId> = context
-        .sql
-        .query_map_collect(
-            "SELECT DISTINCT msg_id FROM reactions_need_broadcast WHERE chat_id=?",
-            (chat_id,),
-            |row| {
-                let msg_id: MsgId = row.get(0)?;
-                Ok(msg_id)
-            },
-        )
-        .await?;
-
-    context
-        .sql
-        .execute(
-            "DELETE FROM reactions_need_broadcast WHERE chat_id=?",
-            (chat_id,),
-        )
-        .await?;
-
-    let mut messages: Vec<BroadcastReactionsMessage> = Vec::new();
-    for msg_id in &msg_ids {
-        let Some(msg) = Message::load_from_db_optional(context, *msg_id).await? else {
-            continue;
-        };
-        let reactions = get_msg_reactions(context, *msg_id).await?;
-        let entries: Vec<BroadcastReactionsEntry> = reactions
-            .emoji_sorted_by_frequency()
-            .into_iter()
-            .map(|(emoji, count)| BroadcastReactionsEntry { emoji, count })
-            .collect();
-        messages.push(BroadcastReactionsMessage {
-            id: msg.rfc724_mid,
-            reactions: entries, // can be empty if all reactions were removed
-        });
-    }
-    if messages.is_empty() {
-        return Ok(());
-    }
-
-    let payload = BroadcastReactionsPayload { messages };
-    let json = serde_json::to_string(&payload)?;
-    let mut msg = Message::new_text(json); // TOOD: maybe json is better put to the header
-    msg.hidden = true;
-    send_msg(context, chat_id, &mut msg).await?;
-
-    Ok(())
-}
-
-/// Wire format for accumulated reactions
-#[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsPayload {
-    messages: Vec<BroadcastReactionsMessage>,
-}
-#[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsMessage {
-    id: String,
-    reactions: Vec<BroadcastReactionsEntry>,
-}
-#[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsEntry {
-    emoji: String,
-    count: usize,
 }
 
 impl Chat {

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -31,7 +31,9 @@ use crate::context::Context;
 use crate::events::EventType;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
-use crate::reaction::broadcast_reactions::{load_broadcast_reactions, refine_broadcast_reactions};
+use crate::reaction::broadcast_reactions::{
+    load_broadcast_reactions, modify_frequencies, refine_frequencies, save_broadcast_reactions,
+};
 
 /// A single reaction.
 #[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq, Serialize)]
@@ -128,6 +130,9 @@ async fn set_msg_id_reaction(
     reaction: &Reaction,
 ) -> Result<()> {
     let mut chat = Chat::load_from_db(context, chat_id).await?;
+    let old_reactions = get_msg_reactions(context, msg_id).await?;
+    let old_self_reaction = old_reactions.by_contact.get(&ContactId::SELF);
+
     if reaction.is_empty() {
         // Simply remove the record instead of setting it to empty string.
         context
@@ -172,6 +177,13 @@ async fn set_msg_id_reaction(
                 (chat_id, msg_id),
             )
             .await?;
+    } else if chat.typ == Chattype::InBroadcast && contact_id == ContactId::SELF {
+        // for immediate feedback, alter `broadcasted_reactions` directly.
+        // this "dirty state" will overwritten on next broadcast,
+        // however, means that `broadcasted_reactions` counts can be assumemd to include SELF-reaction eventually.
+        let mut frequencies = load_broadcast_reactions(context, msg_id).await?;
+        modify_frequencies(&mut frequencies, old_self_reaction, reaction);
+        save_broadcast_reactions(context, msg_id, &frequencies).await?;
     }
 
     context.emit_event(EventType::ReactionsChanged {
@@ -446,7 +458,7 @@ pub async fn get_msg_reactions(context: &Context, msg_id: MsgId) -> Result<React
 
     let broadcasted_reactions = load_broadcast_reactions(context, msg_id).await?;
     let frequencies = if !broadcasted_reactions.is_empty() {
-        refine_broadcast_reactions(broadcasted_reactions, &by_contact)
+        refine_frequencies(broadcasted_reactions, &by_contact)
     } else {
         calc_frequencies(&by_contact)
     };

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -106,14 +106,6 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
         )
         .await?;
 
-    context
-        .sql
-        .execute(
-            "DELETE FROM reactions_need_broadcast WHERE chat_id=?",
-            (chat_id,),
-        )
-        .await?;
-
     let mut messages: Vec<WireMessage> = Vec::new();
     for msg_id in &msg_ids {
         let Some(msg) = Message::load_from_db_optional(context, *msg_id).await? else {
@@ -133,17 +125,24 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
             reactions: entries, // can be empty if all reactions were removed
         });
     }
-    if messages.is_empty() {
-        return Ok(());
+
+    if !messages.is_empty() {
+        let payload = WirePayload { messages };
+        let json = serde_json::to_string(&payload)?;
+        let mut reaction_msg = Message::new_text("".to_string());
+        reaction_msg.set_reaction();
+        reaction_msg.param.set(Param::BroadcastReactions, json);
+        reaction_msg.hidden = true;
+        send_msg(context, chat_id, &mut reaction_msg).await?;
     }
 
-    let payload = WirePayload { messages };
-    let json = serde_json::to_string(&payload)?;
-    let mut reaction_msg = Message::new_text("".to_string());
-    reaction_msg.set_reaction();
-    reaction_msg.param.set(Param::BroadcastReactions, json);
-    reaction_msg.hidden = true;
-    send_msg(context, chat_id, &mut reaction_msg).await?;
+    context
+        .sql
+        .execute(
+            "DELETE FROM reactions_need_broadcast WHERE chat_id=?",
+            (chat_id,),
+        )
+        .await?;
 
     Ok(())
 }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -6,7 +6,6 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use crate::chat::{Chat, ChatId, send_msg};
@@ -17,7 +16,7 @@ use crate::context::Context;
 use crate::log::warn;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
-use crate::reaction::{Reaction, ReactionFrequency, get_msg_reactions};
+use crate::reaction::{Reaction, ReactionFrequency, get_msg_reactions, sort_frequencies};
 use crate::tools::time;
 use crate::{EventType, chatlist_events};
 
@@ -232,7 +231,7 @@ pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Vec<ReactionFrequency> {
-    for (_contact_id, reaction) in by_contact {
+    for reaction in by_contact.values() {
         if !broadcasted_reactions
             .iter()
             .any(|entry| entry.reaction == *reaction)

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -126,7 +126,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
     let json = serde_json::to_string(&payload)?;
     let mut reaction_msg = Message::new_text("".to_string());
     reaction_msg.set_reaction();
-    reaction_msg.param.set(Param::ChatReactions, json);
+    reaction_msg.param.set(Param::BroadcastReactions, json);
     reaction_msg.hidden = true;
     send_msg(context, chat_id, &mut reaction_msg).await?;
 
@@ -188,7 +188,7 @@ mod tests {
 
         // Alice broadcasts reaction to Claire
         // On the wire, the hidden message has a header like
-        // `Chat-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
+        // `Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
         maybe_broadcast_reactions(alice).await?;
         assert_eq!(
             alice

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -332,6 +332,48 @@ mod tests {
     use crate::test_utils::TestContextManager;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_broadcast_reaction_wire_format() {
+        let payload = WirePayload {
+            messages: vec![
+                WireMessage {
+                    id: "12345678@foo".to_string(),
+                    reactions: vec![
+                        WireEntry {
+                            emoji: "😎".to_string(),
+                            count: 4,
+                        },
+                        WireEntry {
+                            emoji: "🕺".to_string(),
+                            count: 2,
+                        },
+                    ],
+                },
+                WireMessage {
+                    id: "23456789@bar".to_string(),
+                    reactions: vec![],
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert_eq!(
+            json,
+            r#"{"messages":[{"id":"12345678@foo","reactions":[{"emoji":"😎","count":4},{"emoji":"🕺","count":2}]},{"id":"23456789@bar","reactions":[]}]}"#
+        );
+
+        let payload: WirePayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(payload.messages.len(), 2);
+        assert_eq!(payload.messages[0].id, "12345678@foo");
+        assert_eq!(payload.messages[0].reactions.len(), 2);
+        assert_eq!(payload.messages[0].reactions[0].emoji, "😎");
+        assert_eq!(payload.messages[0].reactions[0].count, 4);
+        assert_eq!(payload.messages[0].reactions[1].emoji, "🕺");
+        assert_eq!(payload.messages[0].reactions[1].count, 2);
+        assert_eq!(payload.messages[1].id, "23456789@bar");
+        assert!(payload.messages[1].reactions.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_modify_frequencies() {
         // Helper to create a ReactionFrequency entry
         let freq = |emoji: &str, count: usize, is_from_self: bool| -> ReactionFrequency {

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -142,7 +142,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
 }
 
 /// Applies incoming, accumulated reactions received via the `Broadcast-Reactions:` header
-/// to the `reactions_accumulated` table.
+/// to the `broadcasted_reactions` table.
 pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
     let payload: BroadcastReactionsPayload = serde_json::from_str(json)?;
 
@@ -164,12 +164,12 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
             .sql
             .transaction(move |transaction| {
                 transaction.execute(
-                    "DELETE FROM reactions_accumulated WHERE msg_id=?",
+                    "DELETE FROM broadcasted_reactions WHERE msg_id=?",
                     (msg_id,),
                 )?;
                 for entry in &message.reactions {
                     transaction.execute(
-                        "INSERT INTO reactions_accumulated (msg_id, reaction, count)
+                        "INSERT INTO broadcasted_reactions (msg_id, reaction, count)
                          VALUES (?1, ?2, ?3)",
                         (msg_id, &entry.emoji, entry.count),
                     )?;
@@ -189,7 +189,7 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
     Ok(())
 }
 
-/// Load broadcasted reactios from `reactions_accumulated`.
+/// Load broadcasted reactios from `broadcasted_reactions`.
 /// This table is filled only for the broadcast channel subscribers (`Chattype::InBroadcast`),
 /// in other cases, `None` is returned.
 pub(crate) async fn load_broadcast_reactions(
@@ -199,7 +199,7 @@ pub(crate) async fn load_broadcast_reactions(
     let mut frequencies: Vec<ReactionFrequency> = context
         .sql
         .query_map_collect(
-            "SELECT reaction, count FROM reactions_accumulated WHERE msg_id=?",
+            "SELECT reaction, count FROM broadcasted_reactions WHERE msg_id=?",
             (msg_id,),
             |row| {
                 let reaction: String = row.get(0)?;
@@ -330,11 +330,11 @@ mod tests {
         claire.recv_msg_hidden(&sent_msg).await;
 
         // Claire got the broadcasted reaction, and then reacts herself.
-        // This means, her local view on reactions are a mix `reactions_accumulated`and `reactions`.
+        // This means, her local view on reactions are a mix `broadcasted_reactions`and `reactions`.
         assert_eq!(
             claire
                 .sql
-                .count("SELECT COUNT(*) FROM reactions_accumulated", ())
+                .count("SELECT COUNT(*) FROM broadcasted_reactions", ())
                 .await?,
             1
         );
@@ -356,7 +356,7 @@ mod tests {
         assert_eq!(reactions.frequencies[1].is_from_self, true);
 
         // Claire's reaction is sent to Alice who in turn broadast it again to Bob and Claire.
-        // This must not modify Clair's get_reactions() even tho the reaction is present now in `reactions_accumulated` and `reactions`.
+        // This must not modify Clair's get_reactions() even tho the reaction is present now in `broadcasted_reactions` and `reactions`.
         let sent_msg = claire.pop_sent_msg().await;
         alice.recv_msg_hidden(&sent_msg).await;
         let reactions = get_msg_reactions(alice, alice_msg_id).await?;
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(
             claire
                 .sql
-                .count("SELECT COUNT(*) FROM reactions_accumulated", ())
+                .count("SELECT COUNT(*) FROM broadcasted_reactions", ())
                 .await?,
             2
         );

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -233,7 +233,7 @@ pub(crate) async fn load_broadcast_reactions(
 pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
-) -> Result<Vec<ReactionFrequency>> {
+) -> Vec<ReactionFrequency> {
     let self_reaction = by_contact.get(&ContactId::SELF).cloned();
 
     for (_contact_id, reaction) in by_contact {
@@ -258,7 +258,7 @@ pub(crate) fn refine_broadcast_reactions(
         }
     }
 
-    Ok(broadcasted_reactions)
+    broadcasted_reactions
 }
 
 #[cfg(test)]

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -181,7 +181,7 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
         context.emit_event(EventType::ReactionsChanged {
             // the event is for the subscriber, ReactionsIncoming is not needed
             chat_id: msg.chat_id,
-            msg_id: msg_id,
+            msg_id,
             contact_id: ContactId::UNDEFINED,
         });
     }
@@ -189,7 +189,7 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
     Ok(())
 }
 
-/// Load broadcasted reactios from `broadcasted_reactions`.
+/// Load broadcasted reactions from `broadcasted_reactions`.
 /// This table is filled only for the broadcast channel subscribers (`Chattype::InBroadcast`),
 /// in other cases, `None` is returned.
 pub(crate) async fn load_broadcast_reactions(
@@ -227,9 +227,10 @@ pub(crate) async fn load_broadcast_reactions(
 
 /// Adds dedicated `by_contact` reaction to broadcasted reaction frequencies.
 ///
-/// This is needed as broadcast subscribers (Chattype::InBroadcast) want always to see their own reaction immediated,
+/// This is needed as broadcast subscribers (Chattype::InBroadcast) want always to see their own reaction immediately,
 /// and have it marked as being a SELF reaction.
 /// Moreover, `by_contact` may contain direct reaction from the broadcast owner.
+/// We do not increase `count` in case the reaction is present as the accumulated counts usually include the ones from `by_contact`.
 pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
@@ -247,7 +248,6 @@ pub(crate) fn refine_broadcast_reactions(
                 is_from_self: false,
             });
         }
-        // no else - do not increase counter, usually, broadcaasted reactions already includes the ones by `by_contact`
     }
 
     if let Some(self_reaction) = &self_reaction {
@@ -334,8 +334,8 @@ mod tests {
         assert_eq!(reactions.frequencies[0].is_from_self, false);
         assert_eq!(reactions.frequencies[1].is_from_self, true);
 
-        // Claire's reaction is sent to Alice who in turn broadast it again to Bob and Claire.
-        // This must not modify Clair's get_reactions() even tho the reaction is present now in `broadcasted_reactions` and `reactions`.
+        // Claire's reaction is sent to Alice who in turn broadcast it again to Bob and Claire.
+        // This must not modify Claire's get_reactions() even tho the reaction is present now in `broadcasted_reactions` and `reactions`.
         let sent_msg = claire.pop_sent_msg().await;
         alice.recv_msg_hidden(&sent_msg).await;
         let reactions = get_msg_reactions(alice, alice_msg_id).await?;

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -218,11 +218,7 @@ pub(crate) async fn load_broadcast_reactions(
         return Ok(None);
     }
 
-    frequencies.sort_by(|a, b| match b.count.cmp(&a.count) {
-        Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
-        other => other,
-    });
-
+    sort_frequencies(&mut frequencies);
     Ok(Some(frequencies))
 }
 
@@ -255,11 +251,7 @@ pub(crate) fn refine_broadcast_reactions(
         }
     }
 
-    broadcasted_reactions.sort_by(|a, b| match b.count.cmp(&a.count) {
-        Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
-        other => other,
-    });
-
+    sort_frequencies(&mut broadcasted_reactions);
     broadcasted_reactions
 }
 

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -231,7 +231,8 @@ pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Vec<ReactionFrequency> {
-    for reaction in by_contact.values() {
+    for (contact_id, reaction) in by_contact {
+        let is_from_self = *contact_id == ContactId::SELF;
         if !broadcasted_reactions
             .iter()
             .any(|entry| entry.reaction == *reaction)
@@ -239,14 +240,20 @@ pub(crate) fn refine_broadcast_reactions(
             broadcasted_reactions.push(ReactionFrequency {
                 reaction: reaction.clone(),
                 count: 1,
-                is_from_self: false,
+                is_from_self,
             });
-        }
-    }
-
-    if let Some(self_reaction) = by_contact.get(&ContactId::SELF) {
-        for entry in &mut broadcasted_reactions {
-            entry.is_from_self = entry.reaction == *self_reaction;
+        } else if is_from_self {
+            for entry in &mut broadcasted_reactions {
+                if entry.reaction == *reaction {
+                    // This results in ones own reaction being count twice for yourself.
+                    // We do this, so that you get an immediate feedback on reacting.
+                    //
+                    // Alternative approach is to alter `broadcast_reactions` accordingly on `send_reaction()` (increase/decrease counters, add/remove rows).
+                    // `broadcast_reactions` will become "dirty" by that, but that is recovered implicitly on next update from the channel owner.
+                    entry.count = entry.count + 1;
+                    entry.is_from_self = true;
+                }
+            }
         }
     }
 
@@ -316,10 +323,11 @@ mod tests {
         by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
         let result = refine_broadcast_reactions(broadcasted, &by_contact);
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].reaction.as_str(), "👍");
-        assert_eq!(result[0].is_from_self, false);
-        assert_eq!(result[1].reaction.as_str(), "❤️");
-        assert_eq!(result[1].is_from_self, true);
+        assert_eq!(result[0].reaction.as_str(), "❤️");
+        assert_eq!(result[0].is_from_self, true);
+        assert_eq!(result[1].reaction.as_str(), "👍");
+        assert_eq!(result[1].is_from_self, false);
+
 
         // Test `by_contact` contains a reaction already in broadcasted; count must NOT increase
         let broadcasted = vec![ReactionFrequency {
@@ -430,12 +438,13 @@ mod tests {
         broadcast_reactions_for_all_chats(alice).await?; // bypass timer in maybe_broadcast_reactions()
         let sent_msg = alice.pop_sent_msg().await;
         bob.recv_msg_hidden(&sent_msg).await;
+
         claire.recv_msg_hidden(&sent_msg).await;
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
-        assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
+        assert_eq!(reactions.to_string(), "💪2 🏳️‍🌈1"); // sic! see comment at `count` increase in refine_broadcast_reactions()
         assert_eq!(reactions.frequencies.len(), 2);
-        assert_eq!(reactions.frequencies[0].is_from_self, false);
-        assert_eq!(reactions.frequencies[1].is_from_self, true);
+        assert_eq!(reactions.frequencies[0].is_from_self, true);
+        assert_eq!(reactions.frequencies[1].is_from_self, false);
 
         Ok(())
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -40,7 +40,7 @@ struct WireEntry {
 /// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
 const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
 
-/// Starts broadcasting if last broadcasting so more than `REACTION_BROADCAST_PERIOD` seconds in the past.
+/// Starts broadcasting if last broadcasting is more than `REACTION_BROADCAST_PERIOD` seconds in the past.
 pub(crate) async fn maybe_broadcast_reactions(context: &Context) -> Result<()> {
     let last_broadcast_time = context
         .get_config_i64(Config::LastReactionsBroadcast)

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -159,15 +159,13 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
         let Some(msg) = Message::load_from_db_optional(context, msg_id).await? else {
             continue; // there may have been a deletion race, ignore error
         };
-
-        let chat: Chat;
-        match Chat::load_from_db(context, msg.chat_id).await {
-            Ok(loaded_chat) => chat = loaded_chat,
+        let chat = match Chat::load_from_db(context, msg.chat_id).await {
+            Ok(chat) => chat,
             Err(err) => {
                 warn!(context, "Cannot load chat for broadcast reaction: {err}");
                 continue;
             }
-        }
+        };
         if chat.typ != Chattype::InBroadcast {
             continue;
         }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -232,11 +232,11 @@ pub(crate) async fn load_broadcast_reactions(
 /// Moreover, `by_contact` may contain direct reaction from the broadcast owner.
 pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
-    by_contact: BTreeMap<ContactId, Reaction>,
+    by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Result<Vec<ReactionFrequency>> {
     let self_reaction = by_contact.get(&ContactId::SELF).cloned();
 
-    for (_contact_id, reaction) in &by_contact {
+    for (_contact_id, reaction) in by_contact {
         if !broadcasted_reactions
             .iter()
             .any(|entry| entry.reaction == *reaction)

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -166,7 +166,7 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
             .map(|entry| ReactionFrequency {
                 reaction: Reaction::new(&entry.emoji),
                 count: entry.count,
-                is_from_self: false, // set in refine_broadcast_reactions()
+                is_from_self: false, // set in refine_frequencies()
             })
             .collect();
         save_broadcast_reactions(context, msg_id, &frequencies).await?;
@@ -213,7 +213,7 @@ pub(crate) async fn load_broadcast_reactions(
 }
 
 /// Save an array of frequencies to the `broadcasted_reactions` table.
-async fn save_broadcast_reactions(
+pub(crate) async fn save_broadcast_reactions(
     context: &Context,
     msg_id: MsgId,
     frequencies: &Vec<ReactionFrequency>,
@@ -238,8 +238,47 @@ async fn save_broadcast_reactions(
     Ok(())
 }
 
+/// Modifies frequencies in-place to reflect a change in the SELF user's reaction.
+///
+/// This is used for immediate local feedback in `Chattype::InBroadcast` before the
+/// next periodic broadcast overwrites this "dirty state".
+pub(crate) fn modify_frequencies(
+    frequencies: &mut Vec<ReactionFrequency>,
+    old_self_reaction: Option<&Reaction>,
+    new_self_reaction: &Reaction,
+) {
+    if let Some(old_reaction) = old_self_reaction {
+        if let Some(idx) = frequencies
+            .iter()
+            .position(|entry| entry.reaction == *old_reaction)
+        {
+            frequencies[idx].count = frequencies[idx].count.saturating_sub(1);
+            if frequencies[idx].count == 0 {
+                frequencies.remove(idx);
+            }
+        }
+    }
+
+    if new_self_reaction.is_empty() {
+        return;
+    }
+
+    if let Some(idx) = frequencies
+        .iter_mut()
+        .position(|entry| entry.reaction == *new_self_reaction)
+    {
+        frequencies[idx].count += 1;
+    } else {
+        frequencies.push(ReactionFrequency {
+            reaction: new_self_reaction.clone(),
+            count: 1,
+            is_from_self: false, // Will be correctly set to `true` by `refine_frequencies`
+        });
+    }
+}
+
 /// Merge `by_contact` status to broadcasted reaction frequencies.
-pub(crate) fn refine_broadcast_reactions(
+pub(crate) fn refine_frequencies(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Vec<ReactionFrequency> {
@@ -278,12 +317,100 @@ mod tests {
     use crate::securejoin::get_securejoin_qr;
     use crate::test_utils::TestContextManager;
 
-    #[test]
-    fn test_refine_broadcast_reactions() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_modify_frequencies() {
+        // Helper to create a ReactionFrequency entry
+        let freq = |emoji: &str, count: usize, is_from_self: bool| -> ReactionFrequency {
+            ReactionFrequency {
+                reaction: Reaction::new(emoji),
+                count,
+                is_from_self,
+            }
+        };
+
+        // Add entry
+        let mut frequencies = vec![freq("👍", 2, false)];
+        let old: Option<&Reaction> = None;
+        let new = Reaction::new("❤️");
+        modify_frequencies(&mut frequencies, old, &new);
+        assert_eq!(frequencies.len(), 2);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 2);
+        assert_eq!(frequencies[1].reaction.as_str(), "❤️");
+        assert_eq!(frequencies[1].count, 1);
+
+        // Increase existing entry
+        let mut frequencies = vec![freq("👍", 2, false)];
+        let old: Option<&Reaction> = None;
+        let new = Reaction::new("👍");
+        modify_frequencies(&mut frequencies, old, &new);
+        assert_eq!(frequencies.len(), 1);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 3);
+
+        // Decreased existing entry
+        let mut frequencies = vec![freq("👍", 2, false)];
+        let old = Some(Reaction::new("👍"));
+        let new = Reaction::new("");
+        modify_frequencies(&mut frequencies, old.as_ref(), &new);
+        assert_eq!(frequencies.len(), 1);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 1);
+
+        // Remove existing entry
+        let mut frequencies = vec![freq("👍", 1, false)];
+        let old = Some(Reaction::new("👍"));
+        let new = Reaction::new("");
+        modify_frequencies(&mut frequencies, old.as_ref(), &new);
+        assert_eq!(frequencies.len(), 0);
+
+        // Reaction changed: old reaction removed (count was 1), new reaction added
+        let mut frequencies = vec![freq("👍", 1, false), freq("❤️", 3, false)];
+        let old = Some(Reaction::new("👍"));
+        let new = Reaction::new("🎉");
+        modify_frequencies(&mut frequencies, old.as_ref(), &new);
+        assert_eq!(frequencies.len(), 2);
+        assert_eq!(frequencies[0].reaction.as_str(), "❤️");
+        assert_eq!(frequencies[0].count, 3);
+        assert_eq!(frequencies[1].reaction.as_str(), "🎉");
+        assert_eq!(frequencies[1].count, 1);
+
+        // Reaction changed: old reaction decreased (count was 2), new reaction added
+        let mut frequencies = vec![freq("👍", 2, false)];
+        let old = Some(Reaction::new("👍"));
+        let new = Reaction::new("🎉");
+        modify_frequencies(&mut frequencies, old.as_ref(), &new);
+        assert_eq!(frequencies.len(), 2);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 1);
+        assert_eq!(frequencies[1].reaction.as_str(), "🎉");
+        assert_eq!(frequencies[1].count, 1);
+
+        // Old and new reaction are the same
+        let mut frequencies = vec![freq("👍", 2, false)];
+        let old = Some(Reaction::new("👍"));
+        let new = Reaction::new("👍");
+        modify_frequencies(&mut frequencies, old.as_ref(), &new);
+        assert_eq!(frequencies.len(), 1);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 2);
+
+        // Empty frequencies array, adding a new reaction
+        let mut frequencies = vec![];
+        let old: Option<&Reaction> = None;
+        let new = Reaction::new("👍");
+        modify_frequencies(&mut frequencies, old, &new);
+        assert_eq!(frequencies.len(), 1);
+        assert_eq!(frequencies[0].reaction.as_str(), "👍");
+        assert_eq!(frequencies[0].count, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_refine_frequencies() {
         // Test for empty inputs
         let broadcasted = vec![];
         let by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
         assert!(result.is_empty());
 
         // Test broadcasted reactions only, no by_contact reactions
@@ -293,7 +420,7 @@ mod tests {
             is_from_self: false,
         }];
         let by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].reaction.as_str(), "👍");
         assert_eq!(result[0].count, 2);
@@ -307,7 +434,7 @@ mod tests {
         }];
         let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
         by_contact.insert(ContactId::new(10), Reaction::new("❤️"));
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].reaction.as_str(), "👍");
         assert_eq!(result[0].count, 2);
@@ -330,7 +457,7 @@ mod tests {
         ];
         let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
         by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].reaction.as_str(), "👍");
         assert_eq!(result[0].is_from_self, false);
@@ -345,7 +472,7 @@ mod tests {
         }];
         let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
         by_contact.insert(ContactId::new(10), Reaction::new("👍"));
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].reaction.as_str(), "👍");
         assert_eq!(result[0].count, 2);
@@ -359,7 +486,7 @@ mod tests {
         let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
         by_contact.insert(ContactId::new(11), Reaction::new("👍"));
         by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
-        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        let result = refine_frequencies(broadcasted, &by_contact);
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].reaction.as_str(), "👍");
@@ -453,6 +580,27 @@ mod tests {
         assert_eq!(reactions.frequencies.len(), 2);
         assert_eq!(reactions.frequencies[0].is_from_self, false);
         assert_eq!(reactions.frequencies[1].is_from_self, true);
+
+        // Claire removes her 💪 reaction, and also reactios with 🏳️‍🌈;
+        // SELF-changes are immediate even tho not broadcasted yet, the bring broadcasted reactions table to a "dirty state" ...
+        send_reaction(claire, claire_msg.id, "").await?;
+        let sent_msg = claire.pop_sent_msg().await;
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1");
+
+        send_reaction(claire, claire_msg.id, "🏳️‍🌈").await?;
+        let sent_msg2 = claire.pop_sent_msg().await;
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈2");
+
+        // ... "dirty state" is fixed after next broadcast then, counters should stay the same
+        alice.recv_msg_hidden(&sent_msg).await;
+        alice.recv_msg_hidden(&sent_msg2).await;
+        broadcast_reactions_for_all_chats(alice).await?; // bypass timer in maybe_broadcast_reactions()
+        let sent_msg = alice.pop_sent_msg().await;
+        claire.recv_msg_hidden(&sent_msg).await;
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈2");
 
         Ok(())
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -248,14 +248,18 @@ pub(crate) fn modify_frequencies(
     new_self_reaction: &Reaction,
 ) {
     if let Some(old_reaction) = old_self_reaction {
-        if let Some(idx) = frequencies
-            .iter()
-            .position(|entry| entry.reaction == *old_reaction)
-        {
-            frequencies[idx].count = frequencies[idx].count.saturating_sub(1);
-            if frequencies[idx].count == 0 {
-                frequencies.remove(idx);
+        let mut remove_idx = None;
+        for (idx, entry) in frequencies.iter_mut().enumerate() {
+            if entry.reaction == *old_reaction {
+                entry.count = entry.count.saturating_sub(1);
+                if entry.count == 0 {
+                    remove_idx = Some(idx);
+                }
+                break;
             }
+        }
+        if let Some(idx) = remove_idx {
+            frequencies.remove(idx);
         }
     }
 
@@ -263,11 +267,11 @@ pub(crate) fn modify_frequencies(
         return;
     }
 
-    if let Some(idx) = frequencies
+    if let Some(entry) = frequencies
         .iter_mut()
-        .position(|entry| entry.reaction == *new_self_reaction)
+        .find(|e| e.reaction == *new_self_reaction)
     {
-        frequencies[idx].count += 1;
+        entry.count = entry.count.saturating_add(1);
     } else {
         frequencies.push(ReactionFrequency {
             reaction: new_self_reaction.clone(),

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -21,7 +21,7 @@ use crate::tools::time;
 use crate::{EventType, chatlist_events};
 
 /// Wire format for accumulated broadcast reactions
-/// (sent from broadcast channel owner to subscriber in `Broadcast-Reactions:` header)
+/// (sent from broadcast channel owner to subscriber in `Chat-Broadcast-Reactions:` header)
 #[derive(Debug, Serialize, Deserialize)]
 struct WirePayload {
     messages: Vec<WireMessage>,
@@ -148,7 +148,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
     Ok(())
 }
 
-/// Applies incoming, accumulated reactions received via the `Broadcast-Reactions:` header
+/// Applies incoming, accumulated reactions received via the `Chat-Broadcast-Reactions:` header
 /// to the `broadcasted_reactions` table.
 pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
     let payload: WirePayload = serde_json::from_str(json)?;
@@ -554,7 +554,7 @@ mod tests {
 
         // Alice broadcasts recent reaction changes to Bob and Claire.
         // On the wire, the hidden message has a header like
-        // `Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
+        // `Chat-Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
         maybe_broadcast_reactions(alice).await?;
         let sent_msg = alice.pop_sent_msg().await;
         bob.recv_msg_hidden(&sent_msg).await;

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use crate::EventType;
+use crate::{EventType, chatlist_events};
 use crate::chat::{Chat, ChatId, send_msg};
 use crate::config::Config;
 use crate::constants::Chattype;
@@ -184,6 +184,7 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
             msg_id,
             contact_id: ContactId::UNDEFINED,
         });
+        chatlist_events::emit_chatlist_item_changed(context, msg.chat_id);
     }
 
     Ok(())

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -306,49 +306,28 @@ mod tests {
         alice.recv_msg_hidden(&sent_msg).await;
         let reactions = get_msg_reactions(alice, alice_msg_id).await?;
         assert_eq!(reactions.to_string(), "🏳️‍🌈1");
-        assert_eq!(
-            alice
-                .sql
-                .count("SELECT COUNT(*) FROM reactions_need_broadcast", ())
-                .await?,
-            1
-        );
 
         // Alice broadcasts recent reaction changes to Bob and Claire.
         // On the wire, the hidden message has a header like
         // `Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
         maybe_broadcast_reactions(alice).await?;
-        assert_eq!(
-            alice
-                .sql
-                .count("SELECT COUNT(*) FROM reactions_need_broadcast", ())
-                .await?,
-            0
-        );
         let sent_msg = alice.pop_sent_msg().await;
         bob.recv_msg_hidden(&sent_msg).await;
         claire.recv_msg_hidden(&sent_msg).await;
 
+        // Check that there is nothing left for Alice to broadcast
+        maybe_broadcast_reactions(alice).await?;
+        broadcast_reactions_for_all_chats(alice).await?;
+        assert!(alice.pop_sent_msg_opt().await.is_none());
+
         // Claire got the broadcasted reaction, and then reacts herself.
         // This means, her local view on reactions are a mix `broadcasted_reactions`and `reactions`.
-        assert_eq!(
-            claire
-                .sql
-                .count("SELECT COUNT(*) FROM broadcasted_reactions", ())
-                .await?,
-            1
-        );
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
         assert_eq!(reactions.to_string(), "🏳️‍🌈1");
+        assert_eq!(reactions.frequencies.len(), 1);
+        assert_eq!(reactions.by_contact.len(), 0);
 
         send_reaction(claire, claire_msg.id, "💪").await?;
-        assert_eq!(
-            claire
-                .sql
-                .count("SELECT COUNT(*) FROM reactions", ())
-                .await?,
-            1
-        );
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
         assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
         assert_eq!(reactions.frequencies.len(), 2);
@@ -366,20 +345,6 @@ mod tests {
         let sent_msg = alice.pop_sent_msg().await;
         bob.recv_msg_hidden(&sent_msg).await;
         claire.recv_msg_hidden(&sent_msg).await;
-        assert_eq!(
-            claire
-                .sql
-                .count("SELECT COUNT(*) FROM broadcasted_reactions", ())
-                .await?,
-            2
-        );
-        assert_eq!(
-            claire
-                .sql
-                .count("SELECT COUNT(*) FROM reactions", ())
-                .await?,
-            1
-        );
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
         assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
         assert_eq!(reactions.frequencies.len(), 2);

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -509,6 +509,11 @@ mod tests {
         let alice_chat_id = create_broadcast(alice, "Channel".to_string()).await?;
         let qr = get_securejoin_qr(alice, Some(alice_chat_id)).await?;
 
+        // Check that the newly created channel is muted -
+        // notifications for reactions to ones messages are usually not much interesting
+        let alice_chat = Chat::load_from_db(alice, alice_chat_id).await?;
+        assert!(alice_chat.is_muted());
+
         // Bob and claire join the channel via QR code
         let bob_chat_id = tcm.exec_securejoin_qr(bob, alice, &qr).await;
         bob_chat_id.accept(bob).await?;

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -28,7 +28,10 @@ struct WirePayload {
 }
 #[derive(Debug, Serialize, Deserialize)]
 struct WireMessage {
+    /// RFC 724 Message-ID.
     id: String,
+
+    /// Array of reaction entries.
     reactions: Vec<WireEntry>,
 }
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -7,16 +7,19 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::chat::{ChatId, send_msg};
+use crate::EventType;
+use crate::chat::{Chat, ChatId, send_msg};
 use crate::config::Config;
+use crate::constants::Chattype;
+use crate::contact::ContactId;
 use crate::context::Context;
 use crate::log::warn;
-use crate::message::{Message, MsgId};
+use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
 use crate::reaction::get_msg_reactions;
 use crate::tools::time;
 
-// Wire format for accumulated reactions
+/// Wire format for accumulated reactions
 #[derive(Debug, Serialize, Deserialize)]
 struct BroadcastReactionsPayload {
     messages: Vec<BroadcastReactionsMessage>,
@@ -32,7 +35,7 @@ struct BroadcastReactionsEntry {
     count: usize,
 }
 
-// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
+/// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
 const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
 
 /// Starts broadcasting if last broadcasting so more than `REACTION_BROADCAST_PERIOD` seconds in the past.
@@ -129,6 +132,54 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
     reaction_msg.param.set(Param::BroadcastReactions, json);
     reaction_msg.hidden = true;
     send_msg(context, chat_id, &mut reaction_msg).await?;
+
+    Ok(())
+}
+
+/// Applies incoming, accumulated reactions received via the `Broadcast-Reactions:` header
+/// to the `reactions_accumulated` table.
+pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
+    let payload: BroadcastReactionsPayload = serde_json::from_str(json)?;
+
+    for message in payload.messages {
+        let Some(msg_id) = rfc724_mid_exists(context, &message.id).await? else {
+            continue; // no need for a pending reaction, the next periodic update has the state again
+        };
+        let Some(msg) = Message::load_from_db_optional(context, msg_id).await? else {
+            continue; // there may have been a deletion race, ignore error
+        };
+        let Ok(chat) = Chat::load_from_db(context, msg.chat_id).await else {
+            continue; // there may have been a deletion race, ignore error
+        };
+        if chat.typ != Chattype::InBroadcast {
+            continue;
+        }
+
+        context
+            .sql
+            .transaction(move |transaction| {
+                transaction.execute(
+                    "DELETE FROM reactions_accumulated WHERE msg_id=?",
+                    (msg_id,),
+                )?;
+                for entry in &message.reactions {
+                    transaction.execute(
+                        "INSERT INTO reactions_accumulated (msg_id, reaction, count)
+                         VALUES (?1, ?2, ?3)",
+                        (msg_id, &entry.emoji, entry.count),
+                    )?;
+                }
+                Ok(())
+            })
+            .await?;
+
+        context.emit_event(EventType::ReactionsChanged {
+            // the event is for the subscriber, ReactionsIncoming is not needed
+            chat_id: msg.chat_id,
+            msg_id: msg_id,
+            contact_id: ContactId::UNDEFINED,
+        });
+    }
 
     Ok(())
 }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -41,14 +41,18 @@ struct WireEntry {
 const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
 
 /// Starts broadcasting if last broadcasting is more than `REACTION_BROADCAST_PERIOD` seconds in the past.
+///
+/// Moreover, also broadcast if `lst_broadcast_time` is in the future:
+/// That way we're not stuck e.g. if the clock was accidentally set to one year in the future and then rewinded back.
 pub(crate) async fn maybe_broadcast_reactions(context: &Context) -> Result<()> {
+    let now = time();
     let last_broadcast_time = context
         .get_config_i64(Config::LastReactionsBroadcast)
         .await?;
     let next_broadcast_time = last_broadcast_time.saturating_add(REACTION_BROADCAST_PERIOD);
-    if next_broadcast_time <= time() {
+    if next_broadcast_time <= now || last_broadcast_time > now {
         context
-            .set_config_internal(Config::LastReactionsBroadcast, Some(&time().to_string()))
+            .set_config_internal(Config::LastReactionsBroadcast, Some(&now.to_string()))
             .await?;
         broadcast_reactions_for_all_chats(context).await?;
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -160,9 +160,15 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
         let Some(msg) = Message::load_from_db_optional(context, msg_id).await? else {
             continue; // there may have been a deletion race, ignore error
         };
-        let Ok(chat) = Chat::load_from_db(context, msg.chat_id).await else {
-            continue; // there may have been a deletion race, ignore error
-        };
+
+        let chat: Chat;
+        match Chat::load_from_db(context, msg.chat_id).await {
+            Ok(loaded_chat) => chat = loaded_chat,
+            Err(err) => {
+                warn!(context, "Cannot load chat for broadcast reaction: {err}");
+                continue;
+            }
+        }
         if chat.typ != Chattype::InBroadcast {
             continue;
         }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -262,6 +262,99 @@ mod tests {
     use crate::securejoin::get_securejoin_qr;
     use crate::test_utils::TestContextManager;
 
+    #[test]
+    fn test_refine_broadcast_reactions() {
+        // Test for empty inputs
+        let broadcasted = vec![];
+        let by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        assert!(result.is_empty());
+
+        // Test broadcasted reactions only, no by_contact reactions
+        let broadcasted = vec![ReactionFrequency {
+            reaction: Reaction::new("👍"),
+            count: 2,
+            is_from_self: false,
+        }];
+        let by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].count, 2);
+        assert_eq!(result[0].is_from_self, false);
+
+        // Test `by_contact` adding a completely new reaction not yet in `broadcasted`
+        let broadcasted = vec![ReactionFrequency {
+            reaction: Reaction::new("👍"),
+            count: 2,
+            is_from_self: false,
+        }];
+        let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        by_contact.insert(ContactId::new(10), Reaction::new("❤️"));
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].count, 2);
+        assert_eq!(result[1].reaction.as_str(), "❤️");
+        assert_eq!(result[1].count, 1);
+        assert_eq!(result[1].is_from_self, false);
+
+        // Test `by_contact` contains SELF reaction, ensuring it is marked correctly
+        let broadcasted = vec![
+            ReactionFrequency {
+                reaction: Reaction::new("❤️"),
+                count: 1,
+                is_from_self: false,
+            },
+            ReactionFrequency {
+                reaction: Reaction::new("👍"),
+                count: 2,
+                is_from_self: false,
+            },
+        ];
+        let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].is_from_self, false);
+        assert_eq!(result[1].reaction.as_str(), "❤️");
+        assert_eq!(result[1].is_from_self, true);
+
+        // Test `by_contact` contains a reaction already in broadcasted; count must NOT increase
+        let broadcasted = vec![ReactionFrequency {
+            reaction: Reaction::new("👍"),
+            count: 2,
+            is_from_self: false,
+        }];
+        let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        by_contact.insert(ContactId::new(10), Reaction::new("👍"));
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].count, 2);
+
+        // Test scenario with multiple contacts, overlapping reactions, and SELF
+        let broadcasted = vec![ReactionFrequency {
+            reaction: Reaction::new("👍"),
+            count: 3,
+            is_from_self: false,
+        }];
+        let mut by_contact: BTreeMap<ContactId, Reaction> = BTreeMap::new();
+        by_contact.insert(ContactId::new(11), Reaction::new("👍"));
+        by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
+        let result = refine_broadcast_reactions(broadcasted, &by_contact);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].count, 3);
+        assert_eq!(result[0].is_from_self, false);
+
+        assert_eq!(result[1].reaction.as_str(), "❤️");
+        assert_eq!(result[1].count, 1);
+        assert_eq!(result[1].is_from_self, true);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_broadcast_channel_reaction() -> Result<()> {
         let mut tcm = TestContextManager::new();

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -520,11 +520,6 @@ mod tests {
         let alice_chat_id = create_broadcast(alice, "Channel".to_string()).await?;
         let qr = get_securejoin_qr(alice, Some(alice_chat_id)).await?;
 
-        // Check that the newly created channel is muted -
-        // notifications for reactions to ones messages are usually not much interesting
-        let alice_chat = Chat::load_from_db(alice, alice_chat_id).await?;
-        assert!(alice_chat.is_muted());
-
         // Bob and claire join the channel via QR code
         let bob_chat_id = tcm.exec_securejoin_qr(bob, alice, &qr).await;
         bob_chat_id.accept(bob).await?;

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -185,11 +185,12 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
 
 /// Load broadcasted reactions from `broadcasted_reactions`.
 /// This table is filled only for the broadcast channel subscribers (`Chattype::InBroadcast`),
-/// in other cases, `None` is returned.
+/// by received reactions from the owner or by or temporarily add SELF-reactions.
+/// In there are no broadcasted reactions, an empty array is returned.
 pub(crate) async fn load_broadcast_reactions(
     context: &Context,
     msg_id: MsgId,
-) -> Result<Option<Vec<ReactionFrequency>>> {
+) -> Result<Vec<ReactionFrequency>> {
     let mut frequencies: Vec<ReactionFrequency> = context
         .sql
         .query_map_collect(
@@ -207,12 +208,8 @@ pub(crate) async fn load_broadcast_reactions(
         )
         .await?;
 
-    if frequencies.is_empty() {
-        return Ok(None);
-    }
-
     sort_frequencies(&mut frequencies);
-    Ok(Some(frequencies))
+    Ok(frequencies)
 }
 
 /// Save an array of frequencies to the `broadcasted_reactions` table.

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -132,3 +132,81 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat::create_broadcast;
+    use crate::reaction::send_reaction;
+    use crate::securejoin::get_securejoin_qr;
+    use crate::test_utils::TestContextManager;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_broadcast_channel_reaction() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &tcm.alice().await;
+        let bob = &tcm.bob().await;
+        let claire = &tcm.charlie().await;
+
+        // Alice creates a channel
+        let alice_chat_id = create_broadcast(alice, "Channel".to_string()).await?;
+        let qr = get_securejoin_qr(alice, Some(alice_chat_id)).await?;
+
+        // Bob and claire join the channel via QR code
+        let bob_chat_id = tcm.exec_securejoin_qr(bob, alice, &qr).await;
+        bob_chat_id.accept(bob).await?;
+        let claire_chat_id = tcm.exec_securejoin_qr(claire, alice, &qr).await;
+        claire_chat_id.accept(claire).await?;
+
+        // Alice sends a message to the channel
+        let sent_msg = alice.send_text(alice_chat_id, "hi channel!").await;
+        let alice_msg_id = sent_msg.load_from_db().await.id;
+
+        // Bob and Claire receive the message
+        let bob_msg = bob.recv_msg(&sent_msg).await;
+        let claire_msg = claire.recv_msg(&sent_msg).await;
+        assert_eq!(bob_msg.get_text(), "hi channel!");
+        assert_eq!(claire_msg.get_text(), "hi channel!");
+
+        // Bob reacts to the message
+        send_reaction(bob, bob_msg.id, "🏳️‍🌈").await?;
+        let sent_msg = bob.pop_sent_msg().await;
+        let reactions = get_msg_reactions(bob, bob_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1");
+
+        // Alice receives Bob's reaction
+        alice.recv_msg_hidden(&sent_msg).await;
+        let reactions = get_msg_reactions(alice, alice_msg_id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1");
+        assert_eq!(
+            alice
+                .sql
+                .count("SELECT COUNT(*) FROM reactions_need_broadcast", ())
+                .await?,
+            1
+        );
+
+        // Alice broadcasts reaction to Claire
+        // On the wire, the hidden message has a header like
+        // `Chat-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
+        maybe_broadcast_reactions(alice).await?;
+        assert_eq!(
+            alice
+                .sql
+                .count("SELECT COUNT(*) FROM reactions_need_broadcast", ())
+                .await?,
+            0
+        );
+        let sent_msg = alice.pop_sent_msg().await;
+        claire.recv_msg_hidden(&sent_msg).await;
+        assert_eq!(
+            claire
+                .sql
+                .count("SELECT COUNT(*) FROM reactions_accumulated", ())
+                .await?,
+            1
+        );
+
+        Ok(())
+    }
+}

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
 use crate::EventType;
 use crate::chat::{Chat, ChatId, send_msg};
@@ -16,7 +17,7 @@ use crate::context::Context;
 use crate::log::warn;
 use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
-use crate::reaction::get_msg_reactions;
+use crate::reaction::{Reaction, ReactionFrequency, get_msg_reactions};
 use crate::tools::time;
 
 /// Wire format for accumulated reactions
@@ -187,6 +188,42 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
     Ok(())
 }
 
+/// Load broadcasted reactios from `reactions_accumulated`.
+/// This table is filled only for the broadcast channel subscribers (`Chattype::InBroadcast`),
+/// in other cases, `None` is returned.
+pub(crate) async fn load_broadcast_reactions(
+    context: &Context,
+    msg_id: MsgId,
+) -> Result<Option<Vec<ReactionFrequency>>> {
+    let mut frequencies: Vec<ReactionFrequency> = context
+        .sql
+        .query_map_collect(
+            "SELECT reaction, count FROM reactions_accumulated WHERE msg_id=?",
+            (msg_id,),
+            |row| {
+                let reaction: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(ReactionFrequency {
+                    reaction: Reaction::new(&reaction),
+                    count: count as usize,
+                    is_from_self: false,
+                })
+            },
+        )
+        .await?;
+
+    if frequencies.is_empty() {
+        return Ok(None);
+    }
+
+    frequencies.sort_by(|a, b| match b.count.cmp(&a.count) {
+        Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
+        other => other,
+    });
+
+    Ok(Some(frequencies))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -240,7 +277,7 @@ mod tests {
             1
         );
 
-        // Alice broadcasts reaction to Claire
+        // Alice broadcasts recent reaction changes to Bob and Claire.
         // On the wire, the hidden message has a header like
         // `Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"🏳️‍🌈","count":1}]}]}`
         maybe_broadcast_reactions(alice).await?;
@@ -260,6 +297,8 @@ mod tests {
                 .await?,
             1
         );
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1");
 
         Ok(())
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -215,6 +215,7 @@ pub(crate) async fn load_broadcast_reactions(
     Ok(Some(frequencies))
 }
 
+/// Save an array of frequencies to the `broadcasted_reactions` table.
 async fn save_broadcast_reactions(
     context: &Context,
     msg_id: MsgId,
@@ -240,18 +241,15 @@ async fn save_broadcast_reactions(
     Ok(())
 }
 
-/// Adds dedicated `by_contact` reaction to broadcasted reaction frequencies.
-///
-/// This is needed as broadcast subscribers (Chattype::InBroadcast) want always to see their own reaction immediately,
-/// and have it marked as being a SELF reaction.
-/// Moreover, `by_contact` may contain direct reaction from the broadcast owner.
-/// We do not increase `count` in case the reaction is present as the accumulated counts usually include the ones from `by_contact`.
+/// Merge `by_contact` status to broadcasted reaction frequencies.
 pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Vec<ReactionFrequency> {
-    for (contact_id, reaction) in by_contact {
-        let is_from_self = *contact_id == ContactId::SELF;
+    // Add missing reactions.
+    // This can happen e.g. for SELF-reactions done during offline when state of owner does not have ones yet.
+    // It will repair on the next reaction broadcast, until then, the following is good enough.
+    for reaction in by_contact.values() {
         if !broadcasted_reactions
             .iter()
             .any(|entry| entry.reaction == *reaction)
@@ -259,20 +257,15 @@ pub(crate) fn refine_broadcast_reactions(
             broadcasted_reactions.push(ReactionFrequency {
                 reaction: reaction.clone(),
                 count: 1,
-                is_from_self,
+                is_from_self: false,
             });
-        } else if is_from_self {
-            for entry in &mut broadcasted_reactions {
-                if entry.reaction == *reaction {
-                    // This results in ones own reaction being count twice for yourself.
-                    // We do this, so that you get an immediate feedback on reacting.
-                    //
-                    // Alternative approach is to alter `broadcast_reactions` accordingly on `send_reaction()` (increase/decrease counters, add/remove rows).
-                    // `broadcast_reactions` will become "dirty" by that, but that is recovered implicitly on next update from the channel owner.
-                    entry.count = entry.count + 1;
-                    entry.is_from_self = true;
-                }
-            }
+        }
+    }
+
+    // Mark SELF-reaction as such
+    if let Some(self_reaction) = by_contact.get(&ContactId::SELF) {
+        for entry in &mut broadcasted_reactions {
+            entry.is_from_self = entry.reaction == *self_reaction;
         }
     }
 
@@ -342,10 +335,10 @@ mod tests {
         by_contact.insert(ContactId::SELF, Reaction::new("❤️"));
         let result = refine_broadcast_reactions(broadcasted, &by_contact);
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].reaction.as_str(), "❤️");
-        assert_eq!(result[0].is_from_self, true);
-        assert_eq!(result[1].reaction.as_str(), "👍");
-        assert_eq!(result[1].is_from_self, false);
+        assert_eq!(result[0].reaction.as_str(), "👍");
+        assert_eq!(result[0].is_from_self, false);
+        assert_eq!(result[1].reaction.as_str(), "❤️");
+        assert_eq!(result[1].is_from_self, true);
 
         // Test `by_contact` contains a reaction already in broadcasted; count must NOT increase
         let broadcasted = vec![ReactionFrequency {
@@ -459,10 +452,10 @@ mod tests {
 
         claire.recv_msg_hidden(&sent_msg).await;
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
-        assert_eq!(reactions.to_string(), "💪2 🏳️‍🌈1"); // sic! see comment at `count` increase in refine_broadcast_reactions()
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
         assert_eq!(reactions.frequencies.len(), 2);
-        assert_eq!(reactions.frequencies[0].is_from_self, true);
-        assert_eq!(reactions.frequencies[1].is_from_self, false);
+        assert_eq!(reactions.frequencies[0].is_from_self, false);
+        assert_eq!(reactions.frequencies[1].is_from_self, true);
 
         Ok(())
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use crate::{EventType, chatlist_events};
 use crate::chat::{Chat, ChatId, send_msg};
 use crate::config::Config;
 use crate::constants::Chattype;
@@ -20,6 +19,7 @@ use crate::message::{Message, MsgId, rfc724_mid_exists};
 use crate::param::Param;
 use crate::reaction::{Reaction, ReactionFrequency, get_msg_reactions};
 use crate::tools::time;
+use crate::{EventType, chatlist_events};
 
 /// Wire format for accumulated reactions
 #[derive(Debug, Serialize, Deserialize)]
@@ -236,8 +236,6 @@ pub(crate) fn refine_broadcast_reactions(
     mut broadcasted_reactions: Vec<ReactionFrequency>,
     by_contact: &BTreeMap<ContactId, Reaction>,
 ) -> Vec<ReactionFrequency> {
-    let self_reaction = by_contact.get(&ContactId::SELF).cloned();
-
     for (_contact_id, reaction) in by_contact {
         if !broadcasted_reactions
             .iter()
@@ -251,13 +249,16 @@ pub(crate) fn refine_broadcast_reactions(
         }
     }
 
-    if let Some(self_reaction) = &self_reaction {
+    if let Some(self_reaction) = by_contact.get(&ContactId::SELF) {
         for entry in &mut broadcasted_reactions {
-            if entry.reaction == *self_reaction {
-                entry.is_from_self = true;
-            }
+            entry.is_from_self = entry.reaction == *self_reaction;
         }
     }
+
+    broadcasted_reactions.sort_by(|a, b| match b.count.cmp(&a.count) {
+        Ordering::Equal => a.reaction.as_str().cmp(b.reaction.as_str()),
+        other => other,
+    });
 
     broadcasted_reactions
 }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -20,18 +20,19 @@ use crate::reaction::{Reaction, ReactionFrequency, get_msg_reactions, sort_frequ
 use crate::tools::time;
 use crate::{EventType, chatlist_events};
 
-/// Wire format for accumulated reactions
+/// Wire format for accumulated broadcast reactions
+/// (sent from broadcast channel owner to subscriber in `Broadcast-Reactions:` header)
 #[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsPayload {
-    messages: Vec<BroadcastReactionsMessage>,
+struct WirePayload {
+    messages: Vec<WireMessage>,
 }
 #[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsMessage {
+struct WireMessage {
     id: String,
-    reactions: Vec<BroadcastReactionsEntry>,
+    reactions: Vec<WireEntry>,
 }
 #[derive(Debug, Serialize, Deserialize)]
-struct BroadcastReactionsEntry {
+struct WireEntry {
     emoji: String,
     count: usize,
 }
@@ -106,21 +107,21 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
         )
         .await?;
 
-    let mut messages: Vec<BroadcastReactionsMessage> = Vec::new();
+    let mut messages: Vec<WireMessage> = Vec::new();
     for msg_id in &msg_ids {
         let Some(msg) = Message::load_from_db_optional(context, *msg_id).await? else {
             continue;
         };
         let reactions = get_msg_reactions(context, *msg_id).await?;
-        let entries: Vec<BroadcastReactionsEntry> = reactions
+        let entries: Vec<WireEntry> = reactions
             .frequencies
             .into_iter()
-            .map(|entry| BroadcastReactionsEntry {
+            .map(|entry| WireEntry {
                 emoji: entry.reaction.as_str().to_string(),
                 count: entry.count,
             })
             .collect();
-        messages.push(BroadcastReactionsMessage {
+        messages.push(WireMessage {
             id: msg.rfc724_mid,
             reactions: entries, // can be empty if all reactions were removed
         });
@@ -129,7 +130,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
         return Ok(());
     }
 
-    let payload = BroadcastReactionsPayload { messages };
+    let payload = WirePayload { messages };
     let json = serde_json::to_string(&payload)?;
     let mut reaction_msg = Message::new_text("".to_string());
     reaction_msg.set_reaction();
@@ -143,7 +144,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
 /// Applies incoming, accumulated reactions received via the `Broadcast-Reactions:` header
 /// to the `broadcasted_reactions` table.
 pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
-    let payload: BroadcastReactionsPayload = serde_json::from_str(json)?;
+    let payload: WirePayload = serde_json::from_str(json)?;
 
     for message in payload.messages {
         let Some(msg_id) = rfc724_mid_exists(context, &message.id).await? else {
@@ -159,23 +160,16 @@ pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -
             continue;
         }
 
-        context
-            .sql
-            .transaction(move |transaction| {
-                transaction.execute(
-                    "DELETE FROM broadcasted_reactions WHERE msg_id=?",
-                    (msg_id,),
-                )?;
-                for entry in &message.reactions {
-                    transaction.execute(
-                        "INSERT INTO broadcasted_reactions (msg_id, reaction, count)
-                         VALUES (?1, ?2, ?3)",
-                        (msg_id, &entry.emoji, entry.count),
-                    )?;
-                }
-                Ok(())
+        let frequencies: Vec<ReactionFrequency> = message
+            .reactions
+            .into_iter()
+            .map(|entry| ReactionFrequency {
+                reaction: Reaction::new(&entry.emoji),
+                count: entry.count,
+                is_from_self: false, // set in refine_broadcast_reactions()
             })
-            .await?;
+            .collect();
+        save_broadcast_reactions(context, msg_id, &frequencies).await?;
 
         context.emit_event(EventType::ReactionsChanged {
             // the event is for the subscriber, ReactionsIncoming is not needed
@@ -219,6 +213,31 @@ pub(crate) async fn load_broadcast_reactions(
 
     sort_frequencies(&mut frequencies);
     Ok(Some(frequencies))
+}
+
+async fn save_broadcast_reactions(
+    context: &Context,
+    msg_id: MsgId,
+    frequencies: &Vec<ReactionFrequency>,
+) -> Result<()> {
+    context
+        .sql
+        .transaction(move |transaction| {
+            transaction.execute(
+                "DELETE FROM broadcasted_reactions WHERE msg_id=?",
+                (msg_id,),
+            )?;
+            for entry in frequencies {
+                transaction.execute(
+                    "INSERT INTO broadcasted_reactions (msg_id, reaction, count)
+                         VALUES (?1, ?2, ?3)",
+                    (msg_id, &entry.reaction.as_str(), entry.count),
+                )?;
+            }
+            Ok(())
+        })
+        .await?;
+    Ok(())
 }
 
 /// Adds dedicated `by_contact` reaction to broadcasted reaction frequencies.
@@ -327,7 +346,6 @@ mod tests {
         assert_eq!(result[0].is_from_self, true);
         assert_eq!(result[1].reaction.as_str(), "👍");
         assert_eq!(result[1].is_from_self, false);
-
 
         // Test `by_contact` contains a reaction already in broadcasted; count must NOT increase
         let broadcasted = vec![ReactionFrequency {

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -7,6 +7,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 
 use crate::EventType;
 use crate::chat::{Chat, ChatId, send_msg};
@@ -224,6 +225,42 @@ pub(crate) async fn load_broadcast_reactions(
     Ok(Some(frequencies))
 }
 
+/// Adds dedicated `by_contact` reaction to broadcasted reaction frequencies.
+///
+/// This is needed as broadcast subscribers (Chattype::InBroadcast) want always to see their own reaction immediated,
+/// and have it marked as being a SELF reaction.
+/// Moreover, `by_contact` may contain direct reaction from the broadcast owner.
+pub(crate) fn refine_broadcast_reactions(
+    mut broadcasted_reactions: Vec<ReactionFrequency>,
+    by_contact: BTreeMap<ContactId, Reaction>,
+) -> Result<Vec<ReactionFrequency>> {
+    let self_reaction = by_contact.get(&ContactId::SELF).cloned();
+
+    for (_contact_id, reaction) in &by_contact {
+        if !broadcasted_reactions
+            .iter()
+            .any(|entry| entry.reaction == *reaction)
+        {
+            broadcasted_reactions.push(ReactionFrequency {
+                reaction: reaction.clone(),
+                count: 1,
+                is_from_self: false,
+            });
+        }
+        // no else - do not increase counter, usually, broadcaasted reactions already includes the ones by `by_contact`
+    }
+
+    if let Some(self_reaction) = &self_reaction {
+        for entry in &mut broadcasted_reactions {
+            if entry.reaction == *self_reaction {
+                entry.is_from_self = true;
+            }
+        }
+    }
+
+    Ok(broadcasted_reactions)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,7 +326,11 @@ mod tests {
             0
         );
         let sent_msg = alice.pop_sent_msg().await;
+        bob.recv_msg_hidden(&sent_msg).await;
         claire.recv_msg_hidden(&sent_msg).await;
+
+        // Claire got the broadcasted reaction, and then reacts herself.
+        // This means, her local view on reactions are a mix `reactions_accumulated`and `reactions`.
         assert_eq!(
             claire
                 .sql
@@ -299,6 +340,51 @@ mod tests {
         );
         let reactions = get_msg_reactions(claire, claire_msg.id).await?;
         assert_eq!(reactions.to_string(), "🏳️‍🌈1");
+
+        send_reaction(claire, claire_msg.id, "💪").await?;
+        assert_eq!(
+            claire
+                .sql
+                .count("SELECT COUNT(*) FROM reactions", ())
+                .await?,
+            1
+        );
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
+        assert_eq!(reactions.frequencies.len(), 2);
+        assert_eq!(reactions.frequencies[0].is_from_self, false);
+        assert_eq!(reactions.frequencies[1].is_from_self, true);
+
+        // Claire's reaction is sent to Alice who in turn broadast it again to Bob and Claire.
+        // This must not modify Clair's get_reactions() even tho the reaction is present now in `reactions_accumulated` and `reactions`.
+        let sent_msg = claire.pop_sent_msg().await;
+        alice.recv_msg_hidden(&sent_msg).await;
+        let reactions = get_msg_reactions(alice, alice_msg_id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
+
+        broadcast_reactions_for_all_chats(alice).await?; // bypass timer in maybe_broadcast_reactions()
+        let sent_msg = alice.pop_sent_msg().await;
+        bob.recv_msg_hidden(&sent_msg).await;
+        claire.recv_msg_hidden(&sent_msg).await;
+        assert_eq!(
+            claire
+                .sql
+                .count("SELECT COUNT(*) FROM reactions_accumulated", ())
+                .await?,
+            2
+        );
+        assert_eq!(
+            claire
+                .sql
+                .count("SELECT COUNT(*) FROM reactions", ())
+                .await?,
+            1
+        );
+        let reactions = get_msg_reactions(claire, claire_msg.id).await?;
+        assert_eq!(reactions.to_string(), "🏳️‍🌈1 💪1");
+        assert_eq!(reactions.frequencies.len(), 2);
+        assert_eq!(reactions.frequencies[0].is_from_self, false);
+        assert_eq!(reactions.frequencies[1].is_from_self, true);
 
         Ok(())
     }

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -1,0 +1,132 @@
+//! # Broadcasting Reactions.
+//!
+//! For broadcast channels, reactions are sent from the subscriber to the broadcast channel owner as usual.
+//! The owner then remembers these changes by adding a record to `reactions_need_broadcast`,
+//! and every some minutes sends an update to all subscribers.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::chat::{ChatId, send_msg};
+use crate::config::Config;
+use crate::context::Context;
+use crate::log::warn;
+use crate::message::{Message, MsgId};
+use crate::reaction::get_msg_reactions;
+use crate::tools::time;
+
+// Wire format for accumulated reactions
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsPayload {
+    messages: Vec<BroadcastReactionsMessage>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsMessage {
+    id: String,
+    reactions: Vec<BroadcastReactionsEntry>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct BroadcastReactionsEntry {
+    emoji: String,
+    count: usize,
+}
+
+// Seconds between sending out accumulated reaction updates for broadcast channels from `reactions_need_broadcast` table
+const REACTION_BROADCAST_PERIOD: i64 = 10 * 60;
+
+/// Starts broadcasting if last broadcasting so more than `REACTION_BROADCAST_PERIOD` seconds in the past.
+pub(crate) async fn maybe_broadcast_reactions(context: &Context) -> Result<()> {
+    let last_broadcast_time = context
+        .get_config_i64(Config::LastReactionsBroadcast)
+        .await?;
+    let next_broadcast_time = last_broadcast_time.saturating_add(REACTION_BROADCAST_PERIOD);
+    if next_broadcast_time <= time() {
+        context
+            .set_config_internal(Config::LastReactionsBroadcast, Some(&time().to_string()))
+            .await?;
+        broadcast_reactions_for_all_chats(context).await?;
+    }
+    Ok(())
+}
+
+/// Sends out accumulated reactions
+/// for all broadcast channels with reactions in `reactions_need_broadcast`.
+///
+/// For every affected `chat_id`,
+/// a single hidden message is sent to all subscribers containing the full, current reaction state (not a diff)
+/// for every message that received a reaction change since the last broadcast.
+async fn broadcast_reactions_for_all_chats(context: &Context) -> Result<()> {
+    let chat_ids: Vec<ChatId> = context
+        .sql
+        .query_map_collect(
+            "SELECT DISTINCT chat_id FROM reactions_need_broadcast",
+            (),
+            |row| {
+                let chat_id: ChatId = row.get(0)?;
+                Ok(chat_id)
+            },
+        )
+        .await?;
+
+    for chat_id in chat_ids {
+        if let Err(err) = broadcast_reactions_for_one_chat(context, chat_id).await {
+            warn!(
+                context,
+                "Failed to broadcast reactions for chat {chat_id}: {err:#}."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Sends out accumulated reactions for a single broadcast channel
+async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) -> Result<()> {
+    let msg_ids: Vec<MsgId> = context
+        .sql
+        .query_map_collect(
+            "SELECT DISTINCT msg_id FROM reactions_need_broadcast WHERE chat_id=?",
+            (chat_id,),
+            |row| {
+                let msg_id: MsgId = row.get(0)?;
+                Ok(msg_id)
+            },
+        )
+        .await?;
+
+    context
+        .sql
+        .execute(
+            "DELETE FROM reactions_need_broadcast WHERE chat_id=?",
+            (chat_id,),
+        )
+        .await?;
+
+    let mut messages: Vec<BroadcastReactionsMessage> = Vec::new();
+    for msg_id in &msg_ids {
+        let Some(msg) = Message::load_from_db_optional(context, *msg_id).await? else {
+            continue;
+        };
+        let reactions = get_msg_reactions(context, *msg_id).await?;
+        let entries: Vec<BroadcastReactionsEntry> = reactions
+            .emoji_sorted_by_frequency()
+            .into_iter()
+            .map(|(emoji, count)| BroadcastReactionsEntry { emoji, count })
+            .collect();
+        messages.push(BroadcastReactionsMessage {
+            id: msg.rfc724_mid,
+            reactions: entries, // can be empty if all reactions were removed
+        });
+    }
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    let payload = BroadcastReactionsPayload { messages };
+    let json = serde_json::to_string(&payload)?;
+    let mut reaction_msg = Message::new_text(json); // TOOD: maybe json is better put to the header
+    reaction_msg.set_reaction();
+    reaction_msg.hidden = true;
+    send_msg(context, chat_id, &mut reaction_msg).await?;
+
+    Ok(())
+}

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -12,6 +12,7 @@ use crate::config::Config;
 use crate::context::Context;
 use crate::log::warn;
 use crate::message::{Message, MsgId};
+use crate::param::Param;
 use crate::reaction::get_msg_reactions;
 use crate::tools::time;
 
@@ -123,8 +124,9 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
 
     let payload = BroadcastReactionsPayload { messages };
     let json = serde_json::to_string(&payload)?;
-    let mut reaction_msg = Message::new_text(json); // TOOD: maybe json is better put to the header
+    let mut reaction_msg = Message::new_text("".to_string());
     reaction_msg.set_reaction();
+    reaction_msg.param.set(Param::ChatReactions, json);
     reaction_msg.hidden = true;
     send_msg(context, chat_id, &mut reaction_msg).await?;
 

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -112,9 +112,12 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
         };
         let reactions = get_msg_reactions(context, *msg_id).await?;
         let entries: Vec<BroadcastReactionsEntry> = reactions
-            .emoji_sorted_by_frequency()
+            .frequencies
             .into_iter()
-            .map(|(emoji, count)| BroadcastReactionsEntry { emoji, count })
+            .map(|entry| BroadcastReactionsEntry {
+                emoji: entry.reaction.as_str().to_string(),
+                count: entry.count,
+            })
             .collect();
         messages.push(BroadcastReactionsMessage {
             id: msg.rfc724_mid,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -41,6 +41,7 @@ use crate::mimeparser::{
 };
 use crate::param::{Param, Params};
 use crate::peer_channels::{add_gossip_peer_from_header, insert_topic_stub, iroh_topic_from_str};
+use crate::reaction::broadcast_reactions::receive_broadcast_reactions;
 use crate::reaction::{Reaction, set_msg_reaction};
 use crate::rusqlite::OptionalExtension;
 use crate::securejoin::{
@@ -898,6 +899,12 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
                 context,
                 "Received webxdc update, but cannot assign it to message."
             );
+        }
+    }
+
+    if let Some(broadcast_reactions) = &mime_parser.broadcast_reactions {
+        if let Err(err) = receive_broadcast_reactions(context, broadcast_reactions).await {
+            warn!(context, "Cannot apply Broadcast-Reactions: {err:#}.");
         }
     }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -902,10 +902,10 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
         }
     }
 
-    if let Some(broadcast_reactions) = &mime_parser.broadcast_reactions {
-        if let Err(err) = receive_broadcast_reactions(context, broadcast_reactions).await {
-            warn!(context, "Cannot apply Broadcast-Reactions: {err:#}.");
-        }
+    if let Some(broadcast_reactions) = &mime_parser.broadcast_reactions
+        && let Err(err) = receive_broadcast_reactions(context, broadcast_reactions).await
+    {
+        warn!(context, "Cannot apply Broadcast-Reactions: {err:#}.");
     }
 
     if let Some(avatar_action) = &mime_parser.user_avatar

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -905,7 +905,7 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
     if let Some(broadcast_reactions) = &mime_parser.broadcast_reactions
         && let Err(err) = receive_broadcast_reactions(context, broadcast_reactions).await
     {
-        warn!(context, "Cannot apply Broadcast-Reactions: {err:#}.");
+        warn!(context, "Cannot apply broadcast reactions: {err:#}.");
     }
 
     if let Some(avatar_action) = &mime_parser.user_avatar

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -448,6 +448,31 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
         }
     };
 
+    match ctx.get_config_i64(Config::LastReactionsBroadcast).await {
+        Ok(last_reaction_broadcast_time) => {
+            let next_reaction_broadcast_time =
+                last_reaction_broadcast_time.saturating_add(constants::REACTION_BROADCAST_PERIOD);
+            if next_reaction_broadcast_time <= time() {
+                if let Err(err) = crate::reaction::broadcast_reactions_for_all_chats(ctx).await {
+                    warn!(
+                        ctx,
+                        "Transport {transport_id}: Failed to broadcast reactions: {err:#}."
+                    );
+                }
+                ctx.set_config_internal(Config::LastReactionsBroadcast, Some(&time().to_string()))
+                    .await
+                    .log_err(ctx)
+                    .ok();
+            }
+        }
+        Err(err) => {
+            warn!(
+                ctx,
+                "Transport {transport_id}: Failed to get last reaction broadcast time: {err:#}"
+            );
+        }
+    };
+
     maybe_send_stats(ctx).await.log_err(ctx).ok();
 
     session

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -20,6 +20,7 @@ use crate::events::EventType;
 use crate::imap::{Imap, session::Session};
 use crate::location;
 use crate::log::{LogExt, warn};
+use crate::reaction::broadcast_reactions::maybe_broadcast_reactions;
 use crate::smtp::{Smtp, send_smtp_messages};
 use crate::sql;
 use crate::stats::maybe_send_stats;
@@ -448,31 +449,7 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
         }
     };
 
-    match ctx.get_config_i64(Config::LastReactionsBroadcast).await {
-        Ok(last_reaction_broadcast_time) => {
-            let next_reaction_broadcast_time =
-                last_reaction_broadcast_time.saturating_add(constants::REACTION_BROADCAST_PERIOD);
-            if next_reaction_broadcast_time <= time() {
-                if let Err(err) = crate::reaction::broadcast_reactions_for_all_chats(ctx).await {
-                    warn!(
-                        ctx,
-                        "Transport {transport_id}: Failed to broadcast reactions: {err:#}."
-                    );
-                }
-                ctx.set_config_internal(Config::LastReactionsBroadcast, Some(&time().to_string()))
-                    .await
-                    .log_err(ctx)
-                    .ok();
-            }
-        }
-        Err(err) => {
-            warn!(
-                ctx,
-                "Transport {transport_id}: Failed to get last reaction broadcast time: {err:#}"
-            );
-        }
-    };
-
+    maybe_broadcast_reactions(ctx).await.log_err(ctx).ok();
     maybe_send_stats(ctx).await.log_err(ctx).ok();
 
     session

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2529,6 +2529,31 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
                 fingerprint TEXT PRIMARY KEY NOT NULL, -- Upper-case fingerprint of the recipient key.
                 attached_timestamp INTEGER NOT NULL
             ) STRICT",
+
+            migration_version,
+        )
+        .await?;
+    }
+
+    inc_and_check(&mut migration_version, 161)?;
+    if dbversion < migration_version {
+        // `reactions_accumulated` stores accumulated reactions for broadcast channel subscribers (Chattype::InBroadcast).
+        // `reactions_accumulated` is unused for broadcast channel owners (Chattype::OutBroadcast),
+        // there `reactions_need_broadcast` is used to find out new reactions to be sent to subscribers.
+        sql.execute_migration(
+            "CREATE TABLE reactions_accumulated (
+                msg_id INTEGER NOT NULL DEFAULT 0,
+                reaction TEXT NOT NULL DEFAULT '',
+                count INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
+            ) STRICT;
+            CREATE INDEX reactions_accumulated_index1 ON reactions_accumulated (msg_id);
+            CREATE TABLE reactions_need_broadcast (
+                chat_id INTEGER NOT NULL DEFAULT 0,
+                msg_id INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
+            ) STRICT;
+            CREATE INDEX reactions_need_broadcast_index1 ON reactions_need_broadcast (chat_id);",
             migration_version,
         )
         .await?;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2537,17 +2537,17 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
 
     inc_and_check(&mut migration_version, 161)?;
     if dbversion < migration_version {
-        // `reactions_accumulated` stores accumulated reactions for broadcast channel subscribers (Chattype::InBroadcast).
-        // `reactions_accumulated` is unused for broadcast channel owners (Chattype::OutBroadcast),
+        // `broadcasted_reactions` stores accumulated reactions for broadcast channel subscribers (Chattype::InBroadcast).
+        // `broadcasted_reactions` is unused for broadcast channel owners (Chattype::OutBroadcast),
         // there `reactions_need_broadcast` is used to find out new reactions to be sent to subscribers.
         sql.execute_migration(
-            "CREATE TABLE reactions_accumulated (
+            "CREATE TABLE broadcasted_reactions (
                 msg_id INTEGER NOT NULL DEFAULT 0,
                 reaction TEXT NOT NULL DEFAULT '',
                 count INTEGER NOT NULL DEFAULT 0,
                 FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
             ) STRICT;
-            CREATE INDEX reactions_accumulated_index1 ON reactions_accumulated (msg_id);
+            CREATE INDEX broadcasted_reactions_index1 ON broadcasted_reactions (msg_id);
             CREATE TABLE reactions_need_broadcast (
                 chat_id INTEGER NOT NULL DEFAULT 0,
                 msg_id INTEGER NOT NULL DEFAULT 0,

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2537,31 +2537,6 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
 
     inc_and_check(&mut migration_version, 161)?;
     if dbversion < migration_version {
-        // `broadcasted_reactions` stores accumulated reactions for broadcast channel subscribers (Chattype::InBroadcast).
-        // `broadcasted_reactions` is unused for broadcast channel owners (Chattype::OutBroadcast),
-        // there `reactions_need_broadcast` is used to find out new reactions to be sent to subscribers.
-        sql.execute_migration(
-            "CREATE TABLE broadcasted_reactions (
-                msg_id INTEGER NOT NULL DEFAULT 0,
-                reaction TEXT NOT NULL DEFAULT '',
-                count INTEGER NOT NULL DEFAULT 0,
-                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
-            ) STRICT;
-            CREATE INDEX broadcasted_reactions_index1 ON broadcasted_reactions (msg_id);
-            CREATE TABLE reactions_need_broadcast (
-                chat_id INTEGER NOT NULL DEFAULT 0,
-                msg_id INTEGER NOT NULL DEFAULT 0,
-                UNIQUE (chat_id, msg_id),
-                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
-            ) STRICT;
-            CREATE INDEX reactions_need_broadcast_index1 ON reactions_need_broadcast (chat_id);",
-            migration_version,
-        )
-        .await?;
-    }
-
-    inc_and_check(&mut migration_version, 161)?;
-    if dbversion < migration_version {
         // TODO put a better list here
         const DEFAULT_RELAY_CANDIDATES: &[&str] = &[
             "mehl.cloud",
@@ -2588,6 +2563,31 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
                 }
                 Ok(())
             },
+            migration_version,
+        )
+        .await?;
+    }
+
+    inc_and_check(&mut migration_version, 162)?;
+    if dbversion < migration_version {
+        // `broadcasted_reactions` stores accumulated reactions for broadcast channel subscribers (Chattype::InBroadcast).
+        // `broadcasted_reactions` is unused for broadcast channel owners (Chattype::OutBroadcast),
+        // there `reactions_need_broadcast` is used to find out new reactions to be sent to subscribers.
+        sql.execute_migration(
+            "CREATE TABLE broadcasted_reactions (
+                msg_id INTEGER NOT NULL DEFAULT 0,
+                reaction TEXT NOT NULL DEFAULT '',
+                count INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
+            ) STRICT;
+            CREATE INDEX broadcasted_reactions_index1 ON broadcasted_reactions (msg_id);
+            CREATE TABLE reactions_need_broadcast (
+                chat_id INTEGER NOT NULL DEFAULT 0,
+                msg_id INTEGER NOT NULL DEFAULT 0,
+                UNIQUE (chat_id, msg_id),
+                FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
+            ) STRICT;
+            CREATE INDEX reactions_need_broadcast_index1 ON reactions_need_broadcast (chat_id);",
             migration_version,
         )
         .await?;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2529,7 +2529,6 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
                 fingerprint TEXT PRIMARY KEY NOT NULL, -- Upper-case fingerprint of the recipient key.
                 attached_timestamp INTEGER NOT NULL
             ) STRICT",
-
             migration_version,
         )
         .await?;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2551,6 +2551,7 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
             CREATE TABLE reactions_need_broadcast (
                 chat_id INTEGER NOT NULL DEFAULT 0,
                 msg_id INTEGER NOT NULL DEFAULT 0,
+                UNIQUE (chat_id, msg_id),
                 FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
             ) STRICT;
             CREATE INDEX reactions_need_broadcast_index1 ON reactions_need_broadcast (chat_id);",

--- a/test-data/golden/test_broadcast_joining_golden_alice
+++ b/test-data/golden/test_broadcast_joining_golden_alice
@@ -1,4 +1,4 @@
-OutBroadcast#Chat#1001: My Channel [1 member(s)] Icon: e9b6c7a78aa2e4f415644f55a553e73.png
+OutBroadcast#Chat#1001: My Channel [1 member(s)]🔇 Icon: e9b6c7a78aa2e4f415644f55a553e73.png
 --------------------------------------------------------------------------------
 Msg#1001: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
 Msg#1002🔒: Me (Contact#Contact#Self): Channel image changed. [INFO] √

--- a/test-data/golden/test_sync_broadcast_alice1
+++ b/test-data/golden/test_sync_broadcast_alice1
@@ -1,4 +1,4 @@
-OutBroadcast#Chat#1001: Channel [0 member(s)]
+OutBroadcast#Chat#1001: Channel [0 member(s)]🔇
 --------------------------------------------------------------------------------
 Msg#1001: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
 Msg#1006🔒: Me (Contact#Contact#Self): Member bob@example.net added. [INFO] √

--- a/test-data/golden/test_sync_broadcast_alice2
+++ b/test-data/golden/test_sync_broadcast_alice2
@@ -1,4 +1,4 @@
-OutBroadcast#Chat#1001: Channel [0 member(s)]
+OutBroadcast#Chat#1001: Channel [0 member(s)]🔇
 --------------------------------------------------------------------------------
 Msg#1002: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
 Msg#1006🔒: Me (Contact#Contact#Self): Member bob@example.net added. [INFO] √


### PR DESCRIPTION
this PR adds support for reactions in broadcast channels.

> the idea of broadcast reactions is that they are sent as usual from subscribers to owner. after some time, the owner broadcasts them to all subscribers, who only get to see reaction+count, not who-reacted-what

the PR is quite large, but a good share are tests and otherwise many things are straight forward.

review should be done by-file, not by-commit. to make review easier, here is a high-level overview:

first a change in the existing internal `Reactions` object was required. before this PR, `Reactions` had a "contact to reaction map" only, and the "frequencies map", that are actually mainly needed for UI, were calculated as needed. with this PR, the "frequencies map" is the field that always exist, the "contact map" is only available on top of that.
moreover, this PR shifts that part to the core, it was unfortunately in the bindings before.

with that preparation, things are done as follows:

1. reactions from broadcast channel subscriber (`Chattype::InBroadcast`) to broadcast channel owner (`Chattype::OutBroadcast`) are sent as usual, only change for that step was to allow sending them at all

2. the owner receives reactions and saves them to the existing `reactions` table as usual. additionally, the changed message is remembered in  `reactions_need_broadcast` table

3. in the IMAP loop, when ~10 minutes have passed, and `reactions_need_broadcast` contains entries, a single, hidden message with accumulated reactions is sent. this message may contain reactions to different messages. for each message, all known reactions are sent as reaction+count.

4. subscriber receive that message and save the accumulated reactions in `reactions_broadcasted`

6. `get_message_reactions` is adapted so that `frequencies` are set independently of who-reacted-what (the old and only field). who-reacted-what is called `by_contact` now. it is always set for compatibility reasons, however, it is not exhaustive for subscribers.
in general, UI should work with frequencies, the API itself, however, has not changed.

other tweaks:

- outgoing channels are muted on creation, and UI shall allow to unmute/mute them as all other chats. reason is that reactions are notified, but in many cases not of large interest. this is also what telegram is doing

- to have an intermediate feedback when reacting, the local state should include ones own reaction, even if it is not yet broadcasted. for that, we modify `reactions_broadcasted` using `modify_frequencies()` as needed when sending an reaction. there are still some situations where the update may not include ones own reaction, in this case it is added lately by `refine_frequencies()`, so that `get_message_reactions()` always contain SELF.
(in a first implementation, we always increased SELF reaction in refine_frequencies(), however, that was worse and led  to SELF counted twice once the owner sent broadcast)

<details>
<summary>wire format</summary>

wire format is a JSON in the `Broadcast-Reactions:` header. additionally, `Content-Disposition: reaction` is set to not show the hidden message on existing devices.

using a header also allows us to broadcast reactions with resent channel messages (on joining) later.

```
{
  "messages": [
    {
      "id": "12345678",
      "reactions": [
        { "emoji": "👍", "count": 4 },
        { "emoji": "🎉", "count": 2 }
      ]
    },
    {
      "id": "23456789",
      "reactions": []
    }
  ]
}
```

for `id`, the wire format needs to use `rfc724_mid` as `msg_id` are local only.

</details>

### known issues

- if the channel owner uses multiple devices, broadcasted reaction updates are sent from each device. the updates are not that big, so that is probably not a big deal. if it turns out that this is an issue, we can think about fixes in another PR. might be done by restarting our 10-minute-wait once we see an update from another device

- we cannot set contact_id for DC_EVENT_REACTIONS_CHANGED - but i doubt it was ever used

### for another pr

- ~~add `Broadcast-Reactions:` header also for resent channel messages, so that new subscriber do not only get the latest messages, but also their reactions. for that, the `Broadcast-Reactions:` header can go to the corresponding message, no need to send extra messages. we would need to change the sending part to send all reactions for a given message. on receiving part, we need to make sure, `receive_broadcast_reactions()` is called when the message actually exist.~~
EDIT: subsequent PR for resending broadcast reactions at https://github.com/chatmail/core/pull/8496

- add api to allow only a subset of reactions, fiter incoming reactions before broadcasting

### misc.

ui pr: https://github.com/deltachat/deltachat-ios/pull/3225 and https://github.com/deltachat/deltachat-android/pull/4560 , which both were tested successfully with this core PR already. desktop is meant to be done once this is merged