### PR TITLE
fix: Don't show "Not Connected" just because one of the relays can't connect

### DIFF
--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -247,14 +247,11 @@ impl Context {
             let connectivity = s.get_basic();
             connectivities.push(connectivity);
         }
-        if connectivities.iter().any(|c| *c == Connectivity::Working) {
+        if connectivities.contains(&Connectivity::Working) {
             Connectivity::Working
-        } else if connectivities.iter().any(|c| *c == Connectivity::Connected) {
+        } else if connectivities.contains(&Connectivity::Connected) {
             Connectivity::Connected
-        } else if connectivities
-            .iter()
-            .any(|c| *c == Connectivity::Connecting)
-        {
+        } else if connectivities.contains(&Connectivity::Connecting) {
             Connectivity::Connecting
         } else {
             Connectivity::NotConnected

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -247,10 +247,18 @@ impl Context {
             let connectivity = s.get_basic();
             connectivities.push(connectivity);
         }
-        connectivities
-            .into_iter()
-            .min()
-            .unwrap_or(Connectivity::NotConnected)
+        if connectivities.iter().any(|c| *c == Connectivity::Working) {
+            Connectivity::Working
+        } else if connectivities.iter().any(|c| *c == Connectivity::Connected) {
+            Connectivity::Connected
+        } else if connectivities
+            .iter()
+            .any(|c| *c == Connectivity::Connecting)
+        {
+            Connectivity::Connecting
+        } else {
+            Connectivity::NotConnected
+        }
     }
 
     pub(crate) fn update_connectivities(&self, sched: &InnerSchedulerState) {


### PR DESCRIPTION
With multi-relay, it can happen that one of the relays can't connect or is stuck in "Connecting...". In this case, right now we show "Not Connected"/"Connecting" as the connectivity, which multiple users already complained about, esp. since it's not obvious how to remove an unpublished, not working relay.

Instead, the new logic is:
- If any relay is working, then we signal this to the user, to signal that new messages may come in.
- Only show "Connecting..." or "Not Connected" if all of the relays are failing to connect, because if any of the relays can connect then things are mostly fine.