### PR TITLE
chore(cargo): bump mail-builder from 0.4.4 to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,9 +3438,9 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mail-builder"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900998f307338c4013a28ab14d760b784067324b164448c6d98a89e44810473b"
+checksum = "4c942e8a4b83f9351236c1e531ea9fa0237913d63c7fc36818430e0128a1ddf3"
 
 [[package]]
 name = "mailparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ iroh-gossip = { version = "0.35", default-features = false, features = ["net"] }
 iroh = { version = "0.35", default-features = false }
 kamadak-exif = "0.6.1"
 libc = { workspace = true }
-mail-builder = { version = "0.4.4", default-features = false }
+mail-builder = { version = "0.5.0", default-features = false }
 mailparse = { workspace = true }
 mime = "0.3.17"
 num_cpus = "1.17"

--- a/src/mimefactory/mimefactory_tests.rs
+++ b/src/mimefactory/mimefactory_tests.rs
@@ -52,7 +52,7 @@ fn test_render_email_address() {
 
     println!("{s}");
 
-    assert_eq!(s, r#""=?utf-8?B?w6Qgc3BhY2U=?=" <x@y.org>"#);
+    assert_eq!(s, "=?utf-8?B?w6Qgc3BhY2U=?= <x@y.org>");
 }
 
 #[test]


### PR DESCRIPTION
Replacement for #8652