### PR TITLE
feat: pinned messages

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4473,6 +4473,7 @@ int             dc_msg_is_info                (const dc_msg_t* msg);
  * - DC_INFO_WEBXDC_INFO_MESSAGE (32) - Info-message created by webxdc app sending `update.info`
  * - DC_INFO_CHAT_E2EE (50) - Info-message for "Chat is end-to-end-encrypted"
  * - DC_INFO_GROUP_DESCRIPTION_CHANGED (70) - Info-message "Description changed", UI should open the profile with the description
+ * - DC_INFO_MESSAGE_PINNED (71) - Message pinned, UI should scroll to the pinned message returned by dc_msg_get_parent()
  *
  * For the messages that refer to a CONTACT,
  * dc_msg_get_info_contact_id() returns the contact ID.
@@ -4532,6 +4533,7 @@ uint32_t        dc_msg_get_info_contact_id    (const dc_msg_t* msg);
 #define         DC_INFO_WEBXDC_INFO_MESSAGE       32
 #define         DC_INFO_CHAT_E2EE                 50
 #define         DC_INFO_GROUP_DESCRIPTION_CHANGED 70
+#define         DC_INFO_MESSAGE_PINNED            71
 
 
 /**
@@ -4849,6 +4851,8 @@ dc_msg_t*       dc_msg_get_quoted_msg         (const dc_msg_t* msg);
  * Used for Webxdc-info-messages
  * to jump to the corresponding instance that created the info message.
  *
+ * For Pinned-info-messages, this refers to the pinned message.
+ *
  * For quotes, please use the more specialized
  * dc_msg_get_quoted_text() and dc_msg_get_quoted_msg().
  *
@@ -4887,6 +4891,20 @@ uint32_t        dc_msg_get_original_msg_id    (const dc_msg_t* msg);
  *     0 if the given message object is not saved.
  */
 uint32_t        dc_msg_get_saved_msg_id     (const dc_msg_t* msg);
