### PR TITLE
feat: client version information

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2791,16 +2791,31 @@ impl CommandApi {
         }
     }
 
-    /// Get version information of a specific client and source.
+    /// Get version information of a specific client and source
+    /// across all configured accounts and transports.
+    ///
+    /// Returns the source with the highest `version_integer`.
+    /// If no matching version information is available at all, `None` is returned.
+    ///
+    /// UIs shall call the function after a reasonable time after app start,
+    /// when most relays have reported the information they have, say 30 seconds.
+    /// After that, once a day.
+    /// (it is accepted if by the simple approach an update message is delayed.
+    /// an event was considered, but that seemed more complex for few benefit:
+    /// as we do not know if "late" relays will report "better" versions,
+    /// also there we would work with timeouts etc.)
+    ///
+    /// If the reported `version_integer` is larger than the running app version,
+    /// the UI shall report to the user, that an update is avialable,
+    /// and, if possible, offer a direct update by the given URL.
     async fn get_app_version(
         &self,
-        account_id: u32,
         client_id: String,
         source_id: String,
     ) -> Result<Option<JsonrpcAppSource>> {
-        let ctx = self.get_context(account_id).await?;
+        let accounts = self.accounts.read().await;
         Ok(
-            deltachat::appversions::get_app_version(&ctx, &client_id, &source_id)
+            deltachat::appversions::get_app_version(&accounts, &client_id, &source_id)
                 .await?
                 .map(|s| JsonrpcAppSource::from_core_type(s)),
         )

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -64,7 +64,7 @@ use self::types::{
         JsonrpcMessageListItem, MessageNotificationInfo, MessageSearchResult, MessageViewtype,
     },
 };
-use crate::api::types::appversions::JsonrpcAppVersionInfo;
+use crate::api::types::appversions::JsonrpcAppSource;
 use crate::api::types::chat_list::{ChatListItemFetchResult, get_chat_list_item_by_id};
 use crate::api::types::login_param::TransportListEntry;
 use crate::api::types::qr::{QrObject, SecurejoinSource, SecurejoinUiPath};
@@ -2791,11 +2791,19 @@ impl CommandApi {
         }
     }
 
