### PR TITLE
Remove dc_chat_is_protected() and cleanup documentation

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3778,17 +3778,6 @@ int             dc_chat_can_send              (const dc_chat_t* chat);
 
 
 /**
- * Deprecated, always returns 0.
- *
- * @memberof dc_chat_t
- * @param chat The chat object.
- * @return Always 0.
- * @deprecated 2025-09-09
- */
-int             dc_chat_is_protected         (const dc_chat_t* chat);
-
-
-/**
  * Check if the chat is encrypted.
  *
  * Single chats with key-contacts and group chats with key-contacts

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2626,7 +2626,6 @@ char*           dc_get_securejoin_qr_svg         (dc_context_t* context, uint32_
  *     to dc_check_qr().
  * @return The chat ID of the joined chat, the UI may redirect to the this chat.
  *     On errors, 0 is returned, however, most errors will happen during handshake later on.
- *     A returned chat ID does not guarantee that the chat is protected or the belonging contact is verified.
  */
 uint32_t        dc_join_securejoin           (dc_context_t* context, const char* qr);
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3047,11 +3047,6 @@ pub unsafe extern "C" fn dc_chat_can_send(chat: *mut dc_chat_t) -> libc::c_int {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn dc_chat_is_protected(_chat: *mut dc_chat_t) -> libc::c_int {
-    0
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_encrypted(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_encrypted()");

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -935,7 +935,6 @@ impl CommandApi {
     ///     to `check_qr()`.
     ///
     /// **returns**: The chat ID of the joined chat, the UI may redirect to the this chat.
-    ///         A returned chat ID does not guarantee that the chat is protected or the belonging contact is verified.
     ///
     async fn secure_join(&self, account_id: u32, qr: String) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -298,7 +298,7 @@ impl ChatId {
         let timestamp = cmp::min(timestamp, time());
         let row_id =
             context.sql.insert(
-                "INSERT INTO chats (type, name, name_normalized, grpid, blocked, created_timestamp, protected, param) VALUES(?, ?, ?, ?, ?, ?, 0, ?)",
+                "INSERT INTO chats (type, name, name_normalized, grpid, blocked, created_timestamp, param) VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (
                     chattype,
                     &grpname,

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1692,8 +1692,6 @@ WHERE addr=?
     /// in contact list items and
     /// in chat member list items.
     ///
-    /// In contact profile view, use this function only if there is no chat with the contact,
-    /// otherwise use is_chat_protected().
     /// Use [Self::get_verifier_id] to display the verifier contact
     /// in the info section of the contact profile.
     pub async fn is_verified(&self, context: &Context) -> Result<bool> {


### PR DESCRIPTION
We still have chats.protected column and use it to set Chat-Verified, but never set it anymore.

See also related issue https://github.com/chatmail/core/issues/7340 for the discussion on what we want to do with protection/verification. The concept of "protected chat" is definitely going to be removed.