### PR TITLE
fix: strip "//" in login_param_from_account_qr()

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -837,6 +837,9 @@ pub(crate) async fn login_param_from_account_qr(
         .get(DCACCOUNT_SCHEME.len()..)
         .context("Invalid DCACCOUNT scheme")?;
 
+    // Handle `dcaccount://...` URLs, the same way `decode_account()` does.
+    let payload = payload.strip_prefix("//").unwrap_or(payload);
+
     if !payload.starts_with(HTTPS_SCHEME) {
         let param = login_param_from_host(payload);
         return Ok(param);

--- a/src/qr/qr_tests.rs
+++ b/src/qr/qr_tests.rs
@@ -743,6 +743,29 @@ async fn test_decode_account() -> Result<()> {
     Ok(())
 }
 
+/// `check_qr()` and `login_param_from_account_qr()` parse the same QR string,
+/// so they have to agree on the optional `//` after the scheme.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_login_param_from_account_qr() -> Result<()> {
+    let ctx = TestContext::new().await;
+
+    for text in [
+        "DCACCOUNT:example.org",
+        "DCACCOUNT://example.org",
+        "dcaccount:example.org",
+        "dcaccount://example.org",
+    ] {
+        let param = login_param_from_account_qr(&ctx.ctx, text).await?;
+        assert!(
+            param.addr.ends_with("@example.org"),
+            "{text:?} produced address {:?}",
+            param.addr
+        );
+    }
+
+    Ok(())
+}
+
 /// Tests that decoding empty `dcaccount://` URL results in an error.
 /// We should not suggest trying to configure an account in this case.
 /// Such links may be created by copy-paste error or because of incorrect parsing.


### PR DESCRIPTION
Closes #8643.

`set_config_from_qr()` (`qr.rs:884`) and `Configure` (`configure.rs:171`) parse a `DCACCOUNT` QR twice: once with `check_qr()` → `decode_account()`, then again with `login_param_from_account_qr()`. #7995 taught the first one to accept `dcaccount://...` but not the second, so the two disagree on the same string.

For `DCACCOUNT://example.org`, `check_qr()` reports `Qr::Account { domain: "example.org" }` and configuration then builds its address from the payload `//example.org`. On current main:

```
"DCACCOUNT://example.org" produced address "viwqxfvmn@//example.org"
```

`DCACCOUNT:example.org` and the lowercase form are unaffected; only the two `//` spellings are.

The added test drives `login_param_from_account_qr()` over exactly the vectors `test_decode_account` already lists. That test covers all four spellings, but only through `check_qr()`, which is why #7995 could patch one of the two parsers and stay green.

Reverting the one-line change makes the new test fail on the two `//` vectors and leaves the other two passing. `cargo fmt --check` is clean.

On `cargo test --lib` locally (macOS): `blob::blob_tests::test_create_and_deduplicate_from_bytes` and `tools::tools_tests::test_maybe_warn_on_outdated` fail on unmodified main too. Two patched runs each had one further failure, a different one each time (`receive_imf::…::test_dont_recreate_contacts_on_add_remove`, then `location::tests::test_send_locations_to_chat`); both pass in isolation and neither touches `qr.rs`, so they look like flakiness under parallel load rather than anything from this change. Flagging it rather than claiming a clean run.
