### PR TITLE
 fix: do not emit events in set_profile_image() if contact avatar is unchanged

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -38,7 +38,9 @@ use crate::param::{Param, Params};
 use crate::pgp::{addresses_from_public_key, merge_openpgp_certificates};
 use crate::sync::{self, Sync::*};
 use crate::tools::{SystemTime, duration_to_str, get_abs_path, normalize_text, time, to_lowercase};
-use crate::{chat, chatlist_events, ensure_and_debug_assert_ne, stock_str};
+use crate::{
+    chat, chatlist_events, ensure_and_debug_assert, ensure_and_debug_assert_ne, stock_str,
+};
 
 /// Time during which a contact is considered as seen recently.
 const SEEN_RECENTLY_SECONDS: i64 = 600;
@@ -1912,32 +1914,25 @@ WHERE type=? AND id IN (
 /// The given profile image is expected to be already in the blob directory
 /// as profile images can be set only by receiving messages, this should be always the case, however.
 ///
-/// For contact SELF, the image is not saved in the contact-database but as Config::Selfavatar.
+/// Cannot be used to set own profile picture, set [`Config::Selfavatar`] instead.
 pub(crate) async fn set_profile_image(
     context: &Context,
     contact_id: ContactId,
     profile_image: &AvatarAction,
 ) -> Result<()> {
+    ensure_and_debug_assert!(
+        !contact_id.is_special(),
+        "Cannot set avatar for special contacts"
+    );
+
     let mut contact = Contact::get_by_id(context, contact_id).await?;
     let changed = match profile_image {
         AvatarAction::Change(profile_image) => {
-            if contact_id == ContactId::SELF {
-                context
-                    .set_config_ext(Nosync, Config::Selfavatar, Some(profile_image))
-                    .await?;
-            } else {
-                contact.param.set(Param::ProfileImage, profile_image);
-            }
+            contact.param.set(Param::ProfileImage, profile_image);
             true
         }
         AvatarAction::Delete => {
-            if contact_id == ContactId::SELF {
-                context
-                    .set_config_ext(Nosync, Config::Selfavatar, None)
-                    .await?;
-            } else {
-                contact.param.remove(Param::ProfileImage);
-            }
+            contact.param.remove(Param::ProfileImage);
             true
         }
     };

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1926,17 +1926,15 @@ pub(crate) async fn set_profile_image(
     );
 
     let mut contact = Contact::get_by_id(context, contact_id).await?;
-    let changed = match profile_image {
-        AvatarAction::Change(profile_image) => {
-            contact.param.set(Param::ProfileImage, profile_image);
-            true
-        }
-        AvatarAction::Delete => {
-            contact.param.remove(Param::ProfileImage);
-            true
-        }
+    let profile_image_opt = match profile_image {
+        AvatarAction::Change(profile_image) => Some(profile_image),
+        AvatarAction::Delete => None,
     };
+    let changed = contact.param.get(Param::ProfileImage) != profile_image_opt.map(|s| s.as_str());
     if changed {
+        contact
+            .param
+            .set_optional(Param::ProfileImage, profile_image_opt);
         contact.update_param(context).await?;
         context.emit_event(EventType::ContactsChanged(Some(contact_id)));
         chatlist_events::emit_chatlist_item_changed_for_contact_chat(context, contact_id).await;

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -1479,3 +1479,74 @@ async fn test_name_changes() -> Result<()> {
 
     Ok(())
 }
+
+/// Tests that ChatlistItemChanged event is not emitted if the same contact avatar is received.
+///
+/// We don't test ContactsChanged event because it is emitted in any case due to "last seen" update.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_same_avatar_no_changed_event() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    let bob2 = &tcm.bob().await;
+
+    // Create chat with Bob.
+    // No messages will be sent to it,
+    // but it should be updated when Bob's avatar changes.
+    let alice_bob_chat = alice.create_chat(bob).await;
+
+    async fn wait_for_chatlist_event(context: &TestContext, expected_chat_id: ChatId) {
+        context
+            .evtracker
+            .get_matching(|evt| {
+                matches!(evt, EventType::ChatlistItemChanged { chat_id } if *chat_id == Some(expected_chat_id))
+            })
+            .await;
+    }
+
+    // One event is for adding E2EE notice ("Messages are end-to-end encrypted")
+    // and another event is for creating the chat itself.
+    wait_for_chatlist_event(alice, alice_bob_chat.id).await;
+    wait_for_chatlist_event(alice, alice_bob_chat.id).await;
+
+    // Create a group chat and single chat with Bob.
+    // Bob will send messages to group chat,
+    // but single chat should get ChatlistItemChanged event
+    // when avatar changes.
+    let alice_group_id = alice.create_group_with_members("test group", &[bob]).await;
+    let alice_sent_msg = alice.send_text(alice_group_id, "testing").await;
+    let bob_group_id = bob.recv_msg(&alice_sent_msg).await.chat_id;
+    bob_group_id.accept(bob).await?;
+    let bob2_group_id = bob2.recv_msg(&alice_sent_msg).await.chat_id;
+    bob2_group_id.accept(bob2).await?;
+
+    // Bob sets the same avatar on two devices at the same time.
+    // Receiving the same avatar should only emit the event about contact change once.
+    for profile in &[bob, bob2] {
+        let avatar_src = profile.get_blobdir().join("avatar.png");
+        tokio::fs::write(&avatar_src, test_utils::AVATAR_900x900_BYTES).await?;
+        profile
+            .set_config(Config::Selfavatar, Some(avatar_src.to_str().unwrap()))
+            .await?;
+    }
+
+    // Avatar is changed by a group message,
+    // so chatlist item for single chat should be refreshed.
+    let sent = bob.send_text(bob_group_id, "Avatar change").await;
+    alice.recv_msg(&sent).await;
+    wait_for_chatlist_event(alice, alice_bob_chat.id).await;
+
+    // Avatar is the same, so single chat is not updated.
+    let sent2 = bob2.send_text(bob2_group_id, "No avatar change").await;
+    alice.recv_msg(&sent2).await;
+    let event_opt = alice
+        .evtracker
+        .get_matching_opt(alice, |evt| {
+            matches!(evt, EventType::ChatlistItemChanged { chat_id } if *chat_id == Some(alice_bob_chat.id))
+        })
+        .await;
+    assert_eq!(event_opt, None);
+
+    Ok(())
+}


### PR DESCRIPTION
There is also a refactoring commit with no test but a debug assertion, removing the ability to set SELF avatar via `set_profile_image`.

Refactoring commit is a follow-up to #8634 and #8605, but then i noticed that `changed` variable is always true.