+
+
+/**
+ * Check if the message is pinned.
+ *
+ * Pinned messages should be marked by a pin needle in the UI.
+ * To pin messages or get all pinned messages, use jsonrpc's "setPinnedMessageState" and "getPinnedMessages".
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return 1=message is pinned, 0=message not pinned.
+ */
+ int             dc_msg_is_pinned           (const dc_msg_t* msg);
+
 
 /**
  * @class dc_contact_t
@@ -5672,6 +5690,7 @@ void dc_jsonrpc_unref(dc_jsonrpc_instance_t* jsonrpc_instance);
  * - getAccountFileSize()
  * - importVcard(), parseVcard(), makeVcard()
  * - sendWebxdcRealtimeData, sendWebxdcRealtimeAdvertisement(), leaveWebxdcRealtime()
+ * - setPinnedMessageState(), getPinnedMessages()
  *
  * @memberof dc_jsonrpc_instance_t
  * @param jsonrpc_instance jsonrpc instance as returned from dc_jsonrpc_init().
@@ -7248,6 +7267,12 @@ void dc_event_unref(dc_event_t* event);
 ///
 /// Used when creating text for the "Encryption Info" dialogs.
 #define DC_STR_MESSAGES_ARE_E2EE 242
+
+/// "You pinned a message."
+#define DC_STR_MESSAGE_PINNED_BY_YOU 243
+
+/// "Message pinned by %1$s."
+#define DC_STR_MESSAGE_PINNED_BY_OTHER 244
 
 /**
  * @}

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3904,6 +3904,16 @@ pub unsafe extern "C" fn dc_msg_get_saved_msg_id(msg: *const dc_msg_t) -> u32 {
         .unwrap_or(0)
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dc_msg_is_pinned(msg: *mut dc_msg_t) -> libc::c_int {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_is_pinned()");
+        return 0;
+    }
+    let ffi_msg = unsafe { &*msg };
+    ffi_msg.message.is_pinned().into()
+}
+
 // dc_contact_t
 
 /// FFI struct for [dc_contact_t]

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1508,6 +1508,26 @@ impl CommandApi {
         MessageNotificationInfo::from_msg_id(&ctx, MsgId::new(message_id)).await
     }
 
+    /// Sets the "pinned" state for a message.
+    async fn set_pinned_message_state(
+        &self,
+        account_id: u32,
+        message_id: u32,
+        pinned_state: bool,
+    ) -> Result<()> {
+        let ctx = self.get_context(account_id).await?;
+        deltachat::pinned_messages::set_pinned_state(&ctx, MsgId::new(message_id), pinned_state)
+            .await
+    }
+
+    /// Returns all pinned messages of a chat.
+    async fn get_pinned_messages(&self, account_id: u32, chat_id: u32) -> Result<Vec<u32>> {
+        let ctx = self.get_context(account_id).await?;
+        let msg_ids =
+            deltachat::pinned_messages::get_pinned_messages(&ctx, ChatId::new(chat_id)).await?;
+        Ok(msg_ids.into_iter().map(|id| id.to_u32()).collect())
+    }
+
     /// Delete messages. The messages are deleted on the current device and
     /// on the IMAP server.
     async fn delete_messages(&self, account_id: u32, message_ids: Vec<u32>) -> Result<()> {

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -103,6 +103,8 @@ pub struct MessageObject {
 
     saved_message_id: Option<u32>,
 
+    is_pinned: bool,
+
     reactions: Option<JsonrpcReactions>,
 
     vcard_contact: Option<VcardContact>,
@@ -263,6 +265,7 @@ impl MessageObject {
                 .await?
                 .map(|id| id.to_u32()),
 
+            is_pinned: message.is_pinned(),
             reactions,
 
             vcard_contact: vcard_contacts.first().cloned(),
@@ -425,6 +428,8 @@ pub enum SystemMessageType {
 
     CallAccepted,
     CallEnded,
+    MessagePinned,
+    MessageUnpinned,
 }
 
 impl From<deltachat::mimeparser::SystemMessage> for SystemMessageType {
@@ -454,6 +459,8 @@ impl From<deltachat::mimeparser::SystemMessage> for SystemMessageType {
             SystemMessage::SecurejoinWaitTimeout => SystemMessageType::SecurejoinWaitTimeout,
             SystemMessage::CallAccepted => SystemMessageType::CallAccepted,
             SystemMessage::CallEnded => SystemMessageType::CallEnded,
+            SystemMessage::MessagePinned => SystemMessageType::MessagePinned,
+            SystemMessage::MessageUnpinned => SystemMessageType::MessageUnpinned,
         }
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4612,6 +4612,7 @@ pub async fn forward_msgs_2ctx(
         msg.rfc724_mid = create_outgoing_rfc724_mid();
         msg.pre_rfc724_mid.clear();
         msg.timestamp_sort = now;
+        msg.pinned = false;
         chat.prepare_msg_raw(ctx_dst, &mut msg, None).await?;
 
         if !create_send_msg_jobs(ctx_dst, &mut msg).await?.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod param;
 mod pgp;
 #[cfg(feature = "internals")]
 pub mod pgp;
+pub mod pinned_messages;
 pub mod provider;
 pub mod qr;
 pub mod qr_code_generator;

--- a/src/message.rs
+++ b/src/message.rs
@@ -461,6 +461,7 @@ pub struct Message {
     pub(crate) in_reply_to: Option<String>,
     pub(crate) is_dc_message: MessengerMessage,
     pub(crate) original_msg_id: MsgId,
+    pub(crate) pinned: bool,
     pub(crate) mime_modified: bool,
     pub(crate) chat_visibility: ChatVisibility,
     pub(crate) chat_blocked: Blocked,
@@ -530,6 +531,7 @@ impl Message {
                     m.error AS error,
                     m.msgrmsg AS msgrmsg,
                     m.starred AS original_msg_id,
+                    m.pinned AS pinned,
                     m.mime_modified AS mime_modified,
                     m.txt AS txt,
                     m.subject AS subject,
@@ -588,6 +590,7 @@ impl Message {
                             .filter(|error| !error.is_empty()),
                         is_dc_message: row.get("msgrmsg")?,
                         original_msg_id: row.get("original_msg_id")?,
+                        pinned: row.get("pinned")?,
                         mime_modified: row.get("mime_modified")?,
                         text,
                         additional_text: String::new(),
@@ -1080,6 +1083,8 @@ impl Message {
             | SystemMessage::IrohNodeAddr
             | SystemMessage::CallAccepted
             | SystemMessage::CallEnded
+            | SystemMessage::MessagePinned // UI should scroll to pinned message on tapping
+            | SystemMessage::MessageUnpinned // UI should scroll to unpinned message on tapping
             | SystemMessage::Unknown => Ok(None),
         }
     }
@@ -1344,6 +1349,11 @@ impl Message {
             )
             .await?;
         Ok(res)
+    }
+
+    /// Returns true if the message is pinned.
+    pub fn is_pinned(&self) -> bool {
+        self.pinned
     }
 
     /// Force the message to be sent in plain text.

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1812,6 +1812,8 @@ impl MimeFactory {
                 SystemMessage::ChatE2ee => {}
                 SystemMessage::CallAccepted => {}
                 SystemMessage::CallEnded => {}
+                SystemMessage::MessagePinned => {}
+                SystemMessage::MessageUnpinned => {}
             }
 
             if command == SystemMessage::GroupDescriptionChanged
@@ -1935,6 +1937,18 @@ impl MimeFactory {
                 headers.push((
                     "Chat-Content",
                     mail_builder::headers::raw::Raw::new("call-ended").into(),
+                ));
+            }
+            SystemMessage::MessagePinned => {
+                headers.push((
+                    "Chat-Content",
+                    mail_builder::headers::raw::Raw::new("message-pinned").into(),
+                ));
+            }
+            SystemMessage::MessageUnpinned => {
+                headers.push((
+                    "Chat-Content",
+                    mail_builder::headers::raw::Raw::new("message-unpinned").into(),
                 ));
             }
             _ => {}

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -263,6 +263,12 @@ pub enum SystemMessage {
 
     /// Group or broadcast channel description changed.
     GroupDescriptionChanged = 70,
+
+    /// Message pinned. The pinned message is referred in `In-Reply-To:` header.
+    MessagePinned = 71,
+
+    /// Message unpinned. The unpinned message is referred in `In-Reply-To:` header.
+    MessageUnpinned = 72,
 }
 
 impl MimeMessage {
@@ -741,6 +747,10 @@ impl MimeMessage {
                 self.is_system_message = SystemMessage::CallAccepted;
             } else if value == "call-ended" {
                 self.is_system_message = SystemMessage::CallEnded;
+            } else if value == "message-pinned" {
+                self.is_system_message = SystemMessage::MessagePinned;
+            } else if value == "message-unpinned" {
+                self.is_system_message = SystemMessage::MessageUnpinned;
             }
         } else if self.get_header(HeaderDef::ChatGroupMemberRemoved).is_some() {
             self.is_system_message = SystemMessage::MemberRemovedFromGroup;

--- a/src/pinned_messages.rs
+++ b/src/pinned_messages.rs
@@ -1,0 +1,328 @@
+//! # Handle pinned messages.
+//!
+//! Pinned messages can be used in all types of chats
+//! and for all but info-messages.
+//!
+//! Pinned messages are synchronized for all chat members by sending an info-message
+//! that refers the pinned message in the `In-Reply-To:` header.
+//! The info-message is only shown for pinning (not for unpinning).
+//! Unpinning is an action that does not require so much attention; internally it is a hidden info-message.
+
+use anyhow::{Result, ensure};
+
+use crate::chat::{ChatId, send_msg};
+use crate::contact::ContactId;
+use crate::context::Context;
+use crate::message::{Message, MessageState, MsgId, Viewtype};
+use crate::mimeparser::SystemMessage;
+use crate::stock_str;
+
+/// Check if the given message is pinnable in general.
+/// This does not mean the local user is allowed to pin/unpin it themselves,
+/// e.g. messages in broadcast channels may be pinnable - but cannot be pinned by the local user.
+fn is_pinnable(msg: &Message) -> bool {
+    !msg.id.is_special()
+    && !msg.is_info()
+    && !msg.hidden
+    && msg.state != MessageState::OutDraft
+    && msg.state != MessageState::OutFailed // Some user did not get the message, pinning it raises wrong expectations
+    && !msg.chat_id.is_special()
+}
+
+/// Pin or unpin a message.
+///
+/// If the message is not pinnable, an error is returned.
+/// If pinning changes, `EventType::MsgsChanged`` event is fired to show/hide the pinning needle.
+pub async fn set_pinned_state(
+    context: &Context,
+    msg_id: MsgId,
+    new_pinned_state: bool,
+) -> Result<()> {
+    let msg = Message::load_from_db(context, msg_id).await?;
+    ensure!(is_pinnable(&msg), "Message is not pinnable.");
+    if msg.is_pinned() == new_pinned_state {
+        return Ok(());
+    }
+
+    let mut info_msg = Message::new(Viewtype::Text);
+    info_msg.text = if new_pinned_state {
+        stock_str::msg_pinned(context, ContactId::SELF).await
+    } else {
+        "Message unpinned.".to_string() // no need to localize, "unpinned" messages are not visible
+    };
+    info_msg.hidden = !new_pinned_state;
+    info_msg.in_reply_to = Some(msg.rfc724_mid.clone());
+    info_msg.param.set_cmd(if new_pinned_state {
+        SystemMessage::MessagePinned
+    } else {
+        SystemMessage::MessageUnpinned
+    });
+    send_msg(context, msg.chat_id, &mut info_msg).await?;
+
+    // alter database only after we successfully sent the message
+    update_pinned_state_in_db(context, &msg, new_pinned_state).await?;
+
+    Ok(())
+}
+
+async fn update_pinned_state_in_db(
+    context: &Context,
+    msg: &Message,
+    new_pinned_state: bool,
+) -> Result<()> {
+    context
+        .sql
+        .execute(
+            "UPDATE msgs SET pinned=? WHERE id=?",
+            (new_pinned_state, msg.id),
+        )
+        .await?;
+    context.emit_msgs_changed(msg.chat_id, msg.id);
+
+    Ok(())
+}
+
+/// Returns all pinned messages of a chat.
+///
+/// The list is ordered by message date, not by pinning date,
+/// and starts with the oldest message - same as the normal message view.
+///
+/// When a chat is opened, UI should show the newest message in the "pinned banner".
+/// The scrollbar of the "pinned banner" will be scrolled down all the way, same as the whole chat.
+/// The pinned message is shown using `Message::get_summary()`, enriched by thumbnails and a "Start" button for webxdc.
+///
+/// Once the banner is tapped, UI should scroll to that message and replace the banner by pinned message one position less.
+/// When the position is 0, UI should wrap and show the newest message again.
+///
+/// By that, usually scrolling the message view and the pinned view have the same direction.
+pub async fn get_pinned_messages(context: &Context, chat_id: ChatId) -> Result<Vec<MsgId>> {
+    ensure!(!chat_id.is_special(), "Invalid chat ID.");
+
+    let pinned_msg_ids = context
+        .sql
+        .query_map_vec(
+            "SELECT id
+               FROM msgs
+              WHERE pinned=1 AND hidden=0 AND chat_id=?
+              ORDER BY timestamp, id;",
+            (chat_id,),
+            |row| {
+                let msg_id: MsgId = row.get(0)?;
+                Ok(msg_id)
+            },
+        )
+        .await?;
+    Ok(pinned_msg_ids)
+}
+
+/// Handle pinned state received from the wire, e.g. by an info message.
+///
+/// This function checks and updates the state and sends events,
+/// but does not add a info message or sync otherwise.
+/// If the message is not pinnable, an error is returned.
+pub(crate) async fn handle_pinned_state_from_wire(
+    context: &Context,
+    msg: &Message,
+    new_pinned_state: bool,
+) -> Result<()> {
+    ensure!(is_pinnable(msg), "Message is not pinnable.");
+    if msg.is_pinned() == new_pinned_state {
+        return Ok(());
+    }
+    update_pinned_state_in_db(context, msg, new_pinned_state).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat::{ChatItem, create_broadcast, get_chat_msgs};
+    use crate::config::Config;
+    use crate::securejoin::get_securejoin_qr;
+    use crate::test_utils::{TestContextManager, sync};
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pinned_messages() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &tcm.alice().await;
+        let alice2 = &tcm.alice().await; // Alice's second device
+        let bob = &tcm.bob().await;
+
+        alice.set_config_bool(Config::SyncMsgs, true).await?;
+        alice2.set_config_bool(Config::SyncMsgs, true).await?;
+
+        // Alice creates all chat types upfront, with Bob as member if possible
+        let single_chat_id = alice.create_chat(bob).await.id;
+        let group_chat_id = alice.create_group_with_members("Group", &[bob]).await;
+        let broadcast_chat_id = create_broadcast(alice, "Channel".to_string()).await?;
+        let qr = get_securejoin_qr(alice, Some(broadcast_chat_id)).await?;
+        tcm.exec_securejoin_qr(bob, alice, &qr).await;
+        let self_chat_id = alice.get_self_chat().await.id;
+        sync(alice, alice2).await;
+
+        for alice_chat_id in [
+            single_chat_id,
+            group_chat_id,
+            broadcast_chat_id,
+            self_chat_id,
+        ] {
+            let pinned = get_pinned_messages(alice, alice_chat_id).await?;
+            assert!(pinned.is_empty());
+
+            // Alice sends message "Foo" and pins it
+            let sent1 = alice.send_text(alice_chat_id, "Foo").await;
+            let msg1 = sent1.load_from_db().await;
+            assert!(!msg1.is_pinned());
+
+            set_pinned_state(alice, msg1.id, true).await?;
+            let sent2 = alice.pop_sent_msg().await;
+            assert!(sent1.load_from_db().await.is_pinned());
+
+            let info_msg = sent2.load_from_db().await;
+            assert!(info_msg.is_info());
+            assert!(!info_msg.hidden);
+            assert_eq!(info_msg.get_info_type(), SystemMessage::MessagePinned);
+            assert!(info_msg.get_info_contact_id(alice).await?.is_none()); // contact not needed, tapping shall jump to message
+
+            let pinned = get_pinned_messages(alice, alice_chat_id).await?;
+            assert_eq!(pinned.len(), 1);
+            assert_eq!(pinned[0], msg1.id);
+
+            // Pinning an info message does not work
+            assert!(set_pinned_state(alice, info_msg.id, true).await.is_err());
+
+            // Unpin the initially pinned message.
+            // Before, send another message "Bar". To test, no visible info message is added this time,
+            let sent3 = alice.send_text(alice_chat_id, "Bar").await;
+
+            set_pinned_state(alice, msg1.id, false).await?;
+            let sent4 = alice.pop_sent_msg().await;
+            assert!(!sent1.load_from_db().await.is_pinned());
+
+            let pinned = get_pinned_messages(alice, alice_chat_id).await?;
+            assert!(pinned.is_empty());
+
+            let msg3 = sent3.load_from_db().await;
+            assert!(!msg3.is_info());
+            assert!(!msg3.is_pinned());
+            assert_eq!(alice.get_last_msg_id_in(msg3.chat_id).await, msg3.id); // last message is still "Bar", not an info message
+
+            if alice_chat_id != self_chat_id {
+                // Bob receives message "Foo"
+                let msg1 = bob.recv_msg(&sent1).await;
+                assert!(!msg1.is_pinned());
+                let pinned = get_pinned_messages(bob, msg1.chat_id).await?;
+                assert!(pinned.is_empty());
+
+                // Bob receives info message to pin "Foo"
+                bob.recv_msg(&sent2).await;
+                assert!(Message::load_from_db(bob, msg1.id).await?.is_pinned());
+
+                let pinned = get_pinned_messages(bob, msg1.chat_id).await?;
+                assert_eq!(pinned.len(), 1);
+                assert_eq!(pinned[0], msg1.id);
+
+                let info_msg =
+                    Message::load_from_db(bob, bob.get_last_msg_id_in(msg1.chat_id).await).await?;
+                assert!(info_msg.is_info());
+                assert!(!info_msg.hidden);
+                assert_eq!(info_msg.get_info_type(), SystemMessage::MessagePinned);
+                assert!(info_msg.get_info_contact_id(bob).await?.is_none());
+
+                // Bob receives message "Bar" and hidden message to unpin message "Foo"
+                bob.recv_msg(&sent3).await;
+                bob.recv_msg_trash(&sent4).await;
+                assert!(!Message::load_from_db(bob, msg1.id).await?.is_pinned());
+
+                let pinned = get_pinned_messages(bob, msg1.chat_id).await?;
+                assert!(pinned.is_empty());
+
+                let no_info_msg =
+                    Message::load_from_db(bob, bob.get_last_msg_id_in(msg1.chat_id).await).await?;
+                assert!(!no_info_msg.is_info());
+                assert_eq!(no_info_msg.text, "Bar");
+            }
+
+            // Alice's second device receives all four messages and ends up in the same state
+            let msg1 = alice2.recv_msg(&sent1).await;
+            alice2.recv_msg(&sent2).await;
+            assert!(Message::load_from_db(alice2, msg1.id).await?.is_pinned());
+
+            alice2.recv_msg(&sent3).await;
+            alice2.recv_msg_trash(&sent4).await;
+            assert!(!Message::load_from_db(alice2, msg1.id).await?.is_pinned());
+
+            let no_info_msg =
+                Message::load_from_db(alice2, alice2.get_last_msg_id_in(msg1.chat_id).await)
+                    .await?;
+            assert!(!no_info_msg.is_info());
+            assert_eq!(no_info_msg.text, "Bar");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_pinned_messages_order() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &tcm.alice().await;
+        let chat_id = alice.get_self_chat().await.id;
+        let boilerplate_msg_count = get_chat_msgs(alice, chat_id).await?.len();
+
+        // create three messages, sent1 and sent2 have different timestamp, sent2 and sent3 may differ by ID only
+        let sent1 = alice.send_text(chat_id, "1").await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        let sent2 = alice.send_text(chat_id, "2").await;
+        let sent3 = alice.send_text(chat_id, "3").await;
+
+        // get_chat_msgs() start with the oldest message
+        let chat_msgs = get_chat_msgs(alice, chat_id).await?;
+        let msg_ids: Vec<_> = chat_msgs
+            .into_iter()
+            .filter_map(|item| match item {
+                ChatItem::Message { msg_id } => Some(msg_id),
+                ChatItem::DayMarker { .. } => None,
+            })
+            .collect();
+        assert_eq!(
+            &msg_ids[boilerplate_msg_count..],
+            &[
+                sent1.sender_msg_id,
+                sent2.sender_msg_id,
+                sent3.sender_msg_id
+            ]
+        );
+
+        // get_pinned_messages() has the same order, also starting with the oldest message
+        set_pinned_state(alice, sent1.sender_msg_id, true).await?;
+        set_pinned_state(alice, sent2.sender_msg_id, true).await?;
+        set_pinned_state(alice, sent3.sender_msg_id, true).await?;
+        let pinned = get_pinned_messages(alice, chat_id).await?;
+        assert_eq!(pinned.len(), 3);
+        assert_eq!(pinned[0], sent1.sender_msg_id);
+        assert_eq!(pinned[1], sent2.sender_msg_id);
+        assert_eq!(pinned[2], sent3.sender_msg_id);
+
+        // order of pinning does not affect the order of pinned messages.
+        // this is to keep scrolling direction of chat bubbles and pinned banner scrollbar in sync,
+        // and not jumping wildly around.
+        // this is also what most other messengers are doing.
+        set_pinned_state(alice, sent1.sender_msg_id, false).await?;
+        set_pinned_state(alice, sent2.sender_msg_id, false).await?;
+        set_pinned_state(alice, sent3.sender_msg_id, false).await?;
+        let pinned = get_pinned_messages(alice, chat_id).await?;
+        assert_eq!(pinned.len(), 0);
+
+        set_pinned_state(alice, sent3.sender_msg_id, true).await?;
+        set_pinned_state(alice, sent2.sender_msg_id, true).await?;
+        set_pinned_state(alice, sent1.sender_msg_id, true).await?;
+        let pinned = get_pinned_messages(alice, chat_id).await?;
+        assert_eq!(pinned.len(), 3);
+        assert_eq!(pinned[0], sent1.sender_msg_id);
+        assert_eq!(pinned[1], sent2.sender_msg_id);
+        assert_eq!(pinned[2], sent3.sender_msg_id);
+
+        Ok(())
+    }
+}

--- a/src/pinned_messages.rs
+++ b/src/pinned_messages.rs
@@ -13,6 +13,7 @@ use anyhow::{Result, ensure};
 use crate::chat::{ChatId, send_msg};
 use crate::contact::ContactId;
 use crate::context::Context;
+use crate::log::warn;
 use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::stock_str;
@@ -119,13 +120,18 @@ pub async fn get_pinned_messages(context: &Context, chat_id: ChatId) -> Result<V
 ///
 /// This function checks and updates the state and sends events,
 /// but does not add a info message or sync otherwise.
-/// If the message is not pinnable, an error is returned.
+///
+/// If the message is not pinnable, a warning is logged and the message is ignored.
 pub(crate) async fn handle_pinned_state_from_wire(
     context: &Context,
     msg: &Message,
     new_pinned_state: bool,
 ) -> Result<()> {
-    ensure!(is_pinnable(msg), "Message is not pinnable.");
+    if !is_pinnable(msg) {
+        warn!(context, "Message is not pinnable.");
+        return Ok(());
+    }
+
     if msg.is_pinned() == new_pinned_state {
         return Ok(());
     }
@@ -136,7 +142,7 @@ pub(crate) async fn handle_pinned_state_from_wire(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chat::{ChatItem, create_broadcast, get_chat_msgs};
+    use crate::chat::{ChatItem, add_info_msg, create_broadcast, get_chat_msgs};
     use crate::config::Config;
     use crate::securejoin::get_securejoin_qr;
     use crate::test_utils::{TestContextManager, sync};
@@ -322,6 +328,36 @@ mod tests {
         assert_eq!(pinned[0], sent1.sender_msg_id);
         assert_eq!(pinned[1], sent2.sender_msg_id);
         assert_eq!(pinned[2], sent3.sender_msg_id);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_handle_pinned_state_from_wire() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &tcm.alice().await;
+        let chat_id = alice.get_self_chat().await.id;
+
+        let sent1 = alice.send_text(chat_id, "pinnable").await;
+        let msg1 = sent1.load_from_db().await;
+        assert!(is_pinnable(&msg1));
+        assert!(
+            handle_pinned_state_from_wire(alice, &msg1, true)
+                .await
+                .is_ok()
+        );
+
+        // For not-pinnable messages, handle_pinned_state_from_wire() logs a warning and returns "ok".
+        // otherwise if there is an incompatibility in which messages are treated as "pinnable",
+        // this error will bubble up and user will get a device message saying "please report a bug".
+        let msg2_id = add_info_msg(alice, chat_id, "not pinnable").await?;
+        let msg2 = Message::load_from_db(alice, msg2_id).await?;
+        assert!(!is_pinnable(&msg2));
+        assert!(
+            handle_pinned_state_from_wire(alice, &msg2, true)
+                .await
+                .is_ok()
+        );
 
         Ok(())
     }

--- a/src/pinned_messages.rs
+++ b/src/pinned_messages.rs
@@ -103,7 +103,7 @@ pub async fn get_pinned_messages(context: &Context, chat_id: ChatId) -> Result<V
         .query_map_vec(
             "SELECT id
                FROM msgs
-              WHERE pinned=1 AND hidden=0 AND chat_id=?
+              WHERE pinned=1 AND chat_id=?
               ORDER BY timestamp, id;",
             (chat_id,),
             |row| {

--- a/src/pinned_messages.rs
+++ b/src/pinned_messages.rs
@@ -32,7 +32,7 @@ fn is_pinnable(msg: &Message) -> bool {
 /// Pin or unpin a message.
 ///
 /// If the message is not pinnable, an error is returned.
-/// If pinning changes, `EventType::MsgsChanged`` event is fired to show/hide the pinning needle.
+/// If pinning changes, `EventType::MsgsChanged` event is fired to show/hide the pinning needle.
 pub async fn set_pinned_state(
     context: &Context,
     msg_id: MsgId,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -41,6 +41,7 @@ use crate::mimeparser::{
 };
 use crate::param::{Param, Params};
 use crate::peer_channels::{add_gossip_peer_from_header, insert_topic_stub, iroh_topic_from_str};
+use crate::pinned_messages::handle_pinned_state_from_wire;
 use crate::reaction::broadcast_reactions::receive_broadcast_reactions;
 use crate::reaction::{Reaction, set_msg_reaction};
 use crate::rusqlite::OptionalExtension;
@@ -1202,6 +1203,9 @@ async fn decide_chat_assignment(
     {
         info!(context, "Call state changed (TRASH).");
         true
+    } else if mime_parser.is_system_message == SystemMessage::MessageUnpinned {
+        info!(context, "Message unpinned (TRASH).");
+        true
     } else if let Some(ref decryption_error) = mime_parser.decryption_error
         && !mime_parser.incoming
     {
@@ -1990,6 +1994,8 @@ async fn add_parts(
         ephemeral_timer = EphemeralTimer::Disabled;
 
         Some(better_msg)
+    } else if mime_parser.is_system_message == SystemMessage::MessagePinned {
+        Some(stock_str::msg_pinned(context, from_id).await) // message unpinned info is trashed in decide_chat_assignment()
     } else {
         None
     };
@@ -2130,6 +2136,15 @@ async fn add_parts(
         } else {
             warn!(context, "Call: Not a reply.")
         }
+    }
+
+    if (mime_parser.is_system_message == SystemMessage::MessagePinned
+        || mime_parser.is_system_message == SystemMessage::MessageUnpinned)
+        && let Some(msg_to_change) =
+            get_parent_message(context, None, mime_parser.get_header(HeaderDef::InReplyTo)).await?
+    {
+        let new_pinned_state = mime_parser.is_system_message == SystemMessage::MessagePinned;
+        handle_pinned_state_from_wire(context, &msg_to_change, new_pinned_state).await?;
     }
 
     let hidden = mime_parser.parts.iter().all(|part| part.is_reaction);

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2143,8 +2143,14 @@ async fn add_parts(
         && let Some(msg_to_change) =
             get_parent_message(context, None, mime_parser.get_header(HeaderDef::InReplyTo)).await?
     {
-        let new_pinned_state = mime_parser.is_system_message == SystemMessage::MessagePinned;
-        handle_pinned_state_from_wire(context, &msg_to_change, new_pinned_state).await?;
+        let chat_contacts =
+            BTreeSet::<ContactId>::from_iter(chat::get_chat_contacts(context, chat_id).await?);
+        let is_from_in_chat =
+            !chat_contacts.contains(&ContactId::SELF) || chat_contacts.contains(&from_id);
+        if is_from_in_chat {
+            let new_pinned_state = mime_parser.is_system_message == SystemMessage::MessagePinned;
+            handle_pinned_state_from_wire(context, &msg_to_change, new_pinned_state).await?;
+        }
     }
 
     let hidden = mime_parser.parts.iter().all(|part| part.is_reaction);

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2592,6 +2592,24 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 163)?;
+    if dbversion < migration_version {
+        // store pinned state as a column rather than in a separate table,
+        // because pinned state must be read together with mostly every message (to show the "pin needle"),
+        // so a LEFT JOIN would add per-row overhead on every message load -
+        // even though pinned messages themselves are rare.
+        // this mirrors how "starred" and "hidden" are handled.
+        //
+        // the partial index `WHERE pinned=1` keeps the index small and useful,
+        // since the vast majority of rows are `pinned=0`.
+        sql.execute_migration(
+            "ALTER TABLE msgs ADD COLUMN pinned INTEGER DEFAULT 0;
+            CREATE INDEX msgs_index10 ON msgs (pinned) WHERE pinned=1;",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2603,7 +2603,7 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
         // the partial index `WHERE pinned=1` keeps the index small and useful,
         // since the vast majority of rows are `pinned=0`.
         sql.execute_migration(
-            "ALTER TABLE msgs ADD COLUMN pinned INTEGER DEFAULT 0;
+            "ALTER TABLE msgs ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
             CREATE INDEX msgs_index10 ON msgs (pinned) WHERE pinned=1;",
             migration_version,
         )

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -421,6 +421,12 @@ https://delta.chat/donate"))]
 
     #[strum(props(fallback = "Messages are end-to-end encrypted."))]
     MessagesAreE2ee = 242,
+
+    #[strum(props(fallback = "You pinned a message."))]
+    MsgYouPinnedAMessage = 243,
+
+    #[strum(props(fallback = "Message pinned by %1$s."))]
+    MsgMessagePinnedBy = 244,
 }
 
 impl StockMessage {
@@ -602,6 +608,17 @@ pub(crate) async fn msg_chat_description_changed(
         translated(context, StockMessage::MsgYouChangedDescription)
     } else {
         translated(context, StockMessage::MsgChatDescriptionChangedBy)
+            .replace1(&by_contact.get_stock_name(context).await)
+    }
+}
+
+/// Stock strings for pinning a message; used in info messages, once tapped, UI scrolled to the pinned message.
+/// For unpinning a message, we do not add a visible info message as this is of fewer interest.
+pub(crate) async fn msg_pinned(context: &Context, by_contact: ContactId) -> String {
+    if by_contact == ContactId::SELF {
+        translated(context, StockMessage::MsgYouPinnedAMessage)
+    } else {
+        translated(context, StockMessage::MsgMessagePinnedBy)
             .replace1(&by_contact.get_stock_name(context).await)
     }
 }

--- a/src/tests/pre_messages/legacy.rs
+++ b/src/tests/pre_messages/legacy.rs
@@ -34,7 +34,7 @@ async fn test_download_stub_message() -> Result<()> {
                 11001,'Mr.12345678901@example.com','',0,
                 11001,11001,1,1763151754,10,10,1,0,
                 '[97.66 KiB message]','','',0,1763151754,1763151754,0,X'',
-                '','',1,0,'',0,0,0,'foo',10,replace('Hop: From: userid; Date: Mon, 4 Dec 2006 13:51:39 +0000\n\nDKIM Results: Passed=true','\n',char(10)),1,NULL,0,'');
+                '','',1,0,'',0,0,0,'foo',10,replace('Hop: From: userid; Date: Mon, 4 Dec 2006 13:51:39 +0000\n\nDKIM Results: Passed=true','\n',char(10)),1,NULL,0,'',0);
         "#, ()).await?;
     let msg = t.get_last_msg().await;
     assert_eq!(msg.download_state(), DownloadState::Available);


### PR DESCRIPTION
this PR adds a "pinned messages API", that will allow UIs to offer the typical things of pinned messages:

- add a menu item to pin/unpin any message
- show a banner with the pinned messages, taps cycle through them (if more than 1) and scroll to the original bubble
- if more than 1 pinned message, UI should show a "scrolling indicator", see existing implementations to get the idea
- show a little "pin icon" beside the date in the message bubbles
- and more

<img width="400" src="https://github.com/user-attachments/assets/05e9061e-5a7b-4f7e-8426-1b6362f74bd0" />

implementation wise, this PR is comparable straight forward - it does not change much of existing flows, only adds, and around half of the added lines are tests and codes :)

- a new `set_pinned_state()` api allows to pin/unpin a message. as several other API (chat names, member added etc.) it sends out an info-message, that carries `Chat-Content: message-pinned` resp. `Chat-Content: message-unpinned` header. the changed message is the parent message, similar as used for webxdc updates.

- noteworthy: the info message is only in the chat if a message is pinned. if a message is unpinned, it is hidden. this is what most other implementations do as well, unpinning an outdated information is of few interest

- when other members or devices receive that message, they change the pinned state accordingly. notifications are done as usual.

- finally, there is a `pinned` API to show the little needle beside messages. this is the only API that also exist for cffi, as android/iOS/ubuntutouch work with cffi message objects

later, we also want to resend pinned messages in channels, this is comparable easy as well, but to keep discussion on point, i moved that to [another PR](https://github.com/chatmail/core/pull/8549) that is about to discussed once this is merged.

android-PR started at https://github.com/deltachat/deltachat-android/pull/4586

closes https://github.com/chatmail/core/issues/7817