### PR TITLE
docs(json-rpc): improve `reactions_by_contact` doc

### DIFF
--- a/deltachat-jsonrpc/src/api/types/reactions.rs
+++ b/deltachat-jsonrpc/src/api/types/reactions.rs
@@ -23,8 +23,11 @@ pub struct JsonrpcReaction {
 #[serde(rename = "Reactions", rename_all = "camelCase")]
 pub struct JsonrpcReactions {
     /// Map from a contact to it's reaction to message.
+    ///
     /// There is only a single reaction per contact,
     /// but this contains a list of reactions for historical reasons.
+    ///
+    /// For channels subscribers, this map is empty or contains `ContactId::SELF` only.
     reactions_by_contact: BTreeMap<u32, Vec<String>>,
     /// Unique reactions and their count, sorted in descending order.
     reactions: Vec<JsonrpcReaction>,


### PR DESCRIPTION
Sync `reactions_by_contact` with the "backend" struct docs.

Follow-up to bd846c6e4370608701b948e30ed75a422820d9d4
(https://github.com/chatmail/core/pull/8450).
