### PR TITLE
feat: Use display name for contacts in encryption info

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1213,7 +1213,7 @@ SELECT id, rfc724_mid, pre_rfc724_mid, timestamp, ?, 1 FROM msgs WHERE chat_id=?
             .filter(|&contact_id| !contact_id.is_special())
         {
             let contact = Contact::get_by_id(context, contact_id).await?;
-            let addr = contact.get_addr();
+            let name = contact.get_display_name();
             logged_debug_assert!(
                 context,
                 contact.is_key_contact(),
@@ -1226,12 +1226,12 @@ SELECT id, rfc724_mid, pre_rfc724_mid, timestamp, ?, 1 FROM msgs WHERE chat_id=?
             if let Some(public_key) = contact.public_key(context).await? {
                 if let Some(relay_addrs) = addresses_from_public_key(&public_key) {
                     let relays = relay_addrs.join(",");
-                    ret += &format!("\n{addr}({relays})\n{fingerprint}\n");
+                    ret += &format!("\n{name}({relays})\n{fingerprint}\n");
                 } else {
-                    ret += &format!("\n{addr}\n{fingerprint}\n");
+                    ret += &format!("\n{name}\n{fingerprint}\n");
                 }
             } else {
-                ret += &format!("\n{addr}\n(key missing)\n{fingerprint}\n");
+                ret += &format!("\n{name}\n(key missing)\n{fingerprint}\n");
             }
         }
 

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -4374,6 +4374,7 @@ async fn test_chat_get_encryption_info() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
+    bob.set_config(Config::Displayname, Some("Bob")).await?;
     let fiona = &tcm.fiona().await;
 
     let contact_bob = alice.add_or_lookup_contact_id(bob).await;
@@ -4390,7 +4391,7 @@ async fn test_chat_get_encryption_info() -> Result<()> {
         chat_id.get_encryption_info(alice).await?,
         "Messages are end-to-end encrypted.\n\
          \n\
-         bob@example.net(bob@example.net)\n\
+         Bob(bob@example.net)\n\
          CCCB 5AA9 F6E1 141C 9431\n\
          65F1 DB18 B18C BCF7 0487"
     );
@@ -4404,7 +4405,7 @@ async fn test_chat_get_encryption_info() -> Result<()> {
          C8BA 50BF 4AC1 2FAF 38D7\n\
          F657 DDFC 8E9F 3C79 9195\n\
          \n\
-         bob@example.net(bob@example.net)\n\
+         Bob(bob@example.net)\n\
          CCCB 5AA9 F6E1 141C 9431\n\
          65F1 DB18 B18C BCF7 0487"
     );
@@ -4425,7 +4426,7 @@ async fn test_chat_get_encryption_info() -> Result<()> {
          C8BA 50BF 4AC1 2FAF 38D7\n\
          F657 DDFC 8E9F 3C79 9195\n\
          \n\
-         bob@example.net\n\
+         Bob\n\
          (key missing)\n\
          CCCB 5AA9 F6E1 141C 9431\n\
          65F1 DB18 B18C BCF7 0487"


### PR DESCRIPTION
Email address is already present in the list of relays, a display name is more useful.