### PR TITLE
docs: update the timeout value in DC_EVENT_CALL_ENDED description

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6462,7 +6462,7 @@ void dc_event_unref(dc_event_t* event);
 
 /**
  * An incoming or outgoing call was ended using dc_end_call() on this or another device, by caller or callee.
- * Moreover, the event is sent when the call was not accepted within 1 minute timeout.
+ * Moreover, the event is sent when the call was not accepted within two minutes.
  *
  * UI usually only takes action in case call UI was opened before, otherwise the event should be ignored.
  *


### PR DESCRIPTION
RINGING_SECONDS constant was changed in 3d234e7fc7ad11c98e60995e1f3b74c9a28d2bed, but the documentation was not updated.