### PR TITLE
fix: filtered reactions are info, not error in device chat

### DIFF
--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -137,7 +137,8 @@ async fn set_msg_id_reaction(
     if matches!(chat.typ, Chattype::OutBroadcast | Chattype::InBroadcast)
         && !is_allowed_reaction(reaction)
     {
-        bail!("Reaction not allowed: {}", reaction.as_str());
+        info!(context, "Reaction {} filtered.", reaction.as_str());
+        return Ok(());
     }
 
     if reaction.is_empty() {

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -174,6 +174,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
 
 /// Applies incoming, accumulated reactions received via the `Chat-Broadcast-States:` header
 /// to the `broadcasted_reactions` table.
+/// We do not check against allowed reactions here; reactions may be done in the past when different filters were active.
 pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
     let payload: WirePayload = serde_json::from_str(json)?;
 


### PR DESCRIPTION
`bail!()` bubbles up the error until it lands in the device chat, which is way over the top for a reaction that is filtered out by channel owner.

currently this happens, as arcance chat uses different default reactions. in the future, this may happen even more often when we allow custom filters, that may change over time.

cc @adbenitez 