-    /// Get version information of clients.
-    async fn get_app_versions(&self, account_id: u32) -> Result<JsonrpcAppVersionInfo> {
+    /// Get version information of a specific client and source.
+    async fn get_app_version(
+        &self,
+        account_id: u32,
+        client_id: String,
+        source_id: String,
+    ) -> Result<Option<JsonrpcAppSource>> {
         let ctx = self.get_context(account_id).await?;
-        let info = deltachat::appversions::get_app_versions(&ctx).await?;
-        JsonrpcAppVersionInfo::from_core_type(info)
+        Ok(
+            deltachat::appversions::get_app_version(&ctx, &client_id, &source_id)
+                .await?
+                .map(|s| JsonrpcAppSource::from_core_type(s)),
+        )
     }
 }
 

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2817,7 +2817,7 @@ impl CommandApi {
         Ok(
             deltachat::appversions::get_app_version(&accounts, &client_id, &source_id)
                 .await?
-                .map(|s| JsonrpcAppSource::from_core_type(s)),
+                .map(JsonrpcAppSource::from_core_type),
         )
     }
 }

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2806,7 +2806,7 @@ impl CommandApi {
     /// also there we would work with timeouts etc.)
     ///
     /// If the reported `version_integer` is larger than the running app version,
-    /// the UI shall report to the user, that an update is avialable,
+    /// the UI shall report to the user, that an update is available,
     /// and, if possible, offer a direct update by the given URL.
     async fn get_app_version(
         &self,

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2808,6 +2808,9 @@ impl CommandApi {
     /// If the reported `version_integer` is larger than the running app version,
     /// the UI shall report to the user, that an update is available,
     /// and, if possible, offer a direct update by the given URL.
+    ///
+    /// Security note: consumers need to verify themselves
+    /// that downloaded app files are valid before installing them.
     async fn get_app_version(
         &self,
         client_id: String,

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -64,6 +64,7 @@ use self::types::{
         JsonrpcMessageListItem, MessageNotificationInfo, MessageSearchResult, MessageViewtype,
     },
 };
+use crate::api::types::appversions::JsonrpcAppVersionInfo;
 use crate::api::types::chat_list::{ChatListItemFetchResult, get_chat_list_item_by_id};
 use crate::api::types::login_param::TransportListEntry;
 use crate::api::types::qr::{QrObject, SecurejoinSource, SecurejoinUiPath};
@@ -2788,6 +2789,13 @@ impl CommandApi {
         } else {
             Err(anyhow!("chat with id {chat_id} doesn't have draft message"))
         }
+    }
+
+    /// Get version information of clients.
+    async fn get_app_versions(&self, account_id: u32) -> Result<JsonrpcAppVersionInfo> {
+        let ctx = self.get_context(account_id).await?;
+        let info = deltachat::appversions::get_app_versions(&ctx).await?;
+        JsonrpcAppVersionInfo::from_core_type(info)
     }
 }
 

--- a/deltachat-jsonrpc/src/api/types/appversions.rs
+++ b/deltachat-jsonrpc/src/api/types/appversions.rs
@@ -13,6 +13,8 @@ pub struct JsonrpcAppSource {
     pub version_string: String,
 
     /// Where to download that version.
+    /// Security note: consumers need to verify themselves 
+    /// that downloaded app files are valid before installing them.
     pub download_url: String,
 }
 

--- a/deltachat-jsonrpc/src/api/types/appversions.rs
+++ b/deltachat-jsonrpc/src/api/types/appversions.rs
@@ -1,34 +1,11 @@
-use anyhow::Result;
-use deltachat::appversions::AppVersionInfo;
+use deltachat::appversions::AppSource;
 use serde::{Deserialize, Serialize};
 use typescript_type_def::TypeDef;
-
-/// Version information of clients.
-#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
-#[serde(rename = "AppVersionInfo", rename_all = "camelCase")]
-pub struct JsonrpcAppVersionInfo {
-    /// Array of clients with version information.
-    pub clients: Vec<JsonrpcAppClient>,
-}
-
-/// Version information of a single client, eg. "deltachat" or "ubuntutouch".
-#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
-#[serde(rename = "AppClient", rename_all = "camelCase")]
-pub struct JsonrpcAppClient {
-    /// ID how the client identifies itself, eg. "deltachat" or "ubuntutouch".
-    pub client_id: String,
-
-    /// Array of sources for that client.
-    pub sources: Vec<JsonrpcAppSource>,
-}
 
 /// Version information of a single source of a client, eg. "gplay" or "fdroid".
 #[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "AppSource", rename_all = "camelCase")]
 pub struct JsonrpcAppSource {
-    /// ID how the client identifies a source, eg. "gplay" or "fdroid".
-    pub app_id: String,
-
     /// Always increasing version number.
     pub version_integer: u32,
 
@@ -39,9 +16,12 @@ pub struct JsonrpcAppSource {
     pub download_url: String,
 }
 
-impl JsonrpcAppVersionInfo {
-    pub fn from_core_type(info: AppVersionInfo) -> Result<Self> {
-        let value = serde_json::to_value(info)?;
-        Ok(serde_json::from_value(value)?)
+impl JsonrpcAppSource {
+    pub fn from_core_type(source: AppSource) -> Self {
+        JsonrpcAppSource {
+            version_integer: source.version_integer,
+            version_string: source.version_string,
+            download_url: source.download_url,
+        }
     }
 }

--- a/deltachat-jsonrpc/src/api/types/appversions.rs
+++ b/deltachat-jsonrpc/src/api/types/appversions.rs
@@ -13,7 +13,7 @@ pub struct JsonrpcAppSource {
     pub version_string: String,
 
     /// Where to download that version.
-    /// Security note: consumers need to verify themselves 
+    /// Security note: consumers need to verify themselves
     /// that downloaded app files are valid before installing them.
     pub download_url: String,
 }

--- a/deltachat-jsonrpc/src/api/types/appversions.rs
+++ b/deltachat-jsonrpc/src/api/types/appversions.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use deltachat::appversions::AppVersionInfo;
+use serde::{Deserialize, Serialize};
+use typescript_type_def::TypeDef;
+
+/// Version information of clients.
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename = "AppVersionInfo", rename_all = "camelCase")]
+pub struct JsonrpcAppVersionInfo {
+    /// Array of clients with version information.
+    pub clients: Vec<JsonrpcAppClient>,
+}
+
+/// Version information of a single client, eg. "deltachat" or "ubuntutouch".
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename = "AppClient", rename_all = "camelCase")]
+pub struct JsonrpcAppClient {
+    /// ID how the client identifies itself, eg. "deltachat" or "ubuntutouch".
+    pub client_id: String,
+
+    /// Array of sources for that client.
+    pub sources: Vec<JsonrpcAppSource>,
+}
+
+/// Version information of a single source of a client, eg. "gplay" or "fdroid".
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
+#[serde(rename = "AppSource", rename_all = "camelCase")]
+pub struct JsonrpcAppSource {
+    /// ID how the client identifies a source, eg. "gplay" or "fdroid".
+    pub app_id: String,
+
+    /// Always increasing version number.
+    pub version_integer: u32,
+
+    /// Any version string.
+    pub version_string: String,
+
+    /// Where to download that version.
+    pub download_url: String,
+}
+
+impl JsonrpcAppVersionInfo {
+    pub fn from_core_type(info: AppVersionInfo) -> Result<Self> {
+        let value = serde_json::to_value(info)?;
+        Ok(serde_json::from_value(value)?)
+    }
+}

