### PR TITLE
feat: do not copy Chat-Version header into unprotected headers

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -381,16 +381,15 @@ pub(crate) fn render_queued_mail(
                 // <https://www.rfc-editor.org/rfc/rfc9787.html#structural-header-fields>.
                 continue;
             }
-            let header_value =
-                if header_name == "chat-version" || header_name == "chat-is-post-message" {
-                    parsed_header.get_value_raw()
-                } else if header_name == "subject" {
-                    &b"[...]"[..]
-                } else if header_name == "to" {
-                    &b"\"hidden-recipients\": ;"[..]
-                } else {
-                    continue;
-                };
+            let header_value = if header_name == "chat-is-post-message" {
+                parsed_header.get_value_raw()
+            } else if header_name == "subject" {
+                &b"[...]"[..]
+            } else if header_name == "to" {
+                &b"\"hidden-recipients\": ;"[..]
+            } else {
+                continue;
+            };
 
             outer_headers.extend(original_header_name.as_bytes());
             outer_headers.extend(b": ");

--- a/src/mimefactory/mimefactory_tests.rs
+++ b/src/mimefactory/mimefactory_tests.rs
@@ -1055,7 +1055,6 @@ Message-ID: <MESSAGE_ID@localhost>
 MIME-Version: 1.0
 To: "hidden-recipients": ;
 Subject: [...]
-Chat-Version: 1.0
 Content-Type: multipart/encrypted; protocol="application/pgp-encrypted"; 
 	boundary="BOUNDARY"
 


### PR DESCRIPTION
spec.md already documents Header Confidentiality Policy that hides Chat-Version header in encrypted messages, but so far we have copied the header into unprotected headers for compatibility.

Since 2.45.0 prefetch does not look at the unprotected Chat-Version do decide if the message should be downloaded
(change b94792706a3c6094a95b83b3210d50a98ccf4820)
and since 2.50 show_emails setting which controlled whether only "chat messages" are processed
is removed (change 63596a4940cea5310d8ae9b324b49d3a5dd11023).