### PR TITLE
docs(json-rpc): clarify when `reactions` is `None`

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2458,6 +2458,7 @@ impl CommandApi {
     }
 
     /// Returns reactions to the message.
+    /// `None` when there are no reactions.
     async fn get_message_reactions(
         &self,
         account_id: u32,

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -105,6 +105,7 @@ pub struct MessageObject {
 
     is_pinned: bool,
 
+    /// `None` when there are no reactions.
     reactions: Option<JsonrpcReactions>,
 
     vcard_contact: Option<VcardContact>,


### PR DESCRIPTION
Initially I thought that this is only `null`
when reactions are somehow not applicable to this message.
