### PR TITLE
refactor: remove MessengerMessage

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -11,7 +11,7 @@ use crate::constants::{
 use crate::ephemeral::Timer;
 use crate::headerdef::HeaderDef;
 use crate::imex::{ImexMode, has_backup, imex};
-use crate::message::{Message, MessengerMessage, delete_msgs};
+use crate::message::{Message, delete_msgs};
 use crate::mimeparser::{self, MimeMessage};
 use crate::pinned_messages::{get_pinned_messages, set_pinned_state};
 use crate::qr::{Qr, check_qr};
@@ -2457,7 +2457,6 @@ async fn test_save_msgs() -> Result<()> {
     );
     assert_eq!(saved_msg.get_text(), "hi, bob");
     assert!(!saved_msg.is_forwarded()); // UI should not flag "saved messages" as "forwarded"
-    assert_eq!(saved_msg.is_dc_message, MessengerMessage::Yes);
     assert_eq!(saved_msg.get_from_id(), ContactId::SELF);
     assert_eq!(saved_msg.get_state(), MessageState::OutDelivered);
     assert_ne!(saved_msg.rfc724_mid(), sent_msg.rfc724_mid());
@@ -2482,7 +2481,6 @@ async fn test_save_msgs() -> Result<()> {
     );
     assert_eq!(saved_msg.get_text(), "hi, bob");
     assert!(!saved_msg.is_forwarded());
-    assert_eq!(saved_msg.is_dc_message, MessengerMessage::Yes);
     assert_ne!(saved_msg.get_from_id(), ContactId::SELF);
     assert_eq!(saved_msg.get_state(), MessageState::InSeen);
     assert_ne!(saved_msg.rfc724_mid(), rcvd_msg.rfc724_mid());

--- a/src/html.rs
+++ b/src/html.rs
@@ -336,7 +336,7 @@ mod tests {
 
     use crate::constants;
     use crate::contact::ContactId;
-    use crate::message::{MessengerMessage, Viewtype};
+    use crate::message::Viewtype;
     use crate::receive_imf::receive_imf;
     use crate::test_utils::{TestContext, TestContextManager};
 
@@ -524,7 +524,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         receive_imf(alice, raw, false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
         assert_ne!(msg.get_from_id(), ContactId::SELF);
-        assert_eq!(msg.is_dc_message, MessengerMessage::No);
         assert!(!msg.is_forwarded());
         assert!(msg.get_text().contains("this is plain"));
         assert!(msg.has_html());
@@ -539,7 +538,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         async fn check_sender(ctx: &TestContext, chat: &Chat) {
             let msg = ctx.get_last_msg_in(chat.get_id()).await;
             assert_eq!(msg.get_from_id(), ContactId::SELF);
-            assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
             assert!(msg.is_forwarded());
             assert!(msg.get_text().contains("this is plain"));
             assert!(msg.has_html());
@@ -556,7 +554,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             let msg = ctx.recv_msg(&sender.pop_sent_msg().await).await;
             assert_eq!(chat.id, msg.chat_id);
             assert_ne!(msg.get_from_id(), ContactId::SELF);
-            assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
             assert!(msg.is_forwarded());
             assert!(msg.get_text().contains("this is plain"));
             assert!(msg.has_html());
@@ -608,7 +605,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert!(!saved_msg.is_forwarded()); // UI should not flag "saved messages" as "forwarded"
         assert_ne!(saved_msg.get_from_id(), ContactId::SELF);
         assert_eq!(saved_msg.get_from_id(), msg.get_from_id());
-        assert_eq!(saved_msg.is_dc_message, MessengerMessage::No);
         assert!(saved_msg.get_text().contains("this is plain"));
         assert!(saved_msg.has_html());
         let html = saved_msg.get_id().get_html(alice).await?.unwrap();
@@ -643,7 +639,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         let msg = alice.recv_msg(&msg).await;
         assert_eq!(msg.chat_id, alice.get_self_chat().await.id);
         assert_eq!(msg.get_from_id(), ContactId::SELF);
-        assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.get_showpadlock());
         assert!(msg.is_forwarded());
         assert!(msg.get_text().contains("this is plain"));

--- a/src/message.rs
+++ b/src/message.rs
@@ -387,29 +387,6 @@ impl rusqlite::types::FromSql for MsgId {
     }
 }
 
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    FromPrimitive,
-    ToPrimitive,
-    FromSql,
-    ToSql,
-    Serialize,
-    Deserialize,
-    Default,
-)]
-#[repr(u8)]
-pub(crate) enum MessengerMessage {
-    #[default]
-    No = 0,
-    Yes = 1,
-
-    /// No, but reply to messenger message.
-    Reply = 2,
-}
-
 /// An object representing a single message in memory.
 /// The message object is not updated.
 /// If you want an update, you have to recreate the object.
