### PR TITLE
chore: Add script to show the sizes of futures (async Rust)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,10 @@ and an own build machine.
 
 - `android-rpc-server.sh` compiles binaries of `deltachat-rpc-server` using Android NDK.
 
+- `future-sizes.sh` prints the sizes of the largest Futures.
+  This can be helpful because Async Rust can lead to huge futures,
+  increasing RAM usage and compilation times.
+
 ## Triggering runs on the build machine locally (fast!)
 
 There is experimental support for triggering a remote Python or Rust test run 

--- a/scripts/future-sizes.sh
+++ b/scripts/future-sizes.sh
@@ -15,7 +15,7 @@ export RUSTFLAGS="-Zprint-type-sizes"
 export RUSTC_BOOTSTRAP=1
 
 # Warm the dependency cache so their output doesn't pollute the report later.
-cargo check -q --release -p deltachat
+cargo check --release -p deltachat >/dev/null
 
 # Recompile only the core crate (release) capture its type-size report.
 cargo clean --release -p deltachat

--- a/scripts/future-sizes.sh
+++ b/scripts/future-sizes.sh
@@ -15,12 +15,12 @@ export RUSTFLAGS="-Zprint-type-sizes"
 export RUSTC_BOOTSTRAP=1
 
 # Warm the dependency cache so their output doesn't pollute the report later.
-cargo check --release -p deltachat >/dev/null
+cargo check --locked --release -p deltachat >/dev/null
 
 # Recompile only the core crate (release) capture its type-size report.
-cargo clean --release -p deltachat
+cargo clean --locked --release -p deltachat
 report="$CARGO_TARGET_DIR/type-sizes.txt"
-if ! cargo check --release -p deltachat >"$report"; then
+if ! cargo check --locked --release -p deltachat >"$report"; then
     tail -20 "$report"
     exit 1
 fi

--- a/scripts/future-sizes.sh
+++ b/scripts/future-sizes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Report the largest async-fn futures using rustc's unstable -Zprint-type-sizes.
+#
+# Usage: scripts/future-sizes.sh [TOP_N]     (default: 30)
+#
+# Uses a dedicated target dir so the normal build cache is untouched
+# and repeated runs only recompile the core crate itself.
+
+TOP_N="${1:-30}"
+
+export CARGO_TARGET_DIR="target/type-sizes"
+export RUSTFLAGS="-Zprint-type-sizes"
+export RUSTC_BOOTSTRAP=1
+
+# Warm the dependency cache so their output doesn't pollute the report later.
+cargo check -q --release -p deltachat
+
+# Recompile only the core crate (release) capture its type-size report.
+cargo clean --release -p deltachat
+report="$CARGO_TARGET_DIR/type-sizes.txt"
+if ! cargo check --release -p deltachat >"$report"; then
+    tail -20 "$report"
+    exit 1
+fi
+
+sizes=$(rg '^print-type-size type: `\{async fn body of (.*)\(\)\}`: ([0-9]+) bytes' \
+    -or '$2 $1' "$report" | sort -rn | uniq)
+if [ -z "$sizes" ]; then
+    echo "error: no type-size output found, see $report" >&2
+    exit 1
+fi
+
+echo "Largest async fn futures in deltachat (top $TOP_N, bytes):"
+head -"$TOP_N" <<<"$sizes"
+
+echo
+echo "Full report (all types, with per-field breakdown): $report"


### PR DESCRIPTION
Add the script from https://github.com/chatmail/core/pull/8345/changes#r3696015000 with a few small tweaks

TODO: Add to readme