### PR TITLE
build: use --locked in scripts/clippy.sh

### DIFF
--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -6,4 +6,4 @@
 #
 # To automatically fix warnings, run
 #   scripts/clippy.sh --fix --allow-dirty
-cargo clippy --workspace --all-targets --all-features "$@" -- -D warnings
+cargo clippy --locked --workspace --all-targets --all-features "$@" -- -D warnings


### PR DESCRIPTION
This is mostly a reaction in response to
https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/

I don't know when exactly
`cargo clippy` and similar commands (check, build, run etc.) may update dependencies
and it does not look like they actively pull
the package index and update yanked crates.
We also keep the lockfile updated all the time
by checking in CI.

Still, all commands better use --locked as a precaution.