### PR TITLE
refactor: stop using msgs.to_id

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -820,7 +820,6 @@ async fn test_self_talk() -> Result<()> {
     let msg_id = send_text_msg(&t, chat.id, "foo self".to_string()).await?;
     let msg = Message::load_from_db(&t, msg_id).await?;
     assert_eq!(msg.from_id, ContactId::SELF);
-    assert_eq!(msg.to_id, ContactId::SELF);
     assert!(msg.get_showpadlock());
 
     let sent_msg = t.pop_sent_msg().await;
@@ -831,7 +830,6 @@ async fn test_self_talk() -> Result<()> {
     let msg = t2.get_last_msg_in(chat.id).await;
     assert_eq!(msg.text, "foo self".to_string());
     assert_eq!(msg.from_id, ContactId::SELF);
-    assert_eq!(msg.to_id, ContactId::SELF);
     assert!(msg.get_showpadlock());
 
     Ok(())
@@ -872,7 +870,6 @@ async fn test_add_device_msg_unlabelled() {
     let msg1 = msg1.unwrap();
     assert_eq!(msg1.text, "first message");
     assert_eq!(msg1.from_id, ContactId::DEVICE);
-    assert_eq!(msg1.to_id, ContactId::SELF);
     assert!(!msg1.is_info());
 
     let msg2 = message::Message::load_from_db(&t, msg2_id.unwrap()).await;
@@ -904,7 +901,6 @@ async fn test_add_device_msg_labelled() -> Result<()> {
     assert_eq!(msg1_id.as_ref().unwrap(), &msg1.id);
     assert_eq!(msg1.text, "first message");
     assert_eq!(msg1.from_id, ContactId::DEVICE);
-    assert_eq!(msg1.to_id, ContactId::SELF);
     assert!(!msg1.is_info());
 
     // check device chat
@@ -2290,7 +2286,6 @@ async fn test_forward_info_msg() -> Result<()> {
     assert!(!msg2.is_info()); // forwarded info-messages lose their info-state
     assert_eq!(msg2.get_info_type(), SystemMessage::Unknown);
     assert_ne!(msg2.from_id, ContactId::INFO);
-    assert_ne!(msg2.to_id, ContactId::INFO);
     assert_eq!(msg2.get_text(), msg1.get_text());
     assert!(msg2.is_forwarded());
 
@@ -5148,7 +5143,6 @@ async fn test_sync_name() -> Result<()> {
     let sent = alice0.pop_sent_msg().await;
     let rcvd = alice1.recv_msg(&sent).await;
     assert_eq!(rcvd.from_id, ContactId::SELF);
-    assert_eq!(rcvd.to_id, ContactId::SELF);
     assert_eq!(
         rcvd.text,
         "Channel name changed from \"Channel\" to \"Broadcast channel 42\"."

--- a/src/ephemeral/ephemeral_tests.rs
+++ b/src/ephemeral/ephemeral_tests.rs
@@ -367,7 +367,6 @@ async fn check_msg_is_deleted(t: &TestContext, chat: &Chat, msg_id: MsgId) {
     // Check that if there is a message left, the text and metadata are gone
     if let Ok(msg) = Message::load_from_db(t, msg_id).await {
         assert_eq!(msg.from_id, ContactId::UNDEFINED);
-        assert_eq!(msg.to_id, ContactId::UNDEFINED);
         assert_eq!(msg.text, "");
         let rawtxt: Option<String> = t
             .sql

--- a/src/message.rs
+++ b/src/message.rs
@@ -245,7 +245,7 @@ SELECT ?1, rfc724_mid, pre_rfc724_mid, timestamp, ?, ? FROM msgs WHERE id=?1
             ret += &format!("Expires: {}\n", timestamp_to_str(msg.ephemeral_timestamp));
         }
 
-        if msg.from_id == ContactId::INFO || msg.to_id == ContactId::INFO {
+        if msg.from_id == ContactId::INFO {
             // device-internal message, no further details needed
             return Ok(ret);
         }
@@ -398,9 +398,6 @@ pub struct Message {
     /// `From:` contact ID.
     pub(crate) from_id: ContactId,
 
-    /// ID of the first contact in the `To:` header.
-    pub(crate) to_id: ContactId,
-
     /// ID of the chat message belongs to.
     pub(crate) chat_id: ChatId,
 
@@ -494,7 +491,6 @@ impl Message {
                     m.mime_in_reply_to AS mime_in_reply_to,
                     m.chat_id AS chat_id,
                     m.from_id AS from_id,
-                    m.to_id AS to_id,
                     m.timestamp AS timestamp,
                     m.timestamp_sent AS timestamp_sent,
                     m.timestamp_rcvd AS timestamp_rcvd,
@@ -552,7 +548,6 @@ impl Message {
                             .and_then(|in_reply_to| parse_message_id(&in_reply_to).ok()),
                         chat_id: row.get("chat_id")?,
                         from_id: row.get("from_id")?,
-                        to_id: row.get("to_id")?,
                         timestamp_sort: row.get("timestamp")?,
                         timestamp_sent: row.get("timestamp_sent")?,
                         timestamp_rcvd: row.get("timestamp_rcvd")?,
@@ -1003,7 +998,6 @@ impl Message {
     pub fn is_info(&self) -> bool {
         let cmd = self.param.get_cmd();
         self.from_id == ContactId::INFO
-            || self.to_id == ContactId::INFO
             || cmd != SystemMessage::Unknown && cmd != SystemMessage::AutocryptSetupMessage
     }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1728,12 +1728,6 @@ async fn add_parts(
     mut chat_id_blocked: Blocked,
     is_chat_created: bool,
 ) -> Result<ReceivedMsg> {
-    let to_id = if mime_parser.incoming {
-        ContactId::SELF
-    } else {
-        to_ids.first().copied().flatten().unwrap_or(ContactId::SELF)
-    };
-
     // if contact renaming is prevented (for mailinglists and bots),
     // we use name from From:-header as override name
     if prevent_rename && let Some(name) = &mime_parser.from.display_name {
@@ -2168,7 +2162,7 @@ async fn add_parts(
 INSERT INTO msgs
   (
     rfc724_mid, pre_rfc724_mid, chat_id,
-    from_id, to_id, timestamp, timestamp_sent, 
+    from_id, timestamp, timestamp_sent, 
     timestamp_rcvd, type, state,
     txt, txt_normalized, subject, param, hidden,
     bytes, mime_headers, mime_compressed, mime_in_reply_to,
@@ -2177,7 +2171,7 @@ INSERT INTO msgs
   )
   VALUES (
     ?, ?, ?, ?, ?,
-    ?, ?, ?, ?,
+    ?, ?, ?,
     ?, ?, ?,
     ?, ?, ?, ?, ?, 1,
     ?, ?, ?, ?,
@@ -2201,7 +2195,6 @@ INSERT INTO msgs
                     },
                     if trash { DC_CHAT_ID_TRASH } else { chat_id },
                     if trash { ContactId::UNDEFINED } else { from_id },
-                    if trash { ContactId::UNDEFINED } else { to_id },
                     sort_timestamp,
                     if trash { 0 } else { mime_parser.timestamp_sent },
                     if trash { 0 } else { mime_parser.timestamp_rcvd },

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -2028,7 +2028,6 @@ Your server is hacked. Have a nice day!"
         let msg = t.get_last_msg().await;
         assert_ne!(msg.chat_id, t.get_self_chat().await.id);
         assert_eq!(msg.from_id, ContactId::SELF);
-        assert_eq!(msg.to_id, ContactId::SELF);
         if let Some(chat_id) = chat_id {
             assert_eq!(msg.chat_id, chat_id);
         } else {
@@ -3068,7 +3067,6 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     let received = alice1.get_last_msg().await;
     let alice1_bob_contact = alice1.add_or_lookup_contact(&bob).await;
     assert_eq!(received.from_id, alice1_bob_contact.id);
-    assert_eq!(received.to_id, ContactId::SELF);
     assert!(!received.hidden);
     assert_eq!(received.text, "Hello all!");
     assert_eq!(received.in_reply_to, None);
@@ -3093,9 +3091,7 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     // That's a regression test for https://github.com/chatmail/core/issues/2949:
     assert_eq!(received.chat_id, alice2.get_chat(&bob).await.id);
 
-    let alice2_bob_contact = alice2.add_or_lookup_contact(&bob).await;
     assert_eq!(received.from_id, ContactId::SELF);
-    assert_eq!(received.to_id, alice2_bob_contact.id);
     assert!(!received.hidden);
     assert_eq!(received.text, "Private reply");
     assert_eq!(
@@ -5008,7 +5004,6 @@ Hello!"
     let received = receive_imf(t, raw, false).await?.unwrap();
     let msg = Message::load_from_db(t, *received.msg_ids.last().unwrap()).await?;
     assert_eq!(msg.from_id, ContactId::SELF);
-    assert_eq!(msg.to_id, ContactId::SELF);
     let chat = Chat::load_from_db(t, msg.chat_id).await?;
     assert_eq!(chat.typ, Chattype::Group);
     assert!(!chat.is_encrypted(t).await?);


### PR DESCRIPTION
Removing all uses of `msgs.to_id` so it can be moved to deprecated/unused section: https://github.com/chatmail/core/pull/8493#discussion_r3761329886