--- a/deltachat-jsonrpc/src/api/types/mod.rs
+++ b/deltachat-jsonrpc/src/api/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod appversions;
 pub mod calls;
 pub mod chat;
 pub mod chat_list;

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -6,10 +6,10 @@
 use crate::accounts::Accounts;
 use crate::log::warn;
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// Version information of clients as used on the wire.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct AppVersionInfo {
     /// Array of clients with version information.
@@ -17,7 +17,7 @@ struct AppVersionInfo {
 }
 
 /// Version information of a single client, eg. "deltachat" or "ubuntutouch".
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct AppClient {
     /// ID how the client identifies itself, eg. "deltachat" or "ubuntutouch"
@@ -28,7 +28,7 @@ struct AppClient {
 }
 
 /// Version information of a single source of a client, eg. "gplay" or "fdroid".
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct AppSource {
     /// ID how the client identifies a source, eg. "gplay" or "fdroid"

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -301,7 +301,6 @@ mod tests {
         assert!(version.is_none());
 
         // second account returns an invalid json, that account is skipped, but app versionss are still gathered from the other
-        let account_id2 = accounts.add_account().await?;
         let json = r"bad json!";
         mockup_app_versions(&accounts, account_id2, json).await;
 

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -31,7 +31,7 @@ struct AppClient {
 #[serde(rename_all = "camelCase", default)]
 pub struct AppSource {
     /// ID how the client identifies a source, eg. "gplay" or "fdroid"
-    app_id: String,
+    source_id: String,
 
     /// Always increasing version number.
     pub version_integer: u32,
@@ -59,7 +59,7 @@ pub async fn get_app_version(
             .clients
             .into_iter()
             .find(|c| c.client_id == client_id)
-            .and_then(|c| c.sources.into_iter().find(|s| s.app_id == source_id));
+            .and_then(|c| c.sources.into_iter().find(|s| s.source_id == source_id));
         return Ok(app_version);
     }
     Ok(None)
@@ -78,7 +78,7 @@ mod tests {
                 "clientId": "deltachat",
                 "sources": [
                   {
-                    "appId": "gplay",
+                    "sourceId": "gplay",
                     "versionInteger": 754,
                     "versionString": "2.57.0",
                     "downloadUrl": "https://github.com/deltachat/deltachat-android/releases/download/v2.57.0/deltachat-gplay-release-2.57.0.apk"
@@ -91,7 +91,7 @@ mod tests {
         assert_eq!(versions.clients.len(), 1);
         assert_eq!(versions.clients[0].client_id, "deltachat");
         assert_eq!(versions.clients[0].sources.len(), 1);
-        assert_eq!(versions.clients[0].sources[0].app_id, "gplay");
+        assert_eq!(versions.clients[0].sources[0].source_id, "gplay");
         assert_eq!(versions.clients[0].sources[0].version_integer, 754);
         assert_eq!(versions.clients[0].sources[0].version_string, "2.57.0");
         assert_eq!(

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -154,10 +154,14 @@ mod tests {
         Ok(())
     }
 
-    async fn mockup_app_versions(accounts: &Accounts, account_id: u32, json: &str) {
+    async fn mockup_app_versions(
+        accounts: &Accounts,
+        account_id: u32,
+        transport_id: u32,
+        json: &str,
+    ) {
         let context = accounts.get_account(account_id).expect("account exists");
         let mut metadata = context.metadata.write().await;
-        let transport_id = 1;
         metadata.entry(transport_id).or_default().app_versions = Some(json.to_string());
     }
 
@@ -206,7 +210,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id1, json).await;
+        mockup_app_versions(&accounts, account_id1, 1, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -243,7 +247,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id2, json).await;
+        mockup_app_versions(&accounts, account_id2, 1, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -280,7 +284,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id3, json).await;
+        mockup_app_versions(&accounts, account_id3, 1, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -302,12 +306,38 @@ mod tests {
 
         // second account returns an invalid json, that account is skipped, but app versionss are still gathered from the other
         let json = r"bad json!";
-        mockup_app_versions(&accounts, account_id2, json).await;
+        mockup_app_versions(&accounts, account_id2, 1, json).await;
 
         let version = get_app_version(&accounts, "foo", "bar").await?.unwrap();
         assert_eq!(version.version_integer, 42);
         assert_eq!(version.version_string, "42.0");
         assert_eq!(version.download_url, "https://foo.bar/42.0.prg");
+
+        // second account now has two transports, returning different version information in different orders
+        let json = r##"{
+            "clients": [
+              { "clientId": "a", "sources": [{"sourceId": "a", "versionInteger": 1, "versionString": "1.0", "downloadUrl": "https://a/1.prg"}] },
+              { "clientId": "b", "sources": [{"sourceId": "b", "versionInteger": 2, "versionString": "2.0", "downloadUrl": "https://b/2.prg"}] },
+              { "clientId": "c", "sources": [{"sourceId": "c", "versionInteger": 2, "versionString": "2.0", "downloadUrl": "https://c/2.prg"}] }
+            ]
+          }"##;
+        mockup_app_versions(&accounts, account_id2, 1, json).await;
+        let json = r##"{
+            "clients": [
+              { "clientId": "a", "sources": [{"sourceId": "a", "versionInteger": 2, "versionString": "2.0", "downloadUrl": "https://a/2.prg"}] },
+              { "clientId": "b", "sources": [{"sourceId": "b", "versionInteger": 1, "versionString": "1.0", "downloadUrl": "https://b/1.prg"}] },
+              { "clientId": "d", "sources": [{"sourceId": "d", "versionInteger": 2, "versionString": "2.0", "downloadUrl": "https://d/2.prg"}] }
+            ]
+          }"##;
+        mockup_app_versions(&accounts, account_id2, 2, json).await;
+        let version = get_app_version(&accounts, "a", "a").await?.unwrap();
+        assert_eq!(version.version_integer, 2);
+        let version = get_app_version(&accounts, "b", "b").await?.unwrap();
+        assert_eq!(version.version_integer, 2);
+        let version = get_app_version(&accounts, "c", "c").await?.unwrap();
+        assert_eq!(version.version_integer, 2);
+        let version = get_app_version(&accounts, "d", "d").await?.unwrap();
+        assert_eq!(version.version_integer, 2);
 
         Ok(())
     }

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Version information of clients as used on the wire.
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-pub struct AppVersionInfo {
+struct AppVersionInfo {
     /// Array clients with version information.
     clients: Vec<AppClient>,
 }
@@ -18,7 +18,7 @@ pub struct AppVersionInfo {
 /// Version infomation of a single client, eg. "deltachat" or "ubuntutouch".
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-pub struct AppClient {
+struct AppClient {
     /// ID how the client identifies itself, eg. "deltachat" or "ubuntutouch"
     client_id: String,
 
@@ -34,29 +34,35 @@ pub struct AppSource {
     app_id: String,
 
     /// Always increasing version number.
-    version_integer: u32,
+    pub version_integer: u32,
 
     /// Any version string.
-    version_string: String,
+    pub version_string: String,
 
     /// Where to download that version.
-    download_url: String,
+    pub download_url: String,
 }
 
-/// Get version information of clients.
+/// Get version information of a specific client and source.
 ///
-/// If no version information are available, `clients` is set to an empty array.
-///
-/// The information is coming from the relay via IMAP METADATA and is not cached.
-/// A call to `get_app_versions()` is cheap and does not involve network or database calls.
-pub async fn get_app_versions(context: &Context) -> Result<AppVersionInfo> {
+/// If no matching version information are available, `None` is returned.
+pub async fn get_app_version(
+    context: &Context,
+    client_id: &str,
+    source_id: &str,
+) -> Result<Option<AppSource>> {
     if let Some(metadata) = context.metadata.read().await.values().next()
         && let Some(json) = &metadata.app_versions
     {
         let app_versions: AppVersionInfo = serde_json::from_str(json)?;
-        return Ok(app_versions);
+        let app_version = app_versions
+            .clients
+            .into_iter()
+            .find(|c| c.client_id == client_id)
+            .and_then(|c| c.sources.into_iter().find(|s| s.app_id == source_id));
+        return Ok(app_version);
     }
-    Ok(AppVersionInfo::default())
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -126,8 +132,8 @@ mod tests {
         let mut tcm = TestContextManager::new();
         let alice = &tcm.alice().await;
 
-        let versions = get_app_versions(alice).await?;
-        assert!(versions.clients.is_empty());
+        let version = get_app_version(alice, "deltachat", "gplay").await?;
+        assert!(version.is_none());
 
         Ok(())
     }

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -15,7 +15,7 @@ struct AppVersionInfo {
     clients: Vec<AppClient>,
 }
 
-/// Version infomation of a single client, eg. "deltachat" or "ubuntutouch".
+/// Version information of a single client, eg. "deltachat" or "ubuntutouch".
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct AppClient {

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -4,6 +4,7 @@
 //! The version information comes in via IMAP METADATA,
 //! (as JSON) and is parsed to `AppVersionInfo`.
 use crate::accounts::Accounts;
+use crate::log::warn;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -65,7 +66,13 @@ pub async fn get_app_version(
             let Some(json) = &metadata.app_versions else {
                 continue;
             };
-            let app_versions: AppVersionInfo = serde_json::from_str(json)?;
+            let app_versions: AppVersionInfo = match serde_json::from_str(json) {
+                Ok(app_versions) => app_versions,
+                Err(err) => {
+                    warn!(context, "Failed to parse appversions: {err:#}.");
+                    continue;
+                }
+            };
             let candidate = app_versions
                 .clients
                 .into_iter()
@@ -166,7 +173,7 @@ mod tests {
         assert!(version.is_none());
 
         // first account reports two clients, with one and two sources
-        let account_id = accounts.add_account().await?;
+        let account_id1 = accounts.add_account().await?;
         let json = r##"{
             "clients": [
               {
@@ -199,7 +206,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id, json).await;
+        mockup_app_versions(&accounts, account_id1, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -220,7 +227,7 @@ mod tests {
         assert!(version.is_none());
 
         // a second account reports a newer version for "bar"
-        let account_id = accounts.add_account().await?;
+        let account_id2 = accounts.add_account().await?;
         let json = r##"{
             "clients": [
               {
@@ -236,7 +243,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id, json).await;
+        mockup_app_versions(&accounts, account_id2, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -257,7 +264,7 @@ mod tests {
         assert!(version.is_none());
 
         // a third account reports a older version for "bar", that is ignored
-        let account_id = accounts.add_account().await?;
+        let account_id3 = accounts.add_account().await?;
         let json = r##"{
             "clients": [
               {
@@ -273,7 +280,7 @@ mod tests {
               }
             ]
           }"##;
-        mockup_app_versions(&accounts, account_id, json).await;
+        mockup_app_versions(&accounts, account_id3, json).await;
 
         let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
         assert_eq!(version.version_integer, 754);
@@ -292,6 +299,16 @@ mod tests {
 
         let version = get_app_version(&accounts, "non-", "existant").await?;
         assert!(version.is_none());
+
+        // second account returns an invalid json, that account is skipped, but app versionss are still gathered from the other
+        let account_id2 = accounts.add_account().await?;
+        let json = r"bad json!";
+        mockup_app_versions(&accounts, account_id2, json).await;
+
+        let version = get_app_version(&accounts, "foo", "bar").await?.unwrap();
+        assert_eq!(version.version_integer, 42);
+        assert_eq!(version.version_string, "42.0");
+        assert_eq!(version.download_url, "https://foo.bar/42.0.prg");
 
         Ok(())
     }

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -1,0 +1,134 @@
+//! Get version information of clients.
+//!
+//! Used by clients to inform about updates.
+//! The version information comes in via IMAP METADATA,
+//! (as JSON) and is parsed to `AppVersionInfo`.
+use crate::context::Context;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Version information of clients as used on the wire.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AppVersionInfo {
+    /// Array clients with version information.
+    clients: Vec<AppClient>,
+}
+
+/// Version infomation of a single client, eg. "deltachat" or "ubuntutouch".
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AppClient {
+    /// ID how the client identifies itself, eg. "deltachat" or "ubuntutouch"
+    client_id: String,
+
+    /// Array of sources for that client.
+    sources: Vec<AppSource>,
+}
+
+/// Version information of a single source of a client, eg. "gplay" or "fdroid".
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AppSource {
+    /// ID how the client identifies a source, eg. "gplay" or "fdroid"
+    app_id: String,
+
+    /// Always increasing version number.
+    version_integer: u32,
+
+    /// Any version string.
+    version_string: String,
+
+    /// Where to download that version.
+    download_url: String,
+}
+
+/// Get version information of clients.
+///
+/// If no version information are available, `clients` is set to an empty array.
+///
+/// The information is coming from the relay via IMAP METADATA and is not cached.
+/// A call to `get_app_versions()` is cheap and does not involve network or database calls.
+pub async fn get_app_versions(context: &Context) -> Result<AppVersionInfo> {
+    if let Some(metadata) = context.metadata.read().await.values().next()
+        && let Some(json) = &metadata.app_versions
+    {
+        let app_versions: AppVersionInfo = serde_json::from_str(json)?;
+        return Ok(app_versions);
+    }
+    Ok(AppVersionInfo::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestContextManager;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_app_version_info_deserialize() -> Result<()> {
+        let json = r##"{
+            "clients": [
+              {
+                "clientId": "deltachat",
+                "sources": [
+                  {
+                    "appId": "gplay",
+                    "versionInteger": 754,
+                    "versionString": "2.57.0",
+                    "downloadUrl": "https://github.com/deltachat/deltachat-android/releases/download/v2.57.0/deltachat-gplay-release-2.57.0.apk"
+                  }
+                ]
+              }
+            ]
+          }"##;
+        let versions: AppVersionInfo = serde_json::from_str(json)?;
+        assert_eq!(versions.clients.len(), 1);
+        assert_eq!(versions.clients[0].client_id, "deltachat");
+        assert_eq!(versions.clients[0].sources.len(), 1);
+        assert_eq!(versions.clients[0].sources[0].app_id, "gplay");
+        assert_eq!(versions.clients[0].sources[0].version_integer, 754);
+        assert_eq!(versions.clients[0].sources[0].version_string, "2.57.0");
+        assert_eq!(
+            versions.clients[0].sources[0].download_url,
+            "https://github.com/deltachat/deltachat-android/releases/download/v2.57.0/deltachat-gplay-release-2.57.0.apk"
+        );
+
+        // missing fields are set to defaults, additional fields are ignored, errors are errors
+        let json = r##"{
+            "clients": [
+              {
+                "clientId": "deltachat",
+                "xsource": "bang"
+              }
+            ],
+            "foo": "bar"
+          }"##;
+        let versions: AppVersionInfo = serde_json::from_str(json)?;
+        assert_eq!(versions.clients.len(), 1);
+        assert_eq!(versions.clients[0].client_id, "deltachat");
+        assert_eq!(versions.clients[0].sources.len(), 0);
+
+        let json = "{}";
+        let versions: AppVersionInfo = serde_json::from_str(json)?;
+        assert_eq!(versions.clients.len(), 0);
+
+        let json = "";
+        assert!(serde_json::from_str::<AppVersionInfo>(json).is_err());
+
+        let json = "bad json";
+        assert!(serde_json::from_str::<AppVersionInfo>(json).is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_app_versions() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &tcm.alice().await;
+
+        let versions = get_app_versions(alice).await?;
+        assert!(versions.clients.is_empty());
+
+        Ok(())
+    }
+}

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct AppVersionInfo {
-    /// Array clients with version information.
+    /// Array of clients with version information.
     clients: Vec<AppClient>,
 }
 

--- a/src/appversions.rs
+++ b/src/appversions.rs
@@ -3,7 +3,7 @@
 //! Used by clients to inform about updates.
 //! The version information comes in via IMAP METADATA,
 //! (as JSON) and is parsed to `AppVersionInfo`.
-use crate::context::Context;
+use crate::accounts::Accounts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -45,30 +45,50 @@ pub struct AppSource {
 
 /// Get version information of a specific client and source.
 ///
-/// If no matching version information are available, `None` is returned.
+/// Iterates over all accounts and all transports,
+/// checking version information set by IMAP METADATA,
+/// and returns the source with the highest `version_integer`.
+///
+/// If no matching version information is available at all, `None` is returned.
 pub async fn get_app_version(
-    context: &Context,
+    accounts: &Accounts,
     client_id: &str,
     source_id: &str,
 ) -> Result<Option<AppSource>> {
-    if let Some(metadata) = context.metadata.read().await.values().next()
-        && let Some(json) = &metadata.app_versions
-    {
-        let app_versions: AppVersionInfo = serde_json::from_str(json)?;
-        let app_version = app_versions
-            .clients
-            .into_iter()
-            .find(|c| c.client_id == client_id)
-            .and_then(|c| c.sources.into_iter().find(|s| s.source_id == source_id));
-        return Ok(app_version);
+    let mut best: Option<AppSource> = None;
+
+    for account_id in accounts.get_all() {
+        let Some(context) = accounts.get_account(account_id) else {
+            continue;
+        };
+        for metadata in context.metadata.read().await.values() {
+            let Some(json) = &metadata.app_versions else {
+                continue;
+            };
+            let app_versions: AppVersionInfo = serde_json::from_str(json)?;
+            let candidate = app_versions
+                .clients
+                .into_iter()
+                .find(|c| c.client_id == client_id)
+                .and_then(|c| c.sources.into_iter().find(|s| s.source_id == source_id));
+
+            if let Some(candidate) = candidate
+                && best
+                    .as_ref()
+                    .is_none_or(|b| candidate.version_integer > b.version_integer)
+            {
+                best = Some(candidate);
+            }
+        }
     }
-    Ok(None)
+
+    Ok(best)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TestContextManager;
+    use std::path::PathBuf;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_app_version_info_deserialize() -> Result<()> {
@@ -127,12 +147,150 @@ mod tests {
         Ok(())
     }
 
+    async fn mockup_app_versions(accounts: &Accounts, account_id: u32, json: &str) {
+        let context = accounts.get_account(account_id).expect("account exists");
+        let mut metadata = context.metadata.write().await;
+        let transport_id = 1;
+        metadata.entry(transport_id).or_default().app_versions = Some(json.to_string());
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_get_app_versions() -> Result<()> {
-        let mut tcm = TestContextManager::new();
-        let alice = &tcm.alice().await;
+        let dir = tempfile::tempdir().unwrap();
+        let p: PathBuf = dir.path().join("accounts");
+        let writable = true;
+        let mut accounts = Accounts::new(p.clone(), writable).await.unwrap();
 
-        let version = get_app_version(alice, "deltachat", "gplay").await?;
+        // no accounts configured, means no versions are reported
+        let version = get_app_version(&accounts, "non-", "existant").await?;
+        assert!(version.is_none());
+
+        // first account reports two clients, with one and two sources
+        let account_id = accounts.add_account().await?;
+        let json = r##"{
+            "clients": [
+              {
+                "clientId": "basta",
+                "sources": [
+                  {
+                    "sourceId": "web",
+                    "versionInteger": 754,
+                    "versionString": "2.57.0",
+                    "downloadUrl": "https://example.org/basta-2.57.0.apk"
+                  }
+                ]
+              },
+              {
+                "clientId": "foo",
+                "sources": [
+                  {
+                    "sourceId": "bar",
+                    "versionInteger": 42,
+                    "versionString": "42.0",
+                    "downloadUrl": "https://foo.bar/42.0.prg"
+                  },
+                  {
+                    "sourceId": "baz",
+                    "versionInteger": 1337,
+                    "versionString": "13.37",
+                    "downloadUrl": "https://dl.org/1337.acc"
+                  }
+                ]
+              }
+            ]
+          }"##;
+        mockup_app_versions(&accounts, account_id, json).await;
+
+        let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
+        assert_eq!(version.version_integer, 754);
+        assert_eq!(version.version_string, "2.57.0");
+        assert_eq!(version.download_url, "https://example.org/basta-2.57.0.apk");
+
+        let version = get_app_version(&accounts, "foo", "bar").await?.unwrap();
+        assert_eq!(version.version_integer, 42);
+        assert_eq!(version.version_string, "42.0");
+        assert_eq!(version.download_url, "https://foo.bar/42.0.prg");
+
+        let version = get_app_version(&accounts, "foo", "baz").await?.unwrap();
+        assert_eq!(version.version_integer, 1337);
+        assert_eq!(version.version_string, "13.37");
+        assert_eq!(version.download_url, "https://dl.org/1337.acc");
+
+        let version = get_app_version(&accounts, "non-", "existant").await?;
+        assert!(version.is_none());
+
+        // a second account reports a newer version for "bar"
+        let account_id = accounts.add_account().await?;
+        let json = r##"{
+            "clients": [
+              {
+                "clientId": "foo",
+                "sources": [
+                  {
+                    "sourceId": "bar",
+                    "versionInteger": 43,
+                    "versionString": "43.0",
+                    "downloadUrl": "https://foo.bar/43.0-is-newer.prg"
+                  }
+                ]
+              }
+            ]
+          }"##;
+        mockup_app_versions(&accounts, account_id, json).await;
+
+        let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
+        assert_eq!(version.version_integer, 754);
+        assert_eq!(version.version_string, "2.57.0");
+        assert_eq!(version.download_url, "https://example.org/basta-2.57.0.apk");
+
+        let version = get_app_version(&accounts, "foo", "bar").await?.unwrap();
+        assert_eq!(version.version_integer, 43);
+        assert_eq!(version.version_string, "43.0");
+        assert_eq!(version.download_url, "https://foo.bar/43.0-is-newer.prg");
+
+        let version = get_app_version(&accounts, "foo", "baz").await?.unwrap();
+        assert_eq!(version.version_integer, 1337);
+        assert_eq!(version.version_string, "13.37");
+        assert_eq!(version.download_url, "https://dl.org/1337.acc");
+
+        let version = get_app_version(&accounts, "non-", "existant").await?;
+        assert!(version.is_none());
+
+        // a third account reports a older version for "bar", that is ignored
+        let account_id = accounts.add_account().await?;
+        let json = r##"{
+            "clients": [
+              {
+                "clientId": "foo",
+                "sources": [
+                  {
+                    "sourceId": "bar",
+                    "versionInteger": 39,
+                    "versionString": "39.0",
+                    "downloadUrl": "https://foo.bar/39.0-is-too-old.prg"
+                  }
+                ]
+              }
+            ]
+          }"##;
+        mockup_app_versions(&accounts, account_id, json).await;
+
+        let version = get_app_version(&accounts, "basta", "web").await?.unwrap();
+        assert_eq!(version.version_integer, 754);
+        assert_eq!(version.version_string, "2.57.0");
+        assert_eq!(version.download_url, "https://example.org/basta-2.57.0.apk");
+
+        let version = get_app_version(&accounts, "foo", "bar").await?.unwrap();
+        assert_eq!(version.version_integer, 43);
+        assert_eq!(version.version_string, "43.0");
+        assert_eq!(version.download_url, "https://foo.bar/43.0-is-newer.prg");
+
+        let version = get_app_version(&accounts, "foo", "baz").await?.unwrap();
+        assert_eq!(version.version_integer, 1337);
+        assert_eq!(version.version_string, "13.37");
+        assert_eq!(version.download_url, "https://dl.org/1337.acc");
+
+        let version = get_app_version(&accounts, "non-", "existant").await?;
         assert!(version.is_none());
 
         Ok(())

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -140,6 +140,10 @@ pub(crate) struct ServerMetadata {
     /// should be fetched from the server
     /// to be ready for WebRTC calls.
     pub ice_servers_expiration_timestamp: i64,
+
+    /// App versions, as raw JSON string.
+    /// Consumed by get_app_versions().
+    pub app_versions: Option<String>,
 }
 
 struct UidGrouper<T: Iterator<Item = (i64, u32, String)>> {
@@ -1342,6 +1346,7 @@ impl Session {
         let mut max_smtp_rcpt_to = None;
         let mut ice_servers = None;
         let mut ice_servers_expiration_timestamp = 0;
+        let mut app_versions = None;
 
         let mailbox = "";
         let options = "";
@@ -1397,6 +1402,9 @@ impl Session {
                         }
                     }
                 }
+                "/shared/vendor/deltachat/appversions" => {
+                    app_versions = m.value;
+                }
                 _ => {}
             }
         }
@@ -1418,6 +1426,7 @@ impl Session {
                 supports_push: max_smtp_rcpt_to.is_some() || self.capabilities.has_xdeltapush,
                 ice_servers,
                 ice_servers_expiration_timestamp,
+                app_versions,
             },
         );
         Ok(())

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1354,7 +1354,7 @@ impl Session {
             .get_metadata(
                 mailbox,
                 options,
-                "(/shared/comment /shared/admin /shared/vendor/deltachat/irohrelay /shared/vendor/deltachat/turn /shared/vendor/deltachat/maxsmtprecipients)",
+                "(/shared/comment /shared/admin /shared/vendor/deltachat/irohrelay /shared/vendor/deltachat/turn /shared/vendor/deltachat/maxsmtprecipients /shared/vendor/deltachat/appversions)",
             )
             .await?;
         for m in metadata {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1297,6 +1297,10 @@ impl Session {
             let now = time();
 
             // Refresh TURN server credentials if they expire in 12 hours.
+            //
+            // Moreover, Take the chance to update `app_versions` as well.
+            // As best effort, even checking every some days is good enough -
+            // and saves one additional time get get_metadata() call.
             if now + 3600 * 12 < old_metadata.ice_servers_expiration_timestamp {
                 return Ok(());
             }
@@ -1307,7 +1311,11 @@ impl Session {
                 let mailbox = "";
                 let options = "";
                 let metadata = self
-                    .get_metadata(mailbox, options, "(/shared/vendor/deltachat/turn)")
+                    .get_metadata(
+                        mailbox,
+                        options,
+                        "(/shared/vendor/deltachat/turn /shared/vendor/deltachat/appversions)",
+                    )
                     .await?;
                 for m in metadata {
                     if m.entry == "/shared/vendor/deltachat/turn"
@@ -1323,6 +1331,8 @@ impl Session {
                                 warn!(context, "Failed to parse TURN server metadata: {err:#}.");
                             }
                         }
+                    } else if m.entry == "/shared/vendor/deltachat/appversions" {
+                        old_metadata.app_versions = m.value;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod events;
 pub use events::*;
 
 mod aheader;
+pub mod appversions;
 mod automatic_relay_management;
 pub mod blob;
 pub mod calls;


### PR DESCRIPTION
> we aim to inform about updates for installations outside of any appstore soon.
>
> there is already a PR on android at https://github.com/deltachat/deltachat-android/pull/4582, however, the information about "update available" is a mockup there. 
>
> in general, there are 3 ideas around about how to gather the "update available" infomation - (1) checking a central url, (2) let contacts provide information, (3) let relay provide information. on various one-to-one discussions, outcome is that (3) is the most reasonable way to go.

this PR is about reading update information via IMAP metadata from the relay.

it is up to the UI to call `get_app_version()` at a reasonable time and frequency, see comment in the code. when called, `get_app_version()` iterates over all known profiles and relays and checks for version information, returning the newest for the given scope.

we do not use an event, as that is tricky wrt changes - we do not know if other relays report later a newer version. we also do not cache anything, to prevent bad relays avoiding us to update permanently. also it is easier :)

<details>
<summary>outdated notes and questions</summary>

- ~~it is up to the clients to get the needed information, we could let core filter, but it seems easy enough the other way round, and may have debug advantages, one can iterate etc.~~ EDIT: we now filter in core, this also makes the jsonrpc part easier, see review comments

- when is IMAP METADATA actually read? when are they ready? is that really the correct place? i am up to change that, but beware, this is not really my expertise, so someone else may need to take over :)
EDIT: see below,  IMAP METADATA is read on connection, before fetching starts, usually fast enough

- relay part is missing. once the format is settled and discussed shortly here, that should be done soon as well. but this is definitely not my expertise and needed to be done by someone else :)

- key for IMAP METADATA is `/shared/vendor/deltachat/appversions` - shall we continue use `deltachat` for compatibility or so? `chatmail` seems to be more correct
EDIT: we stay with the current
</details>

relay counterpart issue: https://github.com/chatmail/relay/issues/1037

cc @link2xt @Hocuri @hpk42 