@@ -459,7 +436,6 @@ pub struct Message {
 
     /// `In-Reply-To` header value.
     pub(crate) in_reply_to: Option<String>,
-    pub(crate) is_dc_message: MessengerMessage,
     pub(crate) original_msg_id: MsgId,
     pub(crate) pinned: bool,
     pub(crate) mime_modified: bool,
@@ -529,7 +505,6 @@ impl Message {
                     mdns.msg_id AS mdn_msg_id,
                     m.download_state AS download_state,
                     m.error AS error,
-                    m.msgrmsg AS msgrmsg,
                     m.starred AS original_msg_id,
                     m.pinned AS pinned,
                     m.mime_modified AS mime_modified,
@@ -588,7 +563,6 @@ impl Message {
                         download_state: row.get("download_state")?,
                         error: Some(row.get::<_, String>("error")?)
                             .filter(|error| !error.is_empty()),
-                        is_dc_message: row.get("msgrmsg")?,
                         original_msg_id: row.get("original_msg_id")?,
                         pinned: row.get("pinned")?,
                         mime_modified: row.get("mime_modified")?,

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -8,7 +8,7 @@ use crate::{
     constants::{self, Blocked, DC_DESIRED_TEXT_LEN, DC_ELLIPSIS},
     contact::Contact,
     key,
-    message::{MessageState, MessengerMessage},
+    message::MessageState,
     receive_imf::receive_imf,
     securejoin::QrInvite,
     test_utils::{self, TestContext, TestContextManager},
@@ -1205,7 +1205,6 @@ async fn test_add_subj_to_multimedia_msg() {
     assert_eq!(msg.text, "subj with important info – body text");
     assert_eq!(msg.viewtype, Viewtype::Image);
     assert_eq!(msg.error(), None);
-    assert_eq!(msg.is_dc_message, MessengerMessage::No);
     assert_eq!(msg.chat_blocked, Blocked::Request);
     assert_eq!(msg.state, MessageState::InFresh);
     assert_eq!(msg.get_filebytes(&t).await.unwrap().unwrap(), 2115);

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -33,8 +33,7 @@ use crate::key::{
 };
 use crate::log::{LogExt as _, warn};
 use crate::message::{
-    self, Message, MessageState, MessengerMessage, MsgId, Viewtype, insert_tombstone,
-    rfc724_mid_exists,
+    self, Message, MessageState, MsgId, Viewtype, insert_tombstone, rfc724_mid_exists,
 };
 use crate::mimeparser::{
     AvatarAction, GossipedKey, MimeMessage, PreMessageMode, SystemMessage, parse_message_ids,
@@ -690,17 +689,6 @@ pub(crate) async fn receive_imf_inner(
         is_old_contact_request = false;
         received_msg
     } else {
-        let is_dc_message = if mime_parser.has_chat_version() {
-            MessengerMessage::Yes
-        } else if let Some(parent_message) = &parent_message {
-            match parent_message.is_dc_message {
-                MessengerMessage::No => MessengerMessage::No,
-                MessengerMessage::Yes | MessengerMessage::Reply => MessengerMessage::Reply,
-            }
-        } else {
-            MessengerMessage::No
-        };
-
         let allow_creation = if mime_parser.decryption_error.is_some() {
             false
         } else {
@@ -740,7 +728,6 @@ pub(crate) async fn receive_imf_inner(
             prevent_rename,
             chat_id,
             chat_id_blocked,
-            is_dc_message,
             is_created,
         )
         .await
@@ -1739,7 +1726,6 @@ async fn add_parts(
     prevent_rename: bool,
     mut chat_id: ChatId,
     mut chat_id_blocked: Blocked,
-    is_dc_message: MessengerMessage,
     is_chat_created: bool,
 ) -> Result<ReceivedMsg> {
     let to_id = if mime_parser.incoming {
@@ -1878,14 +1864,13 @@ async fn add_parts(
                 context,
                 "Ignoring ephemeral timer change to {ephemeral_timer:?} for chat {chat_id} because sender {from_id} is not a member.",
             );
-        } else if is_dc_message == MessengerMessage::Yes
-            && get_previous_message(context, mime_parser)
-                .await?
-                .map(|p| p.ephemeral_timer)
-                == Some(ephemeral_timer)
+        } else if get_previous_message(context, mime_parser)
+            .await?
+            .map(|p| p.ephemeral_timer)
+            == Some(ephemeral_timer)
             && mime_parser.is_system_message != SystemMessage::EphemeralTimerChanged
         {
-            // The message is a Delta Chat message, so we know that previous message according to
+            // Assuming the message is a chat message, previous message according to
             // References header is the last message in the chat as seen by the sender. The timer
             // is the same in both the received message and the last message, so we know that the
             // sender has not seen any change of the timer between these messages. As our timer
@@ -2184,7 +2169,7 @@ INSERT INTO msgs
   (
     rfc724_mid, pre_rfc724_mid, chat_id,
     from_id, to_id, timestamp, timestamp_sent, 
-    timestamp_rcvd, type, state, msgrmsg, 
+    timestamp_rcvd, type, state,
     txt, txt_normalized, subject, param, hidden,
     bytes, mime_headers, mime_compressed, mime_in_reply_to,
     mime_references, mime_modified, error, ephemeral_timer,
@@ -2193,7 +2178,7 @@ INSERT INTO msgs
   VALUES (
     ?, ?, ?, ?, ?,
     ?, ?, ?, ?,
-    ?, ?, ?, ?,
+    ?, ?, ?,
     ?, ?, ?, ?, ?, 1,
     ?, ?, ?, ?,
     ?, ?, ?, ?
@@ -2231,11 +2216,6 @@ INSERT INTO msgs
                         MessageState::Undefined
                     } else {
                         state
-                    },
-                    if trash {
-                        MessengerMessage::No
-                    } else {
-                        is_dc_message
                     },
                     if trash || hidden { "" } else { msg },
                     if trash || hidden {

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -390,7 +390,6 @@ async fn test_escaped_from() {
         "Имя, Фамилия",
     );
     let msg = get_chat_msg(&t, chat_id, 0, 1).await;
-    assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
     assert_eq!(msg.text, "hello");
     assert_eq!(msg.param.get_int(Param::WantsMdn).unwrap(), 1);
 }
@@ -437,7 +436,6 @@ async fn test_escaped_recipients() {
     let msg = Message::load_from_db(&t, chats.get_msg_id(0).unwrap().unwrap())
         .await
         .unwrap();
-    assert_eq!(msg.is_dc_message, MessengerMessage::No);
     assert_eq!(msg.text, "foo – hello");
 }
 


### PR DESCRIPTION
This value is not used for any logic
except the disappearing messages timer rollback prevention. It is unlikely that non-chat clients
participate in chats with disappearing messages,
and the case was not tested anyway.