### PR TITLE
feat: delete avatars referred to by parameters of special contacts

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1639,7 +1639,10 @@ WHERE addr=?
             }
         } else if self.id == ContactId::DEVICE {
             Ok(Some(chat::get_device_icon(context).await?))
-        } else if show_fallback_icon && !self.id.is_special() && !self.is_key_contact() {
+        } else if self.id.is_special() {
+            // All special contacts are handled above.
+            Ok(None)
+        } else if show_fallback_icon && !self.is_key_contact() {
             Ok(Some(chat::get_unencrypted_icon(context).await?))
         } else if let Some(image_rel) = self.param.get(Param::ProfileImage)
             && !image_rel.is_empty()

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1002,10 +1002,17 @@ pub async fn remove_unused_files(context: &Context) -> Result<()> {
         Param::ProfileImage,
     )
     .await?;
+
+    // Only non-special contacts are selected
+    // because special contacts don't store profile image in parameters.
+    // ContactId::DEVICE has a hardcoded profile image
+    // and ContactId::SELF has the avatar stored in Config::Selfavatar.
+    // If some special contact has a profile image set
+    // e.g due to a bug, the file can be safely deleted.
     maybe_add_from_param(
         &context.sql,
         &mut files_in_use,
-        "SELECT param FROM contacts;",
+        "SELECT param FROM contacts WHERE id > 9;",
         Param::ProfileImage,
     )
     .await?;


### PR DESCRIPTION
It is not clear if old versions stored SELF avatar in parameters or if it happened due to a bug, but if it happens, we can safely delete the avatar.

Follow-up to #8605