### PR TITLE
refactor: rename `_ex()` -> `_ext()`

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1065,7 +1065,7 @@ pub unsafe extern "C" fn dc_send_delete_request(
     let ctx = unsafe { &*context };
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
 
-    block_on(message::delete_msgs_ex(ctx, &msg_ids, true))
+    block_on(message::delete_msgs_ext(ctx, &msg_ids, true))
         .context("failed dc_send_delete_request() call")
         .log_err(ctx)
         .ok();
@@ -1308,7 +1308,7 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
 
     let add_daymarker = (flags & DC_GCM_ADDDAYMARKER) != 0;
     Box::into_raw(Box::new(
-        block_on(chat::get_chat_msgs_ex(
+        block_on(chat::get_chat_msgs_ext(
             ctx,
             ChatId::new(chat_id),
             MessageListOptions { add_daymarker },

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -12,7 +12,7 @@ use deltachat::blob::BlobObject;
 use deltachat::calls::ice_servers;
 use deltachat::chat::{
     self, Chat, ChatId, ChatItem, MessageListOptions, add_contact_to_chat, forward_msgs,
-    forward_msgs_2ctx, get_chat_media, get_chat_msgs, get_chat_msgs_ex, markfresh_chat,
+    forward_msgs_2ctx, get_chat_media, get_chat_msgs, get_chat_msgs_ext, markfresh_chat,
     marknoticed_all_chats, marknoticed_chat, remove_contact_from_chat,
 };
 use deltachat::chatlist::Chatlist;
@@ -24,7 +24,7 @@ use deltachat::ephemeral::Timer;
 use deltachat::imex;
 use deltachat::location;
 use deltachat::message::{
-    self, Message, MessageState, MsgId, Viewtype, delete_msgs_ex, get_existing_msg_ids,
+    self, Message, MessageState, MsgId, Viewtype, delete_msgs_ext, get_existing_msg_ids,
     get_msg_read_receipt_count, get_msg_read_receipts, markseen_msgs,
 };
 use deltachat::peer_channels::{
@@ -1393,7 +1393,7 @@ impl CommandApi {
         add_daymarker: bool,
     ) -> Result<Vec<u32>> {
         let ctx = self.get_context(account_id).await?;
-        let msg = get_chat_msgs_ex(
+        let msg = get_chat_msgs_ext(
             &ctx,
             ChatId::new(chat_id),
             MessageListOptions { add_daymarker },
@@ -1442,7 +1442,7 @@ impl CommandApi {
         add_daymarker: bool,
     ) -> Result<Vec<JsonrpcMessageListItem>> {
         let ctx = self.get_context(account_id).await?;
-        let msg = get_chat_msgs_ex(
+        let msg = get_chat_msgs_ext(
             &ctx,
             ChatId::new(chat_id),
             MessageListOptions { add_daymarker },
@@ -1513,7 +1513,7 @@ impl CommandApi {
     async fn delete_messages(&self, account_id: u32, message_ids: Vec<u32>) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         let msgs: Vec<MsgId> = message_ids.into_iter().map(MsgId::new).collect();
-        delete_msgs_ex(&ctx, &msgs, false).await
+        delete_msgs_ext(&ctx, &msgs, false).await
     }
 
     /// Delete messages. The messages are deleted on the current device,
@@ -1521,7 +1521,7 @@ impl CommandApi {
     async fn delete_messages_for_all(&self, account_id: u32, message_ids: Vec<u32>) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         let msgs: Vec<MsgId> = message_ids.into_iter().map(MsgId::new).collect();
-        delete_msgs_ex(&ctx, &msgs, true).await
+        delete_msgs_ext(&ctx, &msgs, true).await
     }
 
     /// Get an informational text for a single message. The text is multiline and may

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -12,7 +12,7 @@ use deltachat::blob::BlobObject;
 use deltachat::calls::ice_servers;
 use deltachat::chat::{
     self, Chat, ChatId, ChatItem, MessageListOptions, add_contact_to_chat, forward_msgs,
-    forward_msgs_2ctx, get_chat_media, get_chat_msgs, get_chat_msgs_ex, markfresh_chat,
+    forward_msgs_2ctx, get_chat_media, get_chat_msgs, get_chat_msgs_ext, markfresh_chat,
     marknoticed_all_chats, marknoticed_chat, remove_contact_from_chat,
 };
 use deltachat::chatlist::Chatlist;
@@ -24,7 +24,7 @@ use deltachat::ephemeral::Timer;
 use deltachat::imex;
 use deltachat::location;
 use deltachat::message::{
-    self, Message, MessageState, MsgId, Viewtype, delete_msgs_ex, get_existing_msg_ids,
+    self, Message, MessageState, MsgId, Viewtype, delete_msgs_ext, get_existing_msg_ids,
     get_msg_read_receipt_count, get_msg_read_receipts, markseen_msgs,
 };
 use deltachat::peer_channels::{
@@ -1393,7 +1393,7 @@ impl CommandApi {
         add_daymarker: bool,
     ) -> Result<Vec<u32>> {
         let ctx = self.get_context(account_id).await?;
-        let msg = get_chat_msgs_ex(
+        let msg = get_chat_msgs_ext(
             &ctx,
             ChatId::new(chat_id),
             MessageListOptions { add_daymarker },
@@ -1442,7 +1442,7 @@ impl CommandApi {
         add_daymarker: bool,
     ) -> Result<Vec<JsonrpcMessageListItem>> {
         let ctx = self.get_context(account_id).await?;
-        let msg = get_chat_msgs_ex(
+        let msg = get_chat_msgs_ext(
             &ctx,
             ChatId::new(chat_id),
             MessageListOptions { add_daymarker },
@@ -1533,7 +1533,7 @@ impl CommandApi {
     async fn delete_messages(&self, account_id: u32, message_ids: Vec<u32>) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         let msgs: Vec<MsgId> = message_ids.into_iter().map(MsgId::new).collect();
-        delete_msgs_ex(&ctx, &msgs, false).await
+        delete_msgs_ext(&ctx, &msgs, false).await
     }
 
     /// Delete messages. The messages are deleted on the current device,
@@ -1541,7 +1541,7 @@ impl CommandApi {
     async fn delete_messages_for_all(&self, account_id: u32, message_ids: Vec<u32>) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         let msgs: Vec<MsgId> = message_ids.into_iter().map(MsgId::new).collect();
-        delete_msgs_ex(&ctx, &msgs, true).await
+        delete_msgs_ext(&ctx, &msgs, true).await
     }
 
     /// Get an informational text for a single message. The text is multiline and may

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -616,7 +616,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let sel_chat = sel_chat.as_ref().unwrap();
 
             let time_start = std::time::SystemTime::now();
-            let msglist = chat::get_chat_msgs_ex(
+            let msglist = chat::get_chat_msgs_ext(
                 &context,
                 sel_chat.get_id(),
                 chat::MessageListOptions {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -361,10 +361,10 @@ impl ChatId {
 
     /// Blocks the chat as a result of explicit user action.
     pub async fn block(self, context: &Context) -> Result<()> {
-        self.block_ex(context, Sync).await
+        self.block_ext(context, Sync).await
     }
 
-    pub(crate) async fn block_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn block_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         let chat = Chat::load_from_db(context, self).await?;
         let mut delete = false;
 
@@ -403,17 +403,17 @@ impl ChatId {
                 .ok();
         }
         if delete {
-            self.delete_ex(context, Nosync).await?;
+            self.delete_ext(context, Nosync).await?;
         }
         Ok(())
     }
 
     /// Unblocks the chat.
     pub async fn unblock(self, context: &Context) -> Result<()> {
-        self.unblock_ex(context, Sync).await
+        self.unblock_ext(context, Sync).await
     }
 
-    pub(crate) async fn unblock_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn unblock_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         self.set_blocked(context, Blocked::Not).await?;
 
         chatlist_events::emit_chatlist_changed(context);
@@ -436,10 +436,10 @@ impl ChatId {
     ///
     /// Unblocks the chat and scales up origin of contacts.
     pub async fn accept(self, context: &Context) -> Result<()> {
-        self.accept_ex(context, Sync).await
+        self.accept_ext(context, Sync).await
     }
 
-    pub(crate) async fn accept_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn accept_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         let chat = Chat::load_from_db(context, self).await?;
 
         match chat.typ {
@@ -524,10 +524,10 @@ impl ChatId {
 
     /// Archives or unarchives a chat.
     pub async fn set_visibility(self, context: &Context, visibility: ChatVisibility) -> Result<()> {
-        self.set_visibility_ex(context, Sync, visibility).await
+        self.set_visibility_ext(context, Sync, visibility).await
     }
 
-    pub(crate) async fn set_visibility_ex(
+    pub(crate) async fn set_visibility_ext(
         self,
         context: &Context,
         sync: sync::Sync,
@@ -643,10 +643,10 @@ impl ChatId {
     /// After that, a `MsgsChanged` event is emitted.
     /// Messages are deleted from the server in background.
     pub async fn delete(self, context: &Context) -> Result<()> {
-        self.delete_ex(context, Sync).await
+        self.delete_ext(context, Sync).await
     }
 
-    pub(crate) async fn delete_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn delete_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         ensure!(
             !self.is_special(),
             "bad chat_id, can not be a special chat: {self}"
@@ -1465,10 +1465,10 @@ impl Chat {
     ///
     /// Otherwise returns a reason useful for logging.
     pub(crate) async fn why_cant_send(&self, context: &Context) -> Result<Option<CantSendReason>> {
-        self.why_cant_send_ex(context, &|_| false).await
+        self.why_cant_send_ext(context, &|_| false).await
     }
 
-    pub(crate) async fn why_cant_send_ex(
+    pub(crate) async fn why_cant_send_ext(
         &self,
         context: &Context,
         skip_fn: &(dyn Send + Sync + Fn(&CantSendReason) -> bool),
@@ -2700,7 +2700,7 @@ async fn prepare_send_msg(
             .unwrap_or_default(),
         _ => false,
     };
-    if let Some(reason) = chat.why_cant_send_ex(context, &skip_fn).await? {
+    if let Some(reason) = chat.why_cant_send_ext(context, &skip_fn).await? {
         bail!("Cannot send to {chat_id}: {reason}");
     }
 
@@ -3163,7 +3163,7 @@ pub struct MessageListOptions {
 
 /// Returns all messages belonging to the chat.
 pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<ChatItem>> {
-    get_chat_msgs_ex(
+    get_chat_msgs_ext(
         context,
         chat_id,
         MessageListOptions {
@@ -3176,7 +3176,7 @@ pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<Cha
 /// Returns messages belonging to the chat according to the given options,
 /// sorted by oldest message first.
 #[expect(clippy::arithmetic_side_effects)]
-pub async fn get_chat_msgs_ex(
+pub async fn get_chat_msgs_ext(
     context: &Context,
     chat_id: ChatId,
     options: MessageListOptions,
@@ -3584,12 +3584,12 @@ pub async fn get_past_chat_contacts(context: &Context, chat_id: ChatId) -> Resul
 
 /// Creates an encrypted group chat.
 pub async fn create_group(context: &Context, name: &str) -> Result<ChatId> {
-    create_group_ex(context, Sync, create_id(), name).await
+    create_group_ext(context, Sync, create_id(), name).await
 }
 
 /// Creates an unencrypted group chat.
 pub async fn create_group_unencrypted(context: &Context, name: &str) -> Result<ChatId> {
-    create_group_ex(context, Sync, String::new(), name).await
+    create_group_ext(context, Sync, String::new(), name).await
 }
 
 /// Creates a group chat.
@@ -3602,7 +3602,7 @@ pub async fn create_group_unencrypted(context: &Context, name: &str) -> Result<C
 /// NB: Unencrypted chats with similar names and the same members are merged on other devices, but
 /// usually users don't create such chats and look up the existing one instead, so chat split on the
 /// first device is acceptable.
-pub(crate) async fn create_group_ex(
+pub(crate) async fn create_group_ext(
     context: &Context,
     sync: sync::Sync,
     grpid: String,
@@ -3680,14 +3680,14 @@ pub(crate) async fn create_group_ex(
 pub async fn create_broadcast(context: &Context, chat_name: String) -> Result<ChatId> {
     let grpid = create_id();
     let secret = create_broadcast_secret();
-    create_out_broadcast_ex(context, Sync, grpid, chat_name, secret).await
+    create_out_broadcast_ext(context, Sync, grpid, chat_name, secret).await
 }
 
 const SQL_INSERT_BROADCAST_SECRET: &str =
     "INSERT INTO broadcast_secrets (chat_id, secret) VALUES (?, ?)
     ON CONFLICT(chat_id) DO UPDATE SET secret=excluded.secret";
 
-pub(crate) async fn create_out_broadcast_ex(
+pub(crate) async fn create_out_broadcast_ext(
     context: &Context,
     sync: sync::Sync,
     grpid: String,
@@ -3905,11 +3905,11 @@ pub async fn add_contact_to_chat(
     chat_id: ChatId,
     contact_id: ContactId,
 ) -> Result<()> {
-    add_contact_to_chat_ex(context, Sync, chat_id, contact_id, false).await?;
+    add_contact_to_chat_ext(context, Sync, chat_id, contact_id, false).await?;
     Ok(())
 }
 
-pub(crate) async fn add_contact_to_chat_ex(
+pub(crate) async fn add_contact_to_chat_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4020,7 +4020,7 @@ pub(crate) async fn add_contact_to_chat_ex(
     }
     if chat.typ == Chattype::OutBroadcast {
         let msgs = get_broadcast_msgs_to_resend(context, chat_id).await?;
-        resend_msgs_ex(context, &msgs, contact.fingerprint())
+        resend_msgs_ext(context, &msgs, contact.fingerprint())
             .await
             .log_err(context)
             .ok();
@@ -4154,10 +4154,10 @@ impl rusqlite::types::FromSql for MuteDuration {
 
 /// Mutes the chat for a given duration or unmutes it.
 pub async fn set_muted(context: &Context, chat_id: ChatId, duration: MuteDuration) -> Result<()> {
-    set_muted_ex(context, Sync, chat_id, duration).await
+    set_muted_ext(context, Sync, chat_id, duration).await
 }
 
-pub(crate) async fn set_muted_ex(
+pub(crate) async fn set_muted_ext(
     context: &Context,
     sync: sync::Sync,
     chat_id: ChatId,
@@ -4304,10 +4304,10 @@ pub async fn set_chat_description(
     chat_id: ChatId,
     new_description: &str,
 ) -> Result<()> {
-    set_chat_description_ex(context, Sync, chat_id, new_description).await
+    set_chat_description_ext(context, Sync, chat_id, new_description).await
 }
 
-async fn set_chat_description_ex(
+async fn set_chat_description_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4391,10 +4391,10 @@ pub async fn get_chat_description(context: &Context, chat_id: ChatId) -> Result<
 ///
 /// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.
 pub async fn set_chat_name(context: &Context, chat_id: ChatId, new_name: &str) -> Result<()> {
-    rename_ex(context, Sync, chat_id, new_name).await
+    rename_ext(context, Sync, chat_id, new_name).await
 }
 
-async fn rename_ex(
+async fn rename_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4734,14 +4734,14 @@ pub(crate) async fn save_copy_in_self_talk(
 ///
 /// This is primarily intended to make existing webxdcs available to new chat members.
 pub async fn resend_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
-    resend_msgs_ex(context, msg_ids, None).await
+    resend_msgs_ext(context, msg_ids, None).await
 }
 
 /// Resends given messages to a contact with fingerprint `to_fingerprint` or, if it's `None`, to
 /// members of the corresponding chats.
 ///
 /// `to_fingerprint` is only passed for `OutBroadcast` chats when a new member is added.
-pub(crate) async fn resend_msgs_ex(
+pub(crate) async fn resend_msgs_ext(
     context: &Context,
     msg_ids: &[MsgId],
     to_fingerprint: Option<Fingerprint>,
@@ -5167,7 +5167,7 @@ async fn set_contacts_by_fingerprints(
     );
     let mut contacts = BTreeSet::new();
     for (fingerprint, addr) in fingerprint_addrs {
-        let contact = Contact::add_or_lookup_ex(context, "", addr, fingerprint, Origin::Hidden)
+        let contact = Contact::add_or_lookup_ext(context, "", addr, fingerprint, Origin::Hidden)
             .await?
             .0;
         contacts.insert(contact);
@@ -5271,7 +5271,7 @@ impl Context {
         let chat_id = match id {
             SyncId::ContactAddr(addr) => {
                 if let SyncAction::Rename(to) = action {
-                    Contact::create_ex(self, Nosync, to, addr).await?;
+                    Contact::create_ext(self, Nosync, to, addr).await?;
                     return Ok(());
                 }
                 let addr = ContactAddress::new(addr).context("Invalid address")?;
@@ -5298,11 +5298,11 @@ impl Context {
                 let name = "";
                 let addr = "";
                 let (contact_id, _) =
-                    Contact::add_or_lookup_ex(self, name, addr, fingerprint, Origin::Hidden)
+                    Contact::add_or_lookup_ext(self, name, addr, fingerprint, Origin::Hidden)
                         .await?;
                 match action {
                     SyncAction::Rename(to) => {
-                        contact_id.set_name_ex(self, Nosync, to).await?;
+                        contact_id.set_name_ext(self, Nosync, to).await?;
                         self.emit_event(EventType::ContactsChanged(Some(contact_id)));
                         return Ok(());
                     }
@@ -5327,7 +5327,7 @@ impl Context {
             SyncId::Grpid(grpid) => {
                 match action {
                     SyncAction::CreateOutBroadcast { chat_name, secret } => {
-                        create_out_broadcast_ex(
+                        create_out_broadcast_ext(
                             self,
                             Nosync,
                             grpid.to_string(),
@@ -5338,7 +5338,7 @@ impl Context {
                         return Ok(());
                     }
                     SyncAction::CreateGroupEncrypted(name) => {
-                        create_group_ex(self, Nosync, grpid.clone(), name).await?;
+                        create_group_ext(self, Nosync, grpid.clone(), name).await?;
                         return Ok(());
                     }
                     _ => {}
@@ -5358,24 +5358,24 @@ impl Context {
             SyncId::Device => ChatId::get_for_contact(self, ContactId::DEVICE).await?,
         };
         match action {
-            SyncAction::Block => chat_id.block_ex(self, Nosync).await,
-            SyncAction::Unblock => chat_id.unblock_ex(self, Nosync).await,
-            SyncAction::Accept => chat_id.accept_ex(self, Nosync).await,
-            SyncAction::SetVisibility(v) => chat_id.set_visibility_ex(self, Nosync, *v).await,
-            SyncAction::SetMuted(duration) => set_muted_ex(self, Nosync, chat_id, *duration).await,
+            SyncAction::Block => chat_id.block_ext(self, Nosync).await,
+            SyncAction::Unblock => chat_id.unblock_ext(self, Nosync).await,
+            SyncAction::Accept => chat_id.accept_ext(self, Nosync).await,
+            SyncAction::SetVisibility(v) => chat_id.set_visibility_ext(self, Nosync, *v).await,
+            SyncAction::SetMuted(duration) => set_muted_ext(self, Nosync, chat_id, *duration).await,
             SyncAction::CreateOutBroadcast { .. } | SyncAction::CreateGroupEncrypted(..) => {
                 // Create action should have been handled above already.
                 Err(anyhow!("sync_alter_chat({id:?}, {action:?}): Bad request."))
             }
-            SyncAction::Rename(to) => rename_ex(self, Nosync, chat_id, to).await,
+            SyncAction::Rename(to) => rename_ext(self, Nosync, chat_id, to).await,
             SyncAction::SetDescription(to) => {
-                set_chat_description_ex(self, Nosync, chat_id, to).await
+                set_chat_description_ext(self, Nosync, chat_id, to).await
             }
             SyncAction::SetContacts(addrs) => set_contacts_by_addrs(self, chat_id, addrs).await,
             SyncAction::SetPgpContacts(fingerprint_addrs) => {
                 set_contacts_by_fingerprints(self, chat_id, fingerprint_addrs).await
             }
-            SyncAction::Delete => chat_id.delete_ex(self, Nosync).await,
+            SyncAction::Delete => chat_id.delete_ext(self, Nosync).await,
         }
     }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -361,10 +361,10 @@ impl ChatId {
 
     /// Blocks the chat as a result of explicit user action.
     pub async fn block(self, context: &Context) -> Result<()> {
-        self.block_ex(context, Sync).await
+        self.block_ext(context, Sync).await
     }
 
-    pub(crate) async fn block_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn block_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         let chat = Chat::load_from_db(context, self).await?;
         let mut delete = false;
 
@@ -403,17 +403,17 @@ impl ChatId {
                 .ok();
         }
         if delete {
-            self.delete_ex(context, Nosync).await?;
+            self.delete_ext(context, Nosync).await?;
         }
         Ok(())
     }
 
     /// Unblocks the chat.
     pub async fn unblock(self, context: &Context) -> Result<()> {
-        self.unblock_ex(context, Sync).await
+        self.unblock_ext(context, Sync).await
     }
 
-    pub(crate) async fn unblock_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn unblock_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         self.set_blocked(context, Blocked::Not).await?;
 
         chatlist_events::emit_chatlist_changed(context);
@@ -436,10 +436,10 @@ impl ChatId {
     ///
     /// Unblocks the chat and scales up origin of contacts.
     pub async fn accept(self, context: &Context) -> Result<()> {
-        self.accept_ex(context, Sync).await
+        self.accept_ext(context, Sync).await
     }
 
-    pub(crate) async fn accept_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn accept_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         let chat = Chat::load_from_db(context, self).await?;
 
         match chat.typ {
@@ -524,10 +524,10 @@ impl ChatId {
 
     /// Archives or unarchives a chat.
     pub async fn set_visibility(self, context: &Context, visibility: ChatVisibility) -> Result<()> {
-        self.set_visibility_ex(context, Sync, visibility).await
+        self.set_visibility_ext(context, Sync, visibility).await
     }
 
-    pub(crate) async fn set_visibility_ex(
+    pub(crate) async fn set_visibility_ext(
         self,
         context: &Context,
         sync: sync::Sync,
@@ -643,10 +643,10 @@ impl ChatId {
     /// After that, a `MsgsChanged` event is emitted.
     /// Messages are deleted from the server in background.
     pub async fn delete(self, context: &Context) -> Result<()> {
-        self.delete_ex(context, Sync).await
+        self.delete_ext(context, Sync).await
     }
 
-    pub(crate) async fn delete_ex(self, context: &Context, sync: sync::Sync) -> Result<()> {
+    pub(crate) async fn delete_ext(self, context: &Context, sync: sync::Sync) -> Result<()> {
         ensure!(
             !self.is_special(),
             "bad chat_id, can not be a special chat: {self}"
@@ -1465,10 +1465,10 @@ impl Chat {
     ///
     /// Otherwise returns a reason useful for logging.
     pub(crate) async fn why_cant_send(&self, context: &Context) -> Result<Option<CantSendReason>> {
-        self.why_cant_send_ex(context, &|_| false).await
+        self.why_cant_send_ext(context, &|_| false).await
     }
 
-    pub(crate) async fn why_cant_send_ex(
+    pub(crate) async fn why_cant_send_ext(
         &self,
         context: &Context,
         skip_fn: &(dyn Send + Sync + Fn(&CantSendReason) -> bool),
@@ -2700,7 +2700,7 @@ async fn prepare_send_msg(
             .unwrap_or_default(),
         _ => false,
     };
-    if let Some(reason) = chat.why_cant_send_ex(context, &skip_fn).await? {
+    if let Some(reason) = chat.why_cant_send_ext(context, &skip_fn).await? {
         bail!("Cannot send to {chat_id}: {reason}");
     }
 
@@ -3163,7 +3163,7 @@ pub struct MessageListOptions {
 
 /// Returns all messages belonging to the chat.
 pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<ChatItem>> {
-    get_chat_msgs_ex(
+    get_chat_msgs_ext(
         context,
         chat_id,
         MessageListOptions {
@@ -3176,7 +3176,7 @@ pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<Cha
 /// Returns messages belonging to the chat according to the given options,
 /// sorted by oldest message first.
 #[expect(clippy::arithmetic_side_effects)]
-pub async fn get_chat_msgs_ex(
+pub async fn get_chat_msgs_ext(
     context: &Context,
     chat_id: ChatId,
     options: MessageListOptions,
@@ -3584,12 +3584,12 @@ pub async fn get_past_chat_contacts(context: &Context, chat_id: ChatId) -> Resul
 
 /// Creates an encrypted group chat.
 pub async fn create_group(context: &Context, name: &str) -> Result<ChatId> {
-    create_group_ex(context, Sync, create_id(), name).await
+    create_group_ext(context, Sync, create_id(), name).await
 }
 
 /// Creates an unencrypted group chat.
 pub async fn create_group_unencrypted(context: &Context, name: &str) -> Result<ChatId> {
-    create_group_ex(context, Sync, String::new(), name).await
+    create_group_ext(context, Sync, String::new(), name).await
 }
 
 /// Creates a group chat.
@@ -3602,7 +3602,7 @@ pub async fn create_group_unencrypted(context: &Context, name: &str) -> Result<C
 /// NB: Unencrypted chats with similar names and the same members are merged on other devices, but
 /// usually users don't create such chats and look up the existing one instead, so chat split on the
 /// first device is acceptable.
-pub(crate) async fn create_group_ex(
+pub(crate) async fn create_group_ext(
     context: &Context,
     sync: sync::Sync,
     grpid: String,
@@ -3680,14 +3680,14 @@ pub(crate) async fn create_group_ex(
 pub async fn create_broadcast(context: &Context, chat_name: String) -> Result<ChatId> {
     let grpid = create_id();
     let secret = create_broadcast_secret();
-    create_out_broadcast_ex(context, Sync, grpid, chat_name, secret).await
+    create_out_broadcast_ext(context, Sync, grpid, chat_name, secret).await
 }
 
 const SQL_INSERT_BROADCAST_SECRET: &str =
     "INSERT INTO broadcast_secrets (chat_id, secret) VALUES (?, ?)
     ON CONFLICT(chat_id) DO UPDATE SET secret=excluded.secret";
 
-pub(crate) async fn create_out_broadcast_ex(
+pub(crate) async fn create_out_broadcast_ext(
     context: &Context,
     sync: sync::Sync,
     grpid: String,
@@ -3905,11 +3905,11 @@ pub async fn add_contact_to_chat(
     chat_id: ChatId,
     contact_id: ContactId,
 ) -> Result<()> {
-    add_contact_to_chat_ex(context, Sync, chat_id, contact_id, false).await?;
+    add_contact_to_chat_ext(context, Sync, chat_id, contact_id, false).await?;
     Ok(())
 }
 
-pub(crate) async fn add_contact_to_chat_ex(
+pub(crate) async fn add_contact_to_chat_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4056,7 +4056,7 @@ ORDER BY timestamp DESC, id DESC LIMIT ?",
         .into_iter()
         .rev()
         .collect();
-    resend_msgs_ex(context, &msgs, to_contact.fingerprint()).await
+    resend_msgs_ext(context, &msgs, to_contact.fingerprint()).await
 }
 
 /// Returns true if an avatar should be attached in the given chat.
@@ -4144,10 +4144,10 @@ impl rusqlite::types::FromSql for MuteDuration {
 
 /// Mutes the chat for a given duration or unmutes it.
 pub async fn set_muted(context: &Context, chat_id: ChatId, duration: MuteDuration) -> Result<()> {
-    set_muted_ex(context, Sync, chat_id, duration).await
+    set_muted_ext(context, Sync, chat_id, duration).await
 }
 
-pub(crate) async fn set_muted_ex(
+pub(crate) async fn set_muted_ext(
     context: &Context,
     sync: sync::Sync,
     chat_id: ChatId,
@@ -4298,10 +4298,10 @@ pub async fn set_chat_description(
     chat_id: ChatId,
     new_description: &str,
 ) -> Result<()> {
-    set_chat_description_ex(context, Sync, chat_id, new_description).await
+    set_chat_description_ext(context, Sync, chat_id, new_description).await
 }
 
-async fn set_chat_description_ex(
+async fn set_chat_description_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4385,10 +4385,10 @@ pub async fn get_chat_description(context: &Context, chat_id: ChatId) -> Result<
 ///
 /// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.
 pub async fn set_chat_name(context: &Context, chat_id: ChatId, new_name: &str) -> Result<()> {
-    rename_ex(context, Sync, chat_id, new_name).await
+    rename_ext(context, Sync, chat_id, new_name).await
 }
 
-async fn rename_ex(
+async fn rename_ext(
     context: &Context,
     mut sync: sync::Sync,
     chat_id: ChatId,
@@ -4727,7 +4727,7 @@ pub(crate) async fn save_copy_in_self_talk(
 ///
 /// This is primarily intended to make existing webxdcs available to new chat members.
 pub async fn resend_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
-    resend_msgs_ex(context, msg_ids, None).await
+    resend_msgs_ext(context, msg_ids, None).await
 }
 
 /// Resends given messages to a contact with fingerprint `to_fingerprint` or, if it's `None`, to
@@ -4737,7 +4737,7 @@ pub async fn resend_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
 /// added. Regarding webxdcs: It is not trivial to resend only the own status updates,
 /// and it is not trivial to resend them only to the newly-joined member,
 /// so that for now, [`resend_last_msgs`] does not automatically resend webxdcs at all.
-pub(crate) async fn resend_msgs_ex(
+pub(crate) async fn resend_msgs_ext(
     context: &Context,
     msg_ids: &[MsgId],
     to_fingerprint: Option<Fingerprint>,
@@ -5163,7 +5163,7 @@ async fn set_contacts_by_fingerprints(
     );
     let mut contacts = BTreeSet::new();
     for (fingerprint, addr) in fingerprint_addrs {
-        let contact = Contact::add_or_lookup_ex(context, "", addr, fingerprint, Origin::Hidden)
+        let contact = Contact::add_or_lookup_ext(context, "", addr, fingerprint, Origin::Hidden)
             .await?
             .0;
         contacts.insert(contact);
@@ -5267,7 +5267,7 @@ impl Context {
         let chat_id = match id {
             SyncId::ContactAddr(addr) => {
                 if let SyncAction::Rename(to) = action {
-                    Contact::create_ex(self, Nosync, to, addr).await?;
+                    Contact::create_ext(self, Nosync, to, addr).await?;
                     return Ok(());
                 }
                 let addr = ContactAddress::new(addr).context("Invalid address")?;
@@ -5294,11 +5294,11 @@ impl Context {
                 let name = "";
                 let addr = "";
                 let (contact_id, _) =
-                    Contact::add_or_lookup_ex(self, name, addr, fingerprint, Origin::Hidden)
+                    Contact::add_or_lookup_ext(self, name, addr, fingerprint, Origin::Hidden)
                         .await?;
                 match action {
                     SyncAction::Rename(to) => {
-                        contact_id.set_name_ex(self, Nosync, to).await?;
+                        contact_id.set_name_ext(self, Nosync, to).await?;
                         self.emit_event(EventType::ContactsChanged(Some(contact_id)));
                         return Ok(());
                     }
@@ -5323,7 +5323,7 @@ impl Context {
             SyncId::Grpid(grpid) => {
                 match action {
                     SyncAction::CreateOutBroadcast { chat_name, secret } => {
-                        create_out_broadcast_ex(
+                        create_out_broadcast_ext(
                             self,
                             Nosync,
                             grpid.to_string(),
@@ -5334,7 +5334,7 @@ impl Context {
                         return Ok(());
                     }
                     SyncAction::CreateGroupEncrypted(name) => {
-                        create_group_ex(self, Nosync, grpid.clone(), name).await?;
+                        create_group_ext(self, Nosync, grpid.clone(), name).await?;
                         return Ok(());
                     }
                     _ => {}
@@ -5354,24 +5354,24 @@ impl Context {
             SyncId::Device => ChatId::get_for_contact(self, ContactId::DEVICE).await?,
         };
         match action {
-            SyncAction::Block => chat_id.block_ex(self, Nosync).await,
-            SyncAction::Unblock => chat_id.unblock_ex(self, Nosync).await,
-            SyncAction::Accept => chat_id.accept_ex(self, Nosync).await,
-            SyncAction::SetVisibility(v) => chat_id.set_visibility_ex(self, Nosync, *v).await,
-            SyncAction::SetMuted(duration) => set_muted_ex(self, Nosync, chat_id, *duration).await,
+            SyncAction::Block => chat_id.block_ext(self, Nosync).await,
+            SyncAction::Unblock => chat_id.unblock_ext(self, Nosync).await,
+            SyncAction::Accept => chat_id.accept_ext(self, Nosync).await,
+            SyncAction::SetVisibility(v) => chat_id.set_visibility_ext(self, Nosync, *v).await,
+            SyncAction::SetMuted(duration) => set_muted_ext(self, Nosync, chat_id, *duration).await,
             SyncAction::CreateOutBroadcast { .. } | SyncAction::CreateGroupEncrypted(..) => {
                 // Create action should have been handled above already.
                 Err(anyhow!("sync_alter_chat({id:?}, {action:?}): Bad request."))
             }
-            SyncAction::Rename(to) => rename_ex(self, Nosync, chat_id, to).await,
+            SyncAction::Rename(to) => rename_ext(self, Nosync, chat_id, to).await,
             SyncAction::SetDescription(to) => {
-                set_chat_description_ex(self, Nosync, chat_id, to).await
+                set_chat_description_ext(self, Nosync, chat_id, to).await
             }
             SyncAction::SetContacts(addrs) => set_contacts_by_addrs(self, chat_id, addrs).await,
             SyncAction::SetPgpContacts(fingerprint_addrs) => {
                 set_contacts_by_fingerprints(self, chat_id, fingerprint_addrs).await
             }
-            SyncAction::Delete => chat_id.delete_ex(self, Nosync).await,
+            SyncAction::Delete => chat_id.delete_ext(self, Nosync).await,
         }
     }
 

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -305,7 +305,7 @@ async fn test_add_contact_to_chat_ex_add_self() {
     // Adding self to a contact should succeed, even though it's pointless.
     let t = TestContext::new_alice().await;
     let chat_id = create_group(&t, "foo").await.unwrap();
-    let added = add_contact_to_chat_ex(&t, Nosync, chat_id, ContactId::SELF, false)
+    let added = add_contact_to_chat_ext(&t, Nosync, chat_id, ContactId::SELF, false)
         .await
         .unwrap();
     assert_eq!(added, false);
@@ -788,7 +788,7 @@ async fn test_add_remove_contact_for_single() {
 
     // adding or removing contacts from single chats result in an error
     let claire = Contact::create(&ctx, "", "claire@foo.de").await.unwrap();
-    let added = add_contact_to_chat_ex(&ctx, Nosync, chat.id, claire, false).await;
+    let added = add_contact_to_chat_ext(&ctx, Nosync, chat.id, claire, false).await;
     assert!(added.is_err());
     assert_eq!(get_chat_contacts(&ctx, chat.id).await.unwrap().len(), 1);
 
@@ -3105,7 +3105,7 @@ async fn test_broadcast_resend_to_new_member() -> Result<()> {
     }
     for i in 0..N_MSGS_TO_NEW_BROADCAST_MEMBER {
         let rev_order = false;
-        let resent_msg = alice.pop_sent_msg_ex(rev_order).await.unwrap();
+        let resent_msg = alice.pop_sent_msg_ext(rev_order).await.unwrap();
         let fiona_msg = fiona.recv_msg(&resent_msg).await;
         assert_eq!(fiona_msg.chat_id, fiona_bc_id);
         assert_eq!(fiona_msg.text, (i + 1).to_string());
@@ -4193,7 +4193,7 @@ async fn test_encrypt_decrypt_broadcast() -> Result<()> {
     let bob_alice_contact_id = bob.add_or_lookup_contact_id(alice).await;
 
     tcm.section("Create a broadcast channel with Bob, and send a message");
-    let alice_chat_id = create_out_broadcast_ex(
+    let alice_chat_id = create_out_broadcast_ext(
         alice,
         Sync,
         "My Channel".to_string(),
@@ -6068,7 +6068,7 @@ async fn test_send_delete_request() -> Result<()> {
     let alice_msg = sent1.load_from_db().await;
     assert_eq!(alice_chat.id.get_msg_cnt(alice).await?, E2EE_INFO_MSGS + 2);
 
-    message::delete_msgs_ex(alice, &[alice_msg.id], true).await?;
+    message::delete_msgs_ext(alice, &[alice_msg.id], true).await?;
     let sent2 = alice.pop_sent_msg().await;
     assert_eq!(alice_chat.id.get_msg_cnt(alice).await?, E2EE_INFO_MSGS + 1);
 
@@ -6114,7 +6114,7 @@ async fn test_send_delete_request_no_encryption() -> Result<()> {
     // Alice sends a message, then tries to send a deletion request which fails.
     let sent1 = alice.send_text(alice_chat.id, "wtf").await;
     assert!(
-        message::delete_msgs_ex(alice, &[sent1.sender_msg_id], true)
+        message::delete_msgs_ext(alice, &[sent1.sender_msg_id], true)
             .await
             .is_err()
     );

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -306,7 +306,7 @@ async fn test_add_contact_to_chat_ex_add_self() {
     // Adding self to a contact should succeed, even though it's pointless.
     let t = TestContext::new_alice().await;
     let chat_id = create_group(&t, "foo").await.unwrap();
-    let added = add_contact_to_chat_ex(&t, Nosync, chat_id, ContactId::SELF, false)
+    let added = add_contact_to_chat_ext(&t, Nosync, chat_id, ContactId::SELF, false)
         .await
         .unwrap();
     assert_eq!(added, false);
@@ -791,7 +791,7 @@ async fn test_add_remove_contact_for_single() {
 
     // adding or removing contacts from single chats result in an error
     let claire = Contact::create(&ctx, "", "claire@foo.de").await.unwrap();
-    let added = add_contact_to_chat_ex(&ctx, Nosync, chat.id, claire, false).await;
+    let added = add_contact_to_chat_ext(&ctx, Nosync, chat.id, claire, false).await;
     assert!(added.is_err());
     assert_eq!(get_chat_contacts(&ctx, chat.id).await.unwrap().len(), 1);
 
@@ -3191,7 +3191,7 @@ async fn test_broadcast_resend_to_new_member() -> Result<()> {
     }
     for i in 0..N_MSGS_TO_NEW_BROADCAST_MEMBER {
         let rev_order = false;
-        let resent_msg = alice.pop_sent_msg_ex(rev_order).await.unwrap();
+        let resent_msg = alice.pop_sent_msg_ext(rev_order).await.unwrap();
         let fiona_msg = fiona.recv_msg(&resent_msg).await;
         assert_eq!(fiona_msg.chat_id, fiona_bc_id);
         assert_eq!(fiona_msg.text, (i + 1).to_string());
@@ -4291,7 +4291,7 @@ async fn test_encrypt_decrypt_broadcast() -> Result<()> {
     let bob_alice_contact_id = bob.add_or_lookup_contact_id(alice).await;
 
     tcm.section("Create a broadcast channel with Bob, and send a message");
-    let alice_chat_id = create_out_broadcast_ex(
+    let alice_chat_id = create_out_broadcast_ext(
         alice,
         Sync,
         "My Channel".to_string(),
@@ -6187,7 +6187,7 @@ async fn test_send_delete_request() -> Result<()> {
     let alice_msg = sent1.load_from_db().await;
     assert_eq!(alice_chat.id.get_msg_cnt(alice).await?, E2EE_INFO_MSGS + 2);
 
-    message::delete_msgs_ex(alice, &[alice_msg.id], true).await?;
+    message::delete_msgs_ext(alice, &[alice_msg.id], true).await?;
     let sent2 = alice.pop_sent_msg().await;
     assert_eq!(alice_chat.id.get_msg_cnt(alice).await?, E2EE_INFO_MSGS + 1);
 
@@ -6234,7 +6234,7 @@ async fn test_send_delete_request_no_encryption() -> Result<()> {
     // Alice sends a message, then tries to send a deletion request which fails.
     let sent1 = alice.send_text(alice_chat.id, "wtf").await;
     assert!(
-        message::delete_msgs_ex(alice, &[sent1.sender_msg_id], true)
+        message::delete_msgs_ext(alice, &[sent1.sender_msg_id], true)
             .await
             .is_err()
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -650,7 +650,7 @@ impl Context {
             _ => Some(value),
         };
         match key.is_synced() {
-            true => self.set_config_ex(Nosync, *key, value).await,
+            true => self.set_config_ext(Nosync, *key, value).await,
             false => Ok(()),
         }
     }
@@ -700,10 +700,10 @@ impl Context {
     }
 
     pub(crate) async fn set_config_internal(&self, key: Config, value: Option<&str>) -> Result<()> {
-        self.set_config_ex(Sync, key, value).await
+        self.set_config_ext(Sync, key, value).await
     }
 
-    pub(crate) async fn set_config_ex(
+    pub(crate) async fn set_config_ext(
         &self,
         sync: sync::Sync,
         key: Config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -645,7 +645,7 @@ impl Context {
             _ => Some(value),
         };
         match key.is_synced() {
-            true => self.set_config_ex(Nosync, *key, value).await,
+            true => self.set_config_ext(Nosync, *key, value).await,
             false => Ok(()),
         }
     }
@@ -695,10 +695,10 @@ impl Context {
     }
 
     pub(crate) async fn set_config_internal(&self, key: Config, value: Option<&str>) -> Result<()> {
-        self.set_config_ex(Sync, key, value).await
+        self.set_config_ext(Sync, key, value).await
     }
 
-    pub(crate) async fn set_config_ex(
+    pub(crate) async fn set_config_ext(
         &self,
         sync: sync::Sync,
         key: Config,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -339,7 +339,7 @@ impl Context {
         if provider::legacy_settings_for_addr(&param.addr)?.worse_media_quality
             && !self.config_exists(Config::MediaQuality).await?
         {
-            self.set_config_ex(Nosync, Config::MediaQuality, Some("1"))
+            self.set_config_ext(Nosync, Config::MediaQuality, Some("1"))
                 .await?;
         }
         Ok(())

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -104,10 +104,10 @@ impl ContactId {
     /// for this contact will switch to the
     /// contact's authorized name.
     pub async fn set_name(self, context: &Context, name: &str) -> Result<()> {
-        self.set_name_ex(context, Sync, name).await
+        self.set_name_ext(context, Sync, name).await
     }
 
-    pub(crate) async fn set_name_ex(
+    pub(crate) async fn set_name_ext(
         self,
         context: &Context,
         sync: sync::Sync,
@@ -285,7 +285,7 @@ pub async fn make_vcard(context: &Context, contacts: &[ContactId]) -> Result<Str
     for id in contacts {
         let c = Contact::get_by_id(context, *id).await?;
         let key = c.public_key(context).await?.map(|k| k.to_base64());
-        let profile_image = match c.get_profile_image_ex(context, false).await? {
+        let profile_image = match c.get_profile_image_ext(context, false).await? {
             None => None,
             Some(path) => tokio::fs::read(path)
                 .await
@@ -424,7 +424,7 @@ async fn import_vcard_contact(context: &Context, contact: &VcardContact) -> Resu
     };
 
     let (id, modified) =
-        match Contact::add_or_lookup_ex(context, &contact.authname, &addr, &fingerprint, origin)
+        match Contact::add_or_lookup_ext(context, &contact.authname, &addr, &fingerprint, origin)
             .await
         {
             Err(e) => return Err(e).context("Contact::add_or_lookup() failed"),
@@ -763,10 +763,10 @@ impl Contact {
     ///
     /// May result in a `#DC_EVENT_CONTACTS_CHANGED` event.
     pub async fn create(context: &Context, name: &str, addr: &str) -> Result<ContactId> {
-        Self::create_ex(context, Sync, name, addr).await
+        Self::create_ext(context, Sync, name, addr).await
     }
 
-    pub(crate) async fn create_ex(
+    pub(crate) async fn create_ext(
         context: &Context,
         sync: sync::Sync,
         name: &str,
@@ -846,12 +846,12 @@ impl Contact {
         addr: &str,
         min_origin: Origin,
     ) -> Result<Option<ContactId>> {
-        Self::lookup_id_by_addr_ex(context, addr, min_origin, Some(Blocked::Not)).await
+        Self::lookup_id_by_addr_ext(context, addr, min_origin, Some(Blocked::Not)).await
     }
 
     /// The same as `lookup_id_by_addr()`, but internal function. Currently also allows looking up
     /// not unblocked contacts.
-    pub(crate) async fn lookup_id_by_addr_ex(
+    pub(crate) async fn lookup_id_by_addr_ext(
         context: &Context,
         addr: &str,
         min_origin: Origin,
@@ -906,7 +906,7 @@ impl Contact {
         addr: &ContactAddress,
         origin: Origin,
     ) -> Result<(ContactId, Modifier)> {
-        Self::add_or_lookup_ex(context, name, addr, "", origin).await
+        Self::add_or_lookup_ext(context, name, addr, "", origin).await
     }
 
     /// Lookup a contact and create it if it does not exist yet.
@@ -936,7 +936,7 @@ impl Contact {
     ///   Depending on the origin, both, "row_name" and "row_authname" are updated from "name".
     ///
     /// Returns the contact_id and a `Modifier` value indicating if a modification occurred.
-    pub(crate) async fn add_or_lookup_ex(
+    pub(crate) async fn add_or_lookup_ext(
         context: &Context,
         name: &str,
         addr: &str,
@@ -1620,13 +1620,13 @@ WHERE addr=?
     /// This is the image set by each remote user on their own
     /// using set_config(context, "selfavatar", image).
     pub async fn get_profile_image(&self, context: &Context) -> Result<Option<PathBuf>> {
-        self.get_profile_image_ex(context, true).await
+        self.get_profile_image_ext(context, true).await
     }
 
     /// Get the contact's profile image.
     /// This is the image set by each remote user on their own
     /// using set_config(context, "selfavatar", image).
-    async fn get_profile_image_ex(
+    async fn get_profile_image_ext(
         &self,
         context: &Context,
         show_fallback_icon: bool,
@@ -1878,7 +1878,7 @@ WHERE type=? AND id IN (
             && contact.origin == Origin::MailinglistAddress
             && let Some((chat_id, ..)) = chat::get_chat_id_by_grpid(context, &contact.addr).await?
         {
-            chat_id.unblock_ex(context, Nosync).await?;
+            chat_id.unblock_ext(context, Nosync).await?;
         }
 
         if sync.into() {
@@ -1919,7 +1919,7 @@ pub(crate) async fn set_profile_image(
         AvatarAction::Change(profile_image) => {
             if contact_id == ContactId::SELF {
                 context
-                    .set_config_ex(Nosync, Config::Selfavatar, Some(profile_image))
+                    .set_config_ext(Nosync, Config::Selfavatar, Some(profile_image))
                     .await?;
             } else {
                 contact.param.set(Param::ProfileImage, profile_image);
@@ -1929,7 +1929,7 @@ pub(crate) async fn set_profile_image(
         AvatarAction::Delete => {
             if contact_id == ContactId::SELF {
                 context
-                    .set_config_ex(Nosync, Config::Selfavatar, None)
+                    .set_config_ext(Nosync, Config::Selfavatar, None)
                     .await?;
             } else {
                 contact.param.remove(Param::ProfileImage);
@@ -1955,7 +1955,7 @@ pub(crate) async fn set_status(
 ) -> Result<()> {
     if contact_id == ContactId::SELF {
         context
-            .set_config_ex(Nosync, Config::Selfstatus, Some(&status))
+            .set_config_ext(Nosync, Config::Selfstatus, Some(&status))
             .await?;
     } else {
         let mut contact = Contact::get_by_id(context, contact_id).await?;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -104,10 +104,10 @@ impl ContactId {
     /// for this contact will switch to the
     /// contact's authorized name.
     pub async fn set_name(self, context: &Context, name: &str) -> Result<()> {
-        self.set_name_ex(context, Sync, name).await
+        self.set_name_ext(context, Sync, name).await
     }
 
-    pub(crate) async fn set_name_ex(
+    pub(crate) async fn set_name_ext(
         self,
         context: &Context,
         sync: sync::Sync,
@@ -285,7 +285,7 @@ pub async fn make_vcard(context: &Context, contacts: &[ContactId]) -> Result<Str
     for id in contacts {
         let c = Contact::get_by_id(context, *id).await?;
         let key = c.public_key(context).await?.map(|k| k.to_base64());
-        let profile_image = match c.get_profile_image_ex(context, false).await? {
+        let profile_image = match c.get_profile_image_ext(context, false).await? {
             None => None,
             Some(path) => tokio::fs::read(path)
                 .await
@@ -424,7 +424,7 @@ async fn import_vcard_contact(context: &Context, contact: &VcardContact) -> Resu
     };
 
     let (id, modified) =
-        match Contact::add_or_lookup_ex(context, &contact.authname, &addr, &fingerprint, origin)
+        match Contact::add_or_lookup_ext(context, &contact.authname, &addr, &fingerprint, origin)
             .await
         {
             Err(e) => return Err(e).context("Contact::add_or_lookup() failed"),
@@ -763,10 +763,10 @@ impl Contact {
     ///
     /// May result in a `#DC_EVENT_CONTACTS_CHANGED` event.
     pub async fn create(context: &Context, name: &str, addr: &str) -> Result<ContactId> {
-        Self::create_ex(context, Sync, name, addr).await
+        Self::create_ext(context, Sync, name, addr).await
     }
 
-    pub(crate) async fn create_ex(
+    pub(crate) async fn create_ext(
         context: &Context,
         sync: sync::Sync,
         name: &str,
@@ -846,12 +846,12 @@ impl Contact {
         addr: &str,
         min_origin: Origin,
     ) -> Result<Option<ContactId>> {
-        Self::lookup_id_by_addr_ex(context, addr, min_origin, Some(Blocked::Not)).await
+        Self::lookup_id_by_addr_ext(context, addr, min_origin, Some(Blocked::Not)).await
     }
 
     /// The same as `lookup_id_by_addr()`, but internal function. Currently also allows looking up
     /// not unblocked contacts.
-    pub(crate) async fn lookup_id_by_addr_ex(
+    pub(crate) async fn lookup_id_by_addr_ext(
         context: &Context,
         addr: &str,
         min_origin: Origin,
@@ -906,7 +906,7 @@ impl Contact {
         addr: &ContactAddress,
         origin: Origin,
     ) -> Result<(ContactId, Modifier)> {
-        Self::add_or_lookup_ex(context, name, addr, "", origin).await
+        Self::add_or_lookup_ext(context, name, addr, "", origin).await
     }
 
     /// Lookup a contact and create it if it does not exist yet.
@@ -936,7 +936,7 @@ impl Contact {
     ///   Depending on the origin, both, "row_name" and "row_authname" are updated from "name".
     ///
     /// Returns the contact_id and a `Modifier` value indicating if a modification occurred.
-    pub(crate) async fn add_or_lookup_ex(
+    pub(crate) async fn add_or_lookup_ext(
         context: &Context,
         name: &str,
         addr: &str,
@@ -1620,13 +1620,13 @@ WHERE addr=?
     /// This is the image set by each remote user on their own
     /// using set_config(context, "selfavatar", image).
     pub async fn get_profile_image(&self, context: &Context) -> Result<Option<PathBuf>> {
-        self.get_profile_image_ex(context, true).await
+        self.get_profile_image_ext(context, true).await
     }
 
     /// Get the contact's profile image.
     /// This is the image set by each remote user on their own
     /// using set_config(context, "selfavatar", image).
-    async fn get_profile_image_ex(
+    async fn get_profile_image_ext(
         &self,
         context: &Context,
         show_fallback_icon: bool,
@@ -1880,7 +1880,7 @@ WHERE type=? AND id IN (
             && contact.origin == Origin::MailinglistAddress
             && let Some((chat_id, ..)) = chat::get_chat_id_by_grpid(context, &contact.addr).await?
         {
-            chat_id.unblock_ex(context, Nosync).await?;
+            chat_id.unblock_ext(context, Nosync).await?;
         }
 
         if sync.into() {
@@ -1921,7 +1921,7 @@ pub(crate) async fn set_profile_image(
         AvatarAction::Change(profile_image) => {
             if contact_id == ContactId::SELF {
                 context
-                    .set_config_ex(Nosync, Config::Selfavatar, Some(profile_image))
+                    .set_config_ext(Nosync, Config::Selfavatar, Some(profile_image))
                     .await?;
             } else {
                 contact.param.set(Param::ProfileImage, profile_image);
@@ -1931,7 +1931,7 @@ pub(crate) async fn set_profile_image(
         AvatarAction::Delete => {
             if contact_id == ContactId::SELF {
                 context
-                    .set_config_ex(Nosync, Config::Selfavatar, None)
+                    .set_config_ext(Nosync, Config::Selfavatar, None)
                     .await?;
             } else {
                 contact.param.remove(Param::ProfileImage);
@@ -1957,7 +1957,7 @@ pub(crate) async fn set_status(
 ) -> Result<()> {
     if contact_id == ContactId::SELF {
         context
-            .set_config_ex(Nosync, Config::Selfstatus, Some(&status))
+            .set_config_ext(Nosync, Config::Selfstatus, Some(&status))
             .await?;
     } else {
         let mut contact = Contact::get_by_id(context, contact_id).await?;

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -1098,7 +1098,7 @@ async fn test_was_seen_recently_event() -> Result<()> {
     Ok(())
 }
 
-async fn test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat: bool) -> Result<()> {
+async fn test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let bob = &tcm.bob().await;
     bob.allow_unencrypted().await?;
@@ -1134,13 +1134,13 @@ Hi"#
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_lookup_id_by_addr_recent() -> Result<()> {
     let accept_unencrypted_chat = true;
-    test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat).await
+    test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_lookup_id_by_addr_recent_accepted() -> Result<()> {
     let accept_unencrypted_chat = false;
-    test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat).await
+    test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -1104,7 +1104,7 @@ async fn test_was_seen_recently_event() -> Result<()> {
     Ok(())
 }
 
-async fn test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat: bool) -> Result<()> {
+async fn test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let bob = &tcm.bob().await;
     bob.allow_unencrypted().await?;
@@ -1140,13 +1140,13 @@ Hi"#
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_lookup_id_by_addr_recent() -> Result<()> {
     let accept_unencrypted_chat = true;
-    test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat).await
+    test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_lookup_id_by_addr_recent_accepted() -> Result<()> {
     let accept_unencrypted_chat = false;
-    test_lookup_id_by_addr_recent_ex(accept_unencrypted_chat).await
+    test_lookup_id_by_addr_recent_ext(accept_unencrypted_chat).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -612,7 +612,7 @@ impl Imap {
             // so the messages will be detected as new
             // in the `INBOX.DeltaChat` folder again.
             let delete = if let Some(message_id) = &message_id {
-                message::rfc724_mid_exists_ex(context, message_id, "deleted=1")
+                message::rfc724_mid_exists_ext(context, message_id, "deleted=1")
                     .await?
                     .is_some_and(|(_msg_id, deleted)| deleted)
             } else {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -608,7 +608,7 @@ impl Imap {
             // so the messages will be detected as new
             // in the `INBOX.DeltaChat` folder again.
             let delete = if let Some(message_id) = &message_id {
-                message::rfc724_mid_exists_ex(context, message_id, "deleted=1")
+                message::rfc724_mid_exists_ext(context, message_id, "deleted=1")
                     .await?
                     .is_some_and(|(_msg_id, deleted)| deleted)
             } else {

--- a/src/location.rs
+++ b/src/location.rs
@@ -1123,7 +1123,7 @@ Content-Disposition: attachment; filename="location.kml"
         bob.evtracker.clear_events();
         bob.recv_msg_opt(&alice.pop_sent_msg().await).await;
         bob.evtracker
-            .get_matching_ex(
+            .get_matching_ext(
                 bob,
                 ExpectedEvents {
                     expected: |e| matches!(e, EventType::MsgsChanged { .. }),

--- a/src/message.rs
+++ b/src/message.rs
@@ -126,7 +126,7 @@ impl MsgId {
             .sql
             .execute(
                 // If you change which information is preserved here, also change
-                // `ChatId::delete_ex()`, `delete_expired_messages()` and which information
+                // `ChatId::delete_ext()`, `delete_expired_messages()` and which information
                 // `receive_imf::add_parts()` still adds to the db if chat_id is TRASH.
                 "
 INSERT OR REPLACE INTO msgs (id, rfc724_mid, pre_rfc724_mid, timestamp, chat_id, deleted)
@@ -1667,13 +1667,13 @@ pub(crate) async fn delete_msgs_locally_done(
 
 /// Delete messages on all devices and on IMAP.
 pub async fn delete_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
-    delete_msgs_ex(context, msg_ids, false).await
+    delete_msgs_ext(context, msg_ids, false).await
 }
 
 /// Delete messages on all devices, on IMAP and optionally for all chat members.
 /// Deleted messages are moved to the trash chat and scheduling for deletion on IMAP.
 /// When deleting messages for others, all messages must be self-sent and in the same chat.
-pub async fn delete_msgs_ex(
+pub async fn delete_msgs_ext(
     context: &Context,
     msg_ids: &[MsgId],
     delete_for_all: bool,
@@ -1931,7 +1931,7 @@ pub async fn get_existing_msg_ids(context: &Context, ids: &[MsgId]) -> Result<Ve
     let query_only = true;
     let res = context
         .sql
-        .transaction_ex(query_only, |transaction| {
+        .transaction_ext(query_only, |transaction| {
             let mut res: Vec<MsgId> = Vec::new();
             for id in ids {
                 if transaction.query_one(
@@ -2115,12 +2115,12 @@ pub async fn estimate_deletion_cnt(
     Ok(cnt)
 }
 
-/// See [`rfc724_mid_exists_ex()`].
+/// See [`rfc724_mid_exists_ext()`].
 pub(crate) async fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
 ) -> Result<Option<MsgId>> {
-    Ok(rfc724_mid_exists_ex(context, rfc724_mid, "1")
+    Ok(rfc724_mid_exists_ext(context, rfc724_mid, "1")
         .await?
         .map(|(id, _)| id))
 }
@@ -2130,7 +2130,7 @@ pub(crate) async fn rfc724_mid_exists(
 ///
 /// * `expr`: SQL expression additionally passed into `SELECT`. Evaluated to `true` iff it is true
 ///   for all messages with the given `rfc724_mid`.
-pub(crate) async fn rfc724_mid_exists_ex(
+pub(crate) async fn rfc724_mid_exists_ext(
     context: &Context,
     rfc724_mid: &str,
     expr: &str,

--- a/src/message.rs
+++ b/src/message.rs
@@ -126,7 +126,7 @@ impl MsgId {
             .sql
             .execute(
                 // If you change which information is preserved here, also change
-                // `ChatId::delete_ex()`, `delete_expired_messages()` and which information
+                // `ChatId::delete_ext()`, `delete_expired_messages()` and which information
                 // `receive_imf::add_parts()` still adds to the db if chat_id is TRASH.
                 "
 INSERT OR REPLACE INTO msgs (id, rfc724_mid, pre_rfc724_mid, timestamp, chat_id, deleted)
@@ -1683,13 +1683,13 @@ pub(crate) async fn delete_msgs_locally_done(
 
 /// Delete messages on all devices and on IMAP.
 pub async fn delete_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
-    delete_msgs_ex(context, msg_ids, false).await
+    delete_msgs_ext(context, msg_ids, false).await
 }
 
 /// Delete messages on all devices, on IMAP and optionally for all chat members.
 /// Deleted messages are moved to the trash chat and scheduling for deletion on IMAP.
 /// When deleting messages for others, all messages must be self-sent and in the same chat.
-pub async fn delete_msgs_ex(
+pub async fn delete_msgs_ext(
     context: &Context,
     msg_ids: &[MsgId],
     delete_for_all: bool,
@@ -1947,7 +1947,7 @@ pub async fn get_existing_msg_ids(context: &Context, ids: &[MsgId]) -> Result<Ve
     let query_only = true;
     let res = context
         .sql
-        .transaction_ex(query_only, |transaction| {
+        .transaction_ext(query_only, |transaction| {
             let mut res: Vec<MsgId> = Vec::new();
             for id in ids {
                 if transaction.query_one(
@@ -2131,12 +2131,12 @@ pub async fn estimate_deletion_cnt(
     Ok(cnt)
 }
 
-/// See [`rfc724_mid_exists_ex()`].
+/// See [`rfc724_mid_exists_ext()`].
 pub(crate) async fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
 ) -> Result<Option<MsgId>> {
-    Ok(rfc724_mid_exists_ex(context, rfc724_mid, "1")
+    Ok(rfc724_mid_exists_ext(context, rfc724_mid, "1")
         .await?
         .map(|(id, _)| id))
 }
@@ -2146,7 +2146,7 @@ pub(crate) async fn rfc724_mid_exists(
 ///
 /// * `expr`: SQL expression additionally passed into `SELECT`. Evaluated to `true` iff it is true
 ///   for all messages with the given `rfc724_mid`.
-pub(crate) async fn rfc724_mid_exists_ex(
+pub(crate) async fn rfc724_mid_exists_ext(
     context: &Context,
     rfc724_mid: &str,
     expr: &str,

--- a/src/message/message_tests.rs
+++ b/src/message/message_tests.rs
@@ -350,16 +350,16 @@ async fn test_msg_seen_on_imap_when_downloaded() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_pre_and_post_msgs_deleted() -> Result<()> {
     let reorder = false;
-    test_pre_and_post_msgs_deleted_ex(reorder).await
+    test_pre_and_post_msgs_deleted_ext(reorder).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_reordered_pre_and_post_msgs_deleted() -> Result<()> {
     let reorder = true;
-    test_pre_and_post_msgs_deleted_ex(reorder).await
+    test_pre_and_post_msgs_deleted_ext(reorder).await
 }
 
-async fn test_pre_and_post_msgs_deleted_ex(reorder: bool) -> Result<()> {
+async fn test_pre_and_post_msgs_deleted_ext(reorder: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -763,7 +763,7 @@ impl MimeFactory {
             {
                 let origin = match recipient_ids.len() {
                     1 => Origin::OutgoingTo,
-                    // Use the same origin as ChatId::accept_ex() does for groups.
+                    // Use the same origin as ChatId::accept_ext() does for groups.
                     _ => Origin::IncomingTo,
                 };
                 info!(

--- a/src/mimeparser/shared_secret_decryption_tests.rs
+++ b/src/mimeparser/shared_secret_decryption_tests.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 ///
 /// To defeat this, a message that was unexpectedly
 /// encrypted with a symmetric secret must be dropped.
-async fn test_shared_secret_decryption_ex(
+async fn test_shared_secret_decryption_ext(
     recipient_ctx: &TestContext,
     from_addr: &str,
     secret_for_encryption: &str,
@@ -134,7 +134,7 @@ async fn test_broadcast_security_attacker_signature() -> Result<()> {
 
     let charlie_addr = charlie.get_config(Config::Addr).await?.unwrap();
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         &charlie_addr,
         &secret,
@@ -159,7 +159,7 @@ async fn test_broadcast_security_no_signature() -> Result<()> {
 
     let secret = load_broadcast_secret(alice, alice_chat_id).await?.unwrap();
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "attacker@example.org",
         &secret,
@@ -189,7 +189,7 @@ async fn test_broadcast_security_happy_path() -> Result<()> {
         .await?
         .unwrap();
 
-    test_shared_secret_decryption_ex(bob, &alice_addr, &secret, Some(alice), None).await
+    test_shared_secret_decryption_ext(bob, &alice_addr, &secret, Some(alice), None).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -210,7 +210,7 @@ async fn test_qr_code_security() -> Result<()> {
 
     let alice_fp = self_fingerprint(alice).await?;
     let secret_for_encryption = format!("securejoin/{alice_fp}/{authcode}");
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         &charlie_addr,
         &secret_for_encryption,
@@ -238,7 +238,7 @@ async fn test_qr_code_happy_path() -> Result<()> {
 
     let alice_fp = self_fingerprint(alice).await?;
     let secret_for_encryption = format!("securejoin/{alice_fp}/{authcode}");
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "alice@example.net",
         &secret_for_encryption,
@@ -255,7 +255,7 @@ async fn test_unknown_secret() -> Result<()> {
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "alice@example.net",
         "Some secret unknown to Bob",

--- a/src/mimeparser/shared_secret_decryption_tests.rs
+++ b/src/mimeparser/shared_secret_decryption_tests.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 ///
 /// To defeat this, a message that was unexpectedly
 /// encrypted with a symmetric secret must be dropped.
-async fn test_shared_secret_decryption_ex(
+async fn test_shared_secret_decryption_ext(
     recipient_ctx: &TestContext,
     from_addr: &str,
     secret_for_encryption: &str,
@@ -134,7 +134,7 @@ async fn test_broadcast_security_attacker_signature() -> Result<()> {
 
     let charlie_addr = charlie.get_config(Config::Addr).await?.unwrap();
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         &charlie_addr,
         &secret,
@@ -156,7 +156,7 @@ async fn test_broadcast_security_no_signature() -> Result<()> {
 
     let secret = load_broadcast_secret(alice, alice_chat_id).await?.unwrap();
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "attacker@example.org",
         &secret,
@@ -183,7 +183,7 @@ async fn test_broadcast_security_happy_path() -> Result<()> {
         .await?
         .unwrap();
 
-    test_shared_secret_decryption_ex(bob, &alice_addr, &secret, Some(alice), None).await
+    test_shared_secret_decryption_ext(bob, &alice_addr, &secret, Some(alice), None).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -204,7 +204,7 @@ async fn test_qr_code_security() -> Result<()> {
 
     let alice_fp = self_fingerprint(alice).await?;
     let secret_for_encryption = format!("securejoin/{alice_fp}/{authcode}");
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         &charlie_addr,
         &secret_for_encryption,
@@ -229,7 +229,7 @@ async fn test_qr_code_happy_path() -> Result<()> {
 
     let alice_fp = self_fingerprint(alice).await?;
     let secret_for_encryption = format!("securejoin/{alice_fp}/{authcode}");
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "alice@example.net",
         &secret_for_encryption,
@@ -246,7 +246,7 @@ async fn test_unknown_secret() -> Result<()> {
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
 
-    test_shared_secret_decryption_ex(
+    test_shared_secret_decryption_ext(
         bob,
         "alice@example.net",
         "Some secret unknown to Bob",

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -687,15 +687,19 @@ mod tests {
             salt: [1; 8],
         };
 
-        test_dont_decrypt_expensive_message_ex(s2k, false, None).await
+        test_dont_decrypt_expensive_message_ext(s2k, false, None).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_dont_decrypt_expensive_message_bad_s2k() -> Result<()> {
         let s2k = StringToKey::new_default(&mut thread_rng()); // Default is IteratedAndSalted
 
-        test_dont_decrypt_expensive_message_ex(s2k, false, Some("unsupported string2key algorithm"))
-            .await
+        test_dont_decrypt_expensive_message_ext(
+            s2k,
+            false,
+            Some("unsupported string2key algorithm"),
+        )
+        .await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -707,7 +711,7 @@ mod tests {
 
         // This error message is actually not great,
         // but grepping for it will lead to the correct code
-        test_dont_decrypt_expensive_message_ex(s2k, true, Some("decrypt_the_ring: missing key"))
+        test_dont_decrypt_expensive_message_ext(s2k, true, Some("decrypt_the_ring: missing key"))
             .await
     }
 
@@ -716,7 +720,7 @@ mod tests {
     /// with an expensive string2key algorithm
     /// or multiple shared secrets.
     /// This is to prevent possible DOS attacks on the app.
-    async fn test_dont_decrypt_expensive_message_ex(
+    async fn test_dont_decrypt_expensive_message_ext(
         s2k: StringToKey,
         encrypt_twice: bool,
         expected_error_msg: Option<&str>,

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -530,7 +530,7 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Result<Qr> {
 
     if let (Some(addr), Some(invitenumber), Some(authcode)) = (&addr, invitenumber, authcode) {
         let addr = ContactAddress::new(addr)?;
-        let (contact_id, _) = Contact::add_or_lookup_ex(
+        let (contact_id, _) = Contact::add_or_lookup_ext(
             context,
             &name,
             &addr,
@@ -643,7 +643,7 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Result<Qr> {
     } else if let Some(addr) = addr {
         let fingerprint = fingerprint.hex();
         let (contact_id, _) =
-            Contact::add_or_lookup_ex(context, "", &addr, &fingerprint, Origin::UnhandledQrScan)
+            Contact::add_or_lookup_ext(context, "", &addr, &fingerprint, Origin::UnhandledQrScan)
                 .await?;
         let contact = Contact::get_by_id(context, contact_id).await?;
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1147,7 +1147,7 @@ pub async fn from_field_to_contact_id(
         }
     }
 
-    let (from_id, _) = Contact::add_or_lookup_ex(
+    let (from_id, _) = Contact::add_or_lookup_ext(
         context,
         display_name.unwrap_or_default(),
         &from_addr,
@@ -1278,7 +1278,8 @@ async fn decide_chat_assignment(
     } = &mime_parser.pre_message
     {
         let post_msg_exists = if let Some((msg_id, not_downloaded)) =
-            message::rfc724_mid_exists_ex(context, post_msg_rfc724_mid, "download_state<>0").await?
+            message::rfc724_mid_exists_ext(context, post_msg_rfc724_mid, "download_state<>0")
+                .await?
         {
             context
                 .sql
@@ -1666,7 +1667,7 @@ async fn do_chat_assignment(
                         {
                             chat_created = true;
                             chat_id = Some(
-                                chat::create_out_broadcast_ex(
+                                chat::create_out_broadcast_ext(
                                     context,
                                     Nosync,
                                     listid,
@@ -1740,7 +1741,7 @@ async fn do_chat_assignment(
             chat_id_blocked = chat.blocked;
 
             if Blocked::Not != chat.blocked {
-                chat.id.unblock_ex(context, Nosync).await?;
+                chat.id.unblock_ext(context, Nosync).await?;
             }
         }
 
@@ -1748,7 +1749,7 @@ async fn do_chat_assignment(
         if chat_id_blocked != Blocked::Not
             && let Some(chat_id) = chat_id
         {
-            chat_id.unblock_ex(context, Nosync).await?;
+            chat_id.unblock_ext(context, Nosync).await?;
             chat_id_blocked = Blocked::Not;
         }
     }
@@ -2419,7 +2420,7 @@ async fn handle_edit_delete(
     } else if let Some(rfc724_mid_list) = mime_parser.get_header(HeaderDef::ChatDelete)
         && let Some(part) = mime_parser.parts.first()
     {
-        // See `message::delete_msgs_ex()`, unlike edit requests, DC doesn't send unencrypted
+        // See `message::delete_msgs_ext()`, unlike edit requests, DC doesn't send unencrypted
         // deletion requests, so there's no need to support them.
         if part.param.get_bool(Param::GuaranteeE2ee) != Some(true) {
             warn!(context, "Delete message: Not encrypted.");
@@ -2781,7 +2782,7 @@ async fn lookup_or_create_adhoc_group(
         Ok(val)
     };
     let query_only = true;
-    if let Some((chat_id, blocked)) = context.sql.transaction_ex(query_only, trans_fn).await? {
+    if let Some((chat_id, blocked)) = context.sql.transaction_ext(query_only, trans_fn).await? {
         info!(
             context,
             "Assigning message to ad-hoc group {chat_id} with matching name and members."
@@ -4190,7 +4191,7 @@ async fn add_or_lookup_key_contacts(
         };
         let display_name = info.display_name.as_deref();
         if let Ok(addr) = ContactAddress::new(addr) {
-            let (contact_id, _) = Contact::add_or_lookup_ex(
+            let (contact_id, _) = Contact::add_or_lookup_ext(
                 context,
                 display_name.unwrap_or_default(),
                 &addr,
@@ -4364,7 +4365,7 @@ async fn lookup_key_contacts_fallback_to_chat(
             let fingerprint: String = fp.hex();
 
             if let Ok(addr) = ContactAddress::new(addr) {
-                let (contact_id, _) = Contact::add_or_lookup_ex(
+                let (contact_id, _) = Contact::add_or_lookup_ext(
                     context,
                     display_name.unwrap_or_default(),
                     &addr,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1095,7 +1095,7 @@ pub async fn from_field_to_contact_id(
         }
     }
 
-    let (from_id, _) = Contact::add_or_lookup_ex(
+    let (from_id, _) = Contact::add_or_lookup_ext(
         context,
         display_name.unwrap_or_default(),
         &from_addr,
@@ -1229,7 +1229,8 @@ async fn decide_chat_assignment(
     } = &mime_parser.pre_message
     {
         let post_msg_exists = if let Some((msg_id, not_downloaded)) =
-            message::rfc724_mid_exists_ex(context, post_msg_rfc724_mid, "download_state<>0").await?
+            message::rfc724_mid_exists_ext(context, post_msg_rfc724_mid, "download_state<>0")
+                .await?
         {
             context
                 .sql
@@ -1617,7 +1618,7 @@ async fn do_chat_assignment(
                         {
                             chat_created = true;
                             chat_id = Some(
-                                chat::create_out_broadcast_ex(
+                                chat::create_out_broadcast_ext(
                                     context,
                                     Nosync,
                                     listid,
@@ -1691,7 +1692,7 @@ async fn do_chat_assignment(
             chat_id_blocked = chat.blocked;
 
             if Blocked::Not != chat.blocked {
-                chat.id.unblock_ex(context, Nosync).await?;
+                chat.id.unblock_ext(context, Nosync).await?;
             }
         }
 
@@ -1699,7 +1700,7 @@ async fn do_chat_assignment(
         if chat_id_blocked != Blocked::Not
             && let Some(chat_id) = chat_id
         {
-            chat_id.unblock_ex(context, Nosync).await?;
+            chat_id.unblock_ext(context, Nosync).await?;
             chat_id_blocked = Blocked::Not;
         }
     }
@@ -2380,7 +2381,7 @@ async fn handle_edit_delete(
     } else if let Some(rfc724_mid_list) = mime_parser.get_header(HeaderDef::ChatDelete)
         && let Some(part) = mime_parser.parts.first()
     {
-        // See `message::delete_msgs_ex()`, unlike edit requests, DC doesn't send unencrypted
+        // See `message::delete_msgs_ext()`, unlike edit requests, DC doesn't send unencrypted
         // deletion requests, so there's no need to support them.
         if part.param.get_bool(Param::GuaranteeE2ee) != Some(true) {
             warn!(context, "Delete message: Not encrypted.");
@@ -2742,7 +2743,7 @@ async fn lookup_or_create_adhoc_group(
         Ok(val)
     };
     let query_only = true;
-    if let Some((chat_id, blocked)) = context.sql.transaction_ex(query_only, trans_fn).await? {
+    if let Some((chat_id, blocked)) = context.sql.transaction_ext(query_only, trans_fn).await? {
         info!(
             context,
             "Assigning message to ad-hoc group {chat_id} with matching name and members."
@@ -4147,7 +4148,7 @@ async fn add_or_lookup_key_contacts(
         };
         let display_name = info.display_name.as_deref();
         if let Ok(addr) = ContactAddress::new(addr) {
-            let (contact_id, _) = Contact::add_or_lookup_ex(
+            let (contact_id, _) = Contact::add_or_lookup_ext(
                 context,
                 display_name.unwrap_or_default(),
                 &addr,
@@ -4321,7 +4322,7 @@ async fn lookup_key_contacts_fallback_to_chat(
             let fingerprint: String = fp.hex();
 
             if let Ok(addr) = ContactAddress::new(addr) {
-                let (contact_id, _) = Contact::add_or_lookup_ex(
+                let (contact_id, _) = Contact::add_or_lookup_ext(
                     context,
                     display_name.unwrap_or_default(),
                     &addr,

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -481,7 +481,7 @@ pub(crate) async fn handle_securejoin_handshake(
 
             let from_addr = ContactAddress::new(&mime_message.from.addr)?;
             let autocrypt_fingerprint = mime_message.autocrypt_fingerprint.as_deref().unwrap_or("");
-            let (autocrypt_contact_id, _) = Contact::add_or_lookup_ex(
+            let (autocrypt_contact_id, _) = Contact::add_or_lookup_ext(
                 context,
                 "",
                 &from_addr,
@@ -533,7 +533,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 warn!(context, "Secure-join denied (bad auth).");
                 return Ok(HandshakeMessage::Ignore);
             }
-            if Contact::lookup_id_by_addr_ex(
+            if Contact::lookup_id_by_addr_ext(
                 context,
                 &mime_message.from.addr,
                 Origin::Unknown,
@@ -663,7 +663,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 ChatId::create_for_contact(context, contact_id).await?;
             }
             if let Some(joining_chat_id) = joining_chat_id {
-                chat::add_contact_to_chat_ex(context, Nosync, joining_chat_id, contact_id, true)
+                chat::add_contact_to_chat_ext(context, Nosync, joining_chat_id, contact_id, true)
                     .await?;
 
                 let chat = Chat::load_from_db(context, joining_chat_id).await?;

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -469,7 +469,7 @@ async fn joining_chat_id(
 
             let chat_id = match chat::get_chat_id_by_grpid(context, grpid).await? {
                 Some((chat_id, _blocked)) => {
-                    chat_id.unblock_ex(context, Nosync).await?;
+                    chat_id.unblock_ext(context, Nosync).await?;
                     chat_id
                 }
                 None => {

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -29,26 +29,26 @@ enum SetupContactCase {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_basic() {
-    test_setup_contact_ex(SetupContactCase::Normal).await;
+    test_setup_contact_ext(SetupContactCase::Normal).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_wrong_alice_gossip() {
-    let (alice, _) = test_setup_contact_ex(SetupContactCase::WrongAliceGossip).await;
+    let (alice, _) = test_setup_contact_ext(SetupContactCase::WrongAliceGossip).await;
     alice.assert_warn("No self addr+pubkey gossip found").await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_alice_is_bot() {
-    test_setup_contact_ex(SetupContactCase::AliceIsBot).await;
+    test_setup_contact_ext(SetupContactCase::AliceIsBot).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_alice_has_name() {
-    test_setup_contact_ex(SetupContactCase::AliceHasName).await;
+    test_setup_contact_ext(SetupContactCase::AliceHasName).await;
 }
 
-async fn test_setup_contact_ex(case: SetupContactCase) -> (TestContext, TestContext) {
+async fn test_setup_contact_ext(case: SetupContactCase) -> (TestContext, TestContext) {
     let _n = TimeShiftFalsePositiveNote;
 
     let mut tcm = TestContextManager::new();
@@ -449,18 +449,18 @@ async fn test_setup_contact_concurrent_calls() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_legacy() -> Result<()> {
-    test_secure_join_group_ex(false, false).await
+    test_secure_join_group_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_v3() -> Result<()> {
-    test_secure_join_group_ex(true, false).await
+    test_secure_join_group_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_v3_without_invite() -> Result<()> {
-    test_secure_join_group_ex(true, true).await
+    test_secure_join_group_ext(true, true).await
 }
 
-async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_secure_join_group_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = tcm.alice().await;
     let bob = tcm.bob().await;
@@ -688,18 +688,18 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_legacy() -> Result<()> {
-    test_secure_join_broadcast_ex(false, false).await
+    test_secure_join_broadcast_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_v3() -> Result<()> {
-    test_secure_join_broadcast_ex(true, false).await
+    test_secure_join_broadcast_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_v3_without_invite() -> Result<()> {
-    test_secure_join_broadcast_ex(true, true).await
+    test_secure_join_broadcast_ext(true, true).await
 }
 
-async fn test_secure_join_broadcast_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_secure_join_broadcast_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
@@ -720,18 +720,18 @@ async fn test_secure_join_broadcast_ex(v3: bool, remove_invite: bool) -> Result<
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_legacy() -> Result<()> {
-    test_setup_contact_compatibility_ex(false, false).await
+    test_setup_contact_compatibility_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_v3() -> Result<()> {
-    test_setup_contact_compatibility_ex(true, false).await
+    test_setup_contact_compatibility_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_v3_without_invite() -> Result<()> {
-    test_setup_contact_compatibility_ex(true, true).await
+    test_setup_contact_compatibility_ext(true, true).await
 }
 
-async fn test_setup_contact_compatibility_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_setup_contact_compatibility_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -29,25 +29,25 @@ enum SetupContactCase {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_basic() {
-    test_setup_contact_ex(SetupContactCase::Normal).await
+    test_setup_contact_ext(SetupContactCase::Normal).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_wrong_alice_gossip() {
-    test_setup_contact_ex(SetupContactCase::WrongAliceGossip).await
+    test_setup_contact_ext(SetupContactCase::WrongAliceGossip).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_alice_is_bot() {
-    test_setup_contact_ex(SetupContactCase::AliceIsBot).await
+    test_setup_contact_ext(SetupContactCase::AliceIsBot).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_alice_has_name() {
-    test_setup_contact_ex(SetupContactCase::AliceHasName).await
+    test_setup_contact_ext(SetupContactCase::AliceHasName).await
 }
 
-async fn test_setup_contact_ex(case: SetupContactCase) {
+async fn test_setup_contact_ext(case: SetupContactCase) {
     let _n = TimeShiftFalsePositiveNote;
 
     let mut tcm = TestContextManager::new();
@@ -445,18 +445,18 @@ async fn test_setup_contact_concurrent_calls() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_legacy() -> Result<()> {
-    test_secure_join_group_ex(false, false).await
+    test_secure_join_group_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_v3() -> Result<()> {
-    test_secure_join_group_ex(true, false).await
+    test_secure_join_group_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_group_v3_without_invite() -> Result<()> {
-    test_secure_join_group_ex(true, true).await
+    test_secure_join_group_ext(true, true).await
 }
 
-async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_secure_join_group_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = tcm.alice().await;
     let bob = tcm.bob().await;
@@ -684,18 +684,18 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_legacy() -> Result<()> {
-    test_secure_join_broadcast_ex(false, false).await
+    test_secure_join_broadcast_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_v3() -> Result<()> {
-    test_secure_join_broadcast_ex(true, false).await
+    test_secure_join_broadcast_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secure_join_broadcast_v3_without_invite() -> Result<()> {
-    test_secure_join_broadcast_ex(true, true).await
+    test_secure_join_broadcast_ext(true, true).await
 }
 
-async fn test_secure_join_broadcast_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_secure_join_broadcast_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
@@ -716,18 +716,18 @@ async fn test_secure_join_broadcast_ex(v3: bool, remove_invite: bool) -> Result<
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_legacy() -> Result<()> {
-    test_setup_contact_compatibility_ex(false, false).await
+    test_setup_contact_compatibility_ext(false, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_v3() -> Result<()> {
-    test_setup_contact_compatibility_ex(true, false).await
+    test_setup_contact_compatibility_ext(true, false).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_v3_without_invite() -> Result<()> {
-    test_setup_contact_compatibility_ex(true, true).await
+    test_setup_contact_compatibility_ext(true, true).await
 }
 
-async fn test_setup_contact_compatibility_ex(v3: bool, remove_invite: bool) -> Result<()> {
+async fn test_setup_contact_compatibility_ext(v3: bool, remove_invite: bool) -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -451,7 +451,7 @@ impl Sql {
         G: Send + FnOnce(&mut rusqlite::Transaction<'_>) -> Result<H>,
     {
         let query_only = false;
-        self.transaction_ex(query_only, callback).await
+        self.transaction_ext(query_only, callback).await
     }
 
     /// Execute the function inside a transaction.
@@ -468,7 +468,7 @@ impl Sql {
     ///
     /// If the function returns an error, the transaction will be rolled back. If it does not return
     /// an error, the transaction will be committed.
-    pub async fn transaction_ex<G, H>(&self, query_only: bool, callback: G) -> Result<H>
+    pub async fn transaction_ext<G, H>(&self, query_only: bool, callback: G) -> Result<H>
     where
         H: Send + 'static,
         G: Send + FnOnce(&mut rusqlite::Transaction<'_>) -> Result<H>,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -341,7 +341,7 @@ impl Context {
         // Since there was a sync message, we know that there is a second device.
         // Set BccSelf to true if it isn't already.
         if !items.items.is_empty() && !self.get_config_bool(Config::BccSelf).await.unwrap_or(true) {
-            self.set_config_ex(Sync::Nosync, Config::BccSelf, Some("1"))
+            self.set_config_ext(Sync::Nosync, Config::BccSelf, Some("1"))
                 .await
                 .log_err(self)
                 .ok();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -274,14 +274,14 @@ impl TestContextManager {
         for _ in 0..2 {
             let mut something_sent = false;
             let rev_order = false;
-            if let Some(sent) = joiner.pop_sent_msg_ex(rev_order).await {
+            if let Some(sent) = joiner.pop_sent_msg_ext(rev_order).await {
                 for inviter in inviters {
                     inviter.recv_msg_opt(&sent).await;
                 }
                 something_sent = true;
             }
             for inviter in inviters {
-                if let Some(sent) = inviter.pop_sent_msg_ex(rev_order).await {
+                if let Some(sent) = inviter.pop_sent_msg_ext(rev_order).await {
                     if sent.recipients.split(' ').any(|addr| addr == inviter_addr) {
                         for observer in inviters {
                             // `imap::prefetch_should_download()` returns false on the sender side.
@@ -592,10 +592,10 @@ impl TestContext {
 
     pub async fn pop_sent_msg_opt(&self) -> Option<SentMessage<'_>> {
         let rev_order = true;
-        self.pop_sent_msg_ex(rev_order).await
+        self.pop_sent_msg_ext(rev_order).await
     }
 
-    pub async fn pop_sent_msg_ex(&self, rev_order: bool) -> Option<SentMessage<'_>> {
+    pub async fn pop_sent_msg_ext(&self, rev_order: bool) -> Option<SentMessage<'_>> {
         let mut query = "
 SELECT id, msg_id, mime, recipients
 FROM smtp
@@ -883,7 +883,7 @@ ORDER BY id"
         let fingerprint = self_fingerprint(other).await.unwrap();
 
         let (contact_id, _modified) =
-            Contact::add_or_lookup_ex(self, "", &addr, fingerprint, Origin::MailinglistAddress)
+            Contact::add_or_lookup_ext(self, "", &addr, fingerprint, Origin::MailinglistAddress)
                 .await
                 .expect("add_or_lookup");
         contact_id
@@ -1053,7 +1053,7 @@ ORDER BY id"
     async fn display_chat(&self, chat_id: ChatId) -> String {
         let mut res = String::new();
 
-        let msglist = chat::get_chat_msgs_ex(
+        let msglist = chat::get_chat_msgs_ext(
             self,
             chat_id,
             MessageListOptions {
@@ -1577,7 +1577,7 @@ pub fn pqc_keypair() -> SignedSecretKey {
 #[derive(Debug)]
 pub struct EventTracker(EventEmitter);
 
-/// See [`super::EventTracker::get_matching_ex`].
+/// See [`super::EventTracker::get_matching_ext`].
 pub struct ExpectedEvents<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool> {
     pub expected: E,
     pub unexpected: U,
@@ -1625,7 +1625,7 @@ impl EventTracker {
         ctx: &Context,
         event_matcher: F,
     ) -> Option<EventType> {
-        self.get_matching_ex(
+        self.get_matching_ext(
             ctx,
             ExpectedEvents {
                 expected: event_matcher,
@@ -1637,7 +1637,7 @@ impl EventTracker {
 
     /// Consumes all emitted events returning the first matching one if any. Panics on unexpected
     /// events.
-    pub async fn get_matching_ex<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool>(
+    pub async fn get_matching_ext<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool>(
         &self,
         ctx: &Context,
         args: ExpectedEvents<E, U>,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -293,14 +293,14 @@ impl TestContextManager {
         for _ in 0..2 {
             let mut something_sent = false;
             let rev_order = false;
-            if let Some(sent) = joiner.pop_sent_msg_ex(rev_order).await {
+            if let Some(sent) = joiner.pop_sent_msg_ext(rev_order).await {
                 for inviter in inviters {
                     inviter.recv_msg_opt(&sent).await;
                 }
                 something_sent = true;
             }
             for inviter in inviters {
-                if let Some(sent) = inviter.pop_sent_msg_ex(rev_order).await {
+                if let Some(sent) = inviter.pop_sent_msg_ext(rev_order).await {
                     if sent.recipients.split(' ').any(|addr| addr == inviter_addr) {
                         for observer in inviters {
                             // `imap::prefetch_should_download()` returns false on the sender side.
@@ -654,10 +654,10 @@ impl TestContext {
 
     pub async fn pop_sent_msg_opt(&self) -> Option<SentMessage<'_>> {
         let rev_order = true;
-        self.pop_sent_msg_ex(rev_order).await
+        self.pop_sent_msg_ext(rev_order).await
     }
 
-    pub async fn pop_sent_msg_ex(&self, rev_order: bool) -> Option<SentMessage<'_>> {
+    pub async fn pop_sent_msg_ext(&self, rev_order: bool) -> Option<SentMessage<'_>> {
         let mut query = "
 SELECT id, msg_id, mime, recipients
 FROM smtp
@@ -945,7 +945,7 @@ ORDER BY id"
         let fingerprint = self_fingerprint(other).await.unwrap();
 
         let (contact_id, _modified) =
-            Contact::add_or_lookup_ex(self, "", &addr, fingerprint, Origin::MailinglistAddress)
+            Contact::add_or_lookup_ext(self, "", &addr, fingerprint, Origin::MailinglistAddress)
                 .await
                 .expect("add_or_lookup");
         contact_id
@@ -1115,7 +1115,7 @@ ORDER BY id"
     async fn display_chat(&self, chat_id: ChatId) -> String {
         let mut res = String::new();
 
-        let msglist = chat::get_chat_msgs_ex(
+        let msglist = chat::get_chat_msgs_ext(
             self,
             chat_id,
             MessageListOptions {
@@ -1527,7 +1527,7 @@ pub fn pqc_keypair() -> SignedSecretKey {
 #[derive(Debug)]
 pub struct EventTracker(EventEmitter);
 
-/// See [`super::EventTracker::get_matching_ex`].
+/// See [`super::EventTracker::get_matching_ext`].
 pub struct ExpectedEvents<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool> {
     pub expected: E,
     pub unexpected: U,
@@ -1575,7 +1575,7 @@ impl EventTracker {
         ctx: &Context,
         event_matcher: F,
     ) -> Option<EventType> {
-        self.get_matching_ex(
+        self.get_matching_ext(
             ctx,
             ExpectedEvents {
                 expected: event_matcher,
@@ -1587,7 +1587,7 @@ impl EventTracker {
 
     /// Consumes all emitted events returning the first matching one if any. Panics on unexpected
     /// events.
-    pub async fn get_matching_ex<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool>(
+    pub async fn get_matching_ext<E: Fn(&EventType) -> bool, U: Fn(&EventType) -> bool>(
         &self,
         ctx: &Context,
         args: ExpectedEvents<E, U>,

--- a/src/tests/pre_messages/forward_and_save.rs
+++ b/src/tests/pre_messages/forward_and_save.rs
@@ -107,7 +107,7 @@ async fn test_receive_both() -> Result<()> {
     forward_msgs(alice, &[alice_msg_id], alice_chat_id).await?;
     let rev_order = false;
     let msg = bob
-        .recv_msg(&alice.pop_sent_msg_ex(rev_order).await.unwrap())
+        .recv_msg(&alice.pop_sent_msg_ext(rev_order).await.unwrap())
         .await;
     assert_eq!(msg.download_state(), DownloadState::Available);
     assert_eq!(msg.is_forwarded(), true);

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -318,7 +318,7 @@ async fn pre_msg_mdn_before_sending_full(text: &str) -> Result<()> {
     msg.set_text(text.to_string());
     chat::send_msg(alice, alice_chat_id, &mut msg).await?;
     let rev_order = false;
-    let pre_msg = alice.pop_sent_msg_ex(rev_order).await.unwrap();
+    let pre_msg = alice.pop_sent_msg_ext(rev_order).await.unwrap();
     let alice_msg_id = msg.id;
 
     let msg = bob.recv_msg(&pre_msg).await;


### PR DESCRIPTION
"ex" means "used to be, but no longer is".
"ext" means "extended", which is the intended meaning.
"Ext" is more common not only in the Rust ecosystem but in general.
We already had several people (myself included) asking
what "ex" is supposed to mean.

To reproduce this commit, search and replace `_ex(?!\w)` -> `_ext`.
But don't change `list_transports_ex` because it's public API.
