### PR TITLE
fix: do not try to load profile image from param for self

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1633,20 +1633,21 @@ WHERE addr=?
     ) -> Result<Option<PathBuf>> {
         if self.id == ContactId::SELF {
             if let Some(p) = context.get_config(Config::Selfavatar).await? {
-                return Ok(Some(PathBuf::from(p))); // get_config() calls get_abs_path() internally already
+                Ok(Some(PathBuf::from(p))) // get_config() calls get_abs_path() internally already
+            } else {
+                Ok(None)
             }
         } else if self.id == ContactId::DEVICE {
-            return Ok(Some(chat::get_device_icon(context).await?));
-        }
-        if show_fallback_icon && !self.id.is_special() && !self.is_key_contact() {
-            return Ok(Some(chat::get_unencrypted_icon(context).await?));
-        }
-        if let Some(image_rel) = self.param.get(Param::ProfileImage)
+            Ok(Some(chat::get_device_icon(context).await?))
+        } else if show_fallback_icon && !self.id.is_special() && !self.is_key_contact() {
+            Ok(Some(chat::get_unencrypted_icon(context).await?))
+        } else if let Some(image_rel) = self.param.get(Param::ProfileImage)
             && !image_rel.is_empty()
         {
-            return Ok(Some(get_abs_path(context, Path::new(image_rel))));
+            Ok(Some(get_abs_path(context, Path::new(image_rel))))
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 
     /// Returns a color for the contact.

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -1015,6 +1015,32 @@ async fn test_selfavatar_changed_event() -> Result<()> {
     Ok(())
 }
 
+/// Tests that for self contact avatar is not loaded from the params.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_selfavatar_no_param() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+
+    let alice = &tcm.alice().await;
+
+    // SELF contact should not have the avatar set
+    // because avatar path is stored in `selfavatar` config,
+    // but apparently some older profiles have it,
+    // possibly due to a bug.
+    let mut self_contact = Contact::get_by_id(alice, ContactId::SELF).await?;
+    self_contact
+        .param
+        .set(Param::ProfileImage, "$BLOBDIR/avatar.jpg");
+    self_contact.update_param(alice).await?;
+
+    assert_eq!(alice.get_config(Config::Selfavatar).await?, None);
+    let self_contact = Contact::get_by_id(alice, ContactId::SELF).await?;
+
+    // Profile image parameter is ignored for self contact.
+    assert_eq!(self_contact.get_profile_image(alice).await?, None);
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_last_seen() -> Result<()> {
     let mut tcm = TestContextManager::new();


### PR DESCRIPTION
I have an old profile which has ProfileImage param set on the reserved SELF contact.  When I deleted
an avatar from the profile, very old profile image showed up in the settings in Delta Chat Desktop instead, which can be "deleted" again without any result.

This fix is to return `None` early from get_profile_image_ext for self contact without trying to load the parameter. Fallthrough to loading params was likely there
since keycontacts and grey avatars for address contacts introduction in 416131b4a25d7fb308439e2ef12c03633e6e459f