### PR TITLE
docs: always suggest using --locked with "cargo install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $ cargo test -- --ignored
 
 Install [`cargo-bolero`](https://github.com/camshaft/bolero) with
 ```sh
-$ cargo install cargo-bolero
+$ cargo install --locked cargo-bolero
 ```
 
 Run fuzzing tests with

--- a/deltachat-rpc-server/README.md
+++ b/deltachat-rpc-server/README.md
@@ -11,7 +11,7 @@ Rename the downloaded binary to `deltachat-rpc-server` and add it to your `PATH`
 To install from source run:
 
 ```sh
-cargo install --git https://github.com/chatmail/core/ deltachat-rpc-server
+cargo install --locked --git https://github.com/chatmail/core/ deltachat-rpc-server
 ```
 
 The `deltachat-rpc-server` executable will be installed into `$HOME/.cargo/bin` that should be available

--- a/deltachat-rpc-server/npm-package/src/errors.js
+++ b/deltachat-rpc-server/npm-package/src/errors.js
@@ -2,7 +2,7 @@
 import { ENV_VAR_NAME } from "./const.js";
 
 const cargoInstallCommand =
-  "cargo install --git https://github.com/chatmail/core deltachat-rpc-server";
+  "cargo install --locked --git https://github.com/chatmail/core deltachat-rpc-server";
 
 export function NPM_NOT_FOUND_SUPPORTED_PLATFORM_ERROR(package_name) {
   return `deltachat-rpc-server not found:

--- a/python/doc/jsonrpc/install.rst
+++ b/python/doc/jsonrpc/install.rst
@@ -17,7 +17,7 @@ Install ``deltachat-rpc-server``
 To get ``deltachat-rpc-server`` binary you have three options:
 
 1. Install ``deltachat-rpc-server`` from PyPI using ``pip install deltachat-rpc-server``.
-2. Build and install ``deltachat-rpc-server`` from source with ``cargo install --git https://github.com/chatmail/core/ deltachat-rpc-server``.
+2. Build and install ``deltachat-rpc-server`` from source with ``cargo install --locked --git https://github.com/chatmail/core/ deltachat-rpc-server``.
 3. Download prebuilt release from https://github.com/chatmail/core/releases and install it into ``PATH``.
 
 Check that ``deltachat-rpc-server`` is installed and can run::


### PR DESCRIPTION
Otherwise the lockfile is completely ignored
as <https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile> says "By default, the Cargo.lock file that is included with the package will be ignored."

Mostly a reaction to <https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/>