### PR TITLE
fix: produce correct python wheel metadata

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -370,6 +370,14 @@ jobs:
       - name: List artifacts
         run: ls -l dist/
 
+      - name: Check that the wheel metadata reads back
+        run: |
+          echo 'You can check a local `nix build` on non-Mac machines against the following checksums.'
+          sha256sum dist/*.whl
+          mkdir tagcheck
+          cp dist/*.whl tagcheck/
+          nix run --inputs-from . nixpkgs#python3Packages.wheel -- tags tagcheck/*.whl
+
       - name: Upload binaries to the GitHub release
         if: github.event_name == 'release'
         env:

--- a/scripts/wheel-rpc-server.py
+++ b/scripts/wheel-rpc-server.py
@@ -20,6 +20,16 @@ Description-Content-Type: text/markdown
 """
 
 
+def wheel_contents(tag):
+    """Render the WHEEL metadata for a filename tag."""
+    interpreter, abi, platforms = tag.split("-")
+    lines = ["Wheel-Version: 1.0", "Root-Is-Purelib: false"]
+    lines += [
+        f"Tag: {interpreter}-{abi}-{platform}" for platform in platforms.split(".")
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def build_wheel(version, binary, tag, windows=False):
     filename = f"deltachat_rpc_server-{version}-{tag}.whl"
 
@@ -60,7 +70,7 @@ def main():
         )
         wheel.writestr(
             f"deltachat_rpc_server-{version}.dist-info/WHEEL",
-            "Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: {tag}",
+            wheel_contents(tag),
         )
         wheel.writestr(
             f"deltachat_rpc_server-{version}.dist-info/entry_points.txt",
@@ -87,7 +97,11 @@ arch2tags = {
 def main():
     with Path("Cargo.toml").open("rb") as fp:
         cargo_manifest = tomllib.load(fp)
-    version = cargo_manifest["package"]["version"]
+
+    # Cargo's SEMVER "-dev" suffix is not a PEP 440 version,
+    # so translate to make wheel tooling and metadata writing happy.
+    version = cargo_manifest["package"]["version"].replace("-dev", ".dev0")
+
     arch = sys.argv[1]
     executable = sys.argv[2]
     tags = arch2tags[arch]


### PR DESCRIPTION
all published deltachat-rpc-server wheels so far fail "wheel tags" 

```
wheel tags deltachat_rpc_server-2.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl 
Traceback (most recent call last):
  File "/home/hpk/chatmail/core/venv/bin/wheel", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/hpk/chatmail/core/venv/lib/python3.12/site-packages/wheel/_commands/__init__.py", line 167, in main
    args.func(args)
  File "/home/hpk/chatmail/core/venv/lib/python3.12/site-packages/wheel/_commands/__init__.py", line 48, in tags_f
    for name in names:
                ^^^^^
  File "/home/hpk/chatmail/core/venv/lib/python3.12/site-packages/wheel/_commands/__init__.py", line 37, in <genexpr>
    tags(
  File "/home/hpk/chatmail/core/venv/lib/python3.12/site-packages/wheel/_commands/tags.py", line 89, in tags
    abivers = {tag.split("-")[1] for tag in tags}
               ~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```