### PR TITLE
fix(ffi): support custom allocators in event string getters

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -690,7 +690,7 @@ pub unsafe extern "C" fn dc_event_get_data1_str(event: *mut dc_event_t) -> *mut 
     match event {
         EventType::IncomingWebxdcNotify { href, .. } => {
             if let Some(href) = href {
-                href.to_c_string().unwrap_or_default().into_raw()
+                href.strdup()
             } else {
                 ptr::null_mut()
             }
@@ -719,10 +719,7 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::DeletedBlobFile(msg)
         | EventType::Warning(msg)
         | EventType::Error(msg)
-        | EventType::ErrorSelfNotInGroup(msg) => {
-            let data2 = msg.to_c_string().unwrap_or_default();
-            data2.into_raw()
-        }
+        | EventType::ErrorSelfNotInGroup(msg) => msg.strdup(),
         EventType::MsgsChanged { .. }
         | EventType::ReactionsChanged { .. }
         | EventType::IncomingMsg { .. }
@@ -756,45 +753,27 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::TransportsModified => ptr::null_mut(),
         EventType::IncomingCall {
             place_call_info, ..
-        } => {
-            let data2 = place_call_info.to_c_string().unwrap_or_default();
-            data2.into_raw()
-        }
+        } => place_call_info.strdup(),
         EventType::OutgoingCallAccepted {
             accept_call_info, ..
-        } => {
-            let data2 = accept_call_info.to_c_string().unwrap_or_default();
-            data2.into_raw()
-        }
+        } => accept_call_info.strdup(),
         EventType::CallEnded { .. } | EventType::EventChannelOverflow { .. } => ptr::null_mut(),
         EventType::ConfigureProgress { comment, .. } => {
             if let Some(comment) = comment {
-                comment.to_c_string().unwrap_or_default().into_raw()
+                comment.strdup()
             } else {
                 ptr::null_mut()
             }
         }
-        EventType::ImexFileWritten(file) => {
-            let data2 = file.to_c_string().unwrap_or_default();
-            data2.into_raw()
-        }
-        EventType::ConfigSynced { key } => {
-            let data2 = key.to_string().to_c_string().unwrap_or_default();
-            data2.into_raw()
-        }
+        EventType::ImexFileWritten(file) => file.strdup(),
+        EventType::ConfigSynced { key } => key.to_string().strdup(),
         EventType::WebxdcRealtimeData { data, .. } => {
             let ptr = unsafe { libc::malloc(data.len()) };
             unsafe { libc::memcpy(ptr, data.as_ptr() as *mut libc::c_void, data.len()) };
             ptr as *mut libc::c_char
         }
-        EventType::IncomingReaction { reaction, .. } => reaction
-            .as_str()
-            .to_c_string()
-            .unwrap_or_default()
-            .into_raw(),
-        EventType::IncomingWebxdcNotify { text, .. } => {
-            text.to_c_string().unwrap_or_default().into_raw()
-        }
+        EventType::IncomingReaction { reaction, .. } => reaction.as_str().strdup(),
+        EventType::IncomingWebxdcNotify { text, .. } => text.strdup(),
         #[allow(unreachable_patterns)]
         #[cfg(test)]
         _ => unreachable!("This is just to silence a rust_analyzer false-positive"),


### PR DESCRIPTION
Event string getters returned Rust-allocated pointers that dc_str_unref() frees with libc. This breaks with custom Rust allocators, so allocate the strings with strdup() instead.