### PR TITLE
refactor: use &[..] instead of &Vec<..>

### DIFF
--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -253,7 +253,7 @@ pub(crate) async fn load_broadcast_reactions(
 pub(crate) async fn save_broadcast_reactions(
     context: &Context,
     msg_id: MsgId,
-    frequencies: &Vec<ReactionFrequency>,
+    frequencies: &[ReactionFrequency],
 ) -> Result<()> {
     context
         .sql

--- a/src/securejoin/qrinvite.rs
+++ b/src/securejoin/qrinvite.rs
@@ -99,7 +99,7 @@ impl QrInvite {
         }
     }
 
-    pub(crate) fn addrs(&self) -> &Vec<String> {
+    pub(crate) fn addrs(&self) -> &[String] {
         match self {
             QrInvite::Contact { addrs, .. } => addrs,
             QrInvite::Group { addrs, .. } => addrs,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -382,7 +382,7 @@ impl Context {
         Ok(())
     }
 
-    async fn sync_message_deletion(&self, msgs: &Vec<String>) -> Result<()> {
+    async fn sync_message_deletion(&self, msgs: &[String]) -> Result<()> {
         let mut modified_chat_ids = BTreeSet::new();
         let mut msg_ids = Vec::new();
         for rfc724_mid in msgs {


### PR DESCRIPTION
Most of such cases are detected by clippy::ptr_arg, but in these cases clippy did not catch anything.