### PR TITLE
deprecate dc_chat_get_info_json()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3557,7 +3557,7 @@ dc_lot_t*        dc_chatlist_get_summary2    (dc_context_t* context, uint32_t ch
 /**
  * Get info summary for a chat, in JSON format.
  *
- * @deprecated 2026-08-13, use dedicatged dc_chat_get_*() getters or jsonrpc
+ * @deprecated 2026-08-13, use dedicated dc_chat_get_*() getters or jsonrpc
  *
  * The returned JSON string has the following key/values:
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3557,6 +3557,8 @@ dc_lot_t*        dc_chatlist_get_summary2    (dc_context_t* context, uint32_t ch
 /**
  * Get info summary for a chat, in JSON format.
  *
+ * @deprecated 2026-08-13, use dedicatged dc_chat_get_*() getters or jsonrpc
+ *
  * The returned JSON string has the following key/values:
  *
  * id: chat id


### PR DESCRIPTION
it is outdated and incomplete, and always was experimental. we likely do not want to maintain that.

it is not in use in any UI but to get the name of the chat in Ubuntu Touch, i created an issue for that at https://codeberg.org/lk108/deltatouch/issues/305

moreover it is used for python bindings as get_summary(), not sure how much that is in use,
we can leave the API for that for now, but we should not encourage further usage